### PR TITLE
Use the empty string as MK_API_KEY in debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,14 @@ def getHVRMLApiKey = { ->
     return ""
 }
 
+def getMKApiKey = { ->
+    if (gradle.hasProperty("userProperties.MK_API_KEY")) {
+        return gradle."userProperties.MK_API_KEY"
+    }
+    return ""
+}
+
+
 // Glean: Generate markdown docs for the collected metrics.
 ext.gleanGenerateMarkdownDocs = true
 ext.gleanDocsDirectory = "$rootDir/docs"
@@ -115,11 +123,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig getUseDebugSigningOnRelease() ? debug.signingConfig : release.signingConfig
             buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props.json"'
+            buildConfigField "String", "MK_API_KEY", "\"${getMKApiKey()}\""
         }
         debug {
             applicationIdSuffix getDevApplicationIdSuffix()
             pseudoLocalesEnabled true
             buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props.json"'
+            buildConfigField "String", "MK_API_KEY", ""
         }
     }
 
@@ -231,6 +241,7 @@ android {
                 }
             }
             buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
+            buildConfigField "String", "MK_API_KEY", ""
         }
 
         noapi {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,7 +129,7 @@ android {
             applicationIdSuffix getDevApplicationIdSuffix()
             pseudoLocalesEnabled true
             buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props.json"'
-            buildConfigField "String", "MK_API_KEY", ""
+            buildConfigField "String", "MK_API_KEY", "\"\""
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
@@ -7,6 +7,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.igalia.wolvic.BuildConfig;
+import com.igalia.wolvic.utils.StringUtils;
 import com.meetkai.speechlibrary.ISpeechRecognitionListener;
 import com.meetkai.speechlibrary.MKSpeechService;
 import com.meetkai.speechlibrary.STTResult;
@@ -32,7 +34,7 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
     private static float FINAL_CONF = 1.0f;
 
 
-    private static final String API_KEY = "WOLVIC_DEBUG";
+    private static final String DEBUG_API_KEY = "WOLVIC_DEBUG";
 
     public MKSpeechRecognizer(Context context) {
         mContext = context;
@@ -43,7 +45,11 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
         mkSpeechService = MKSpeechService.getInstance();
         mCallback = callback;
         mkSpeechService.addListener(this);
-        mkSpeechService.start(mContext, settings.locale, API_KEY);
+        String key = BuildConfig.MK_API_KEY;
+        if (StringUtils.isEmpty(key)) {
+            key = DEBUG_API_KEY;
+        }
+        mkSpeechService.start(mContext, settings.locale, key);
     }
 
     @Override


### PR DESCRIPTION
When specifying the build options things like `""` as in `buildConfigField "String", "MK_API_KEY", ""` are not interpreted as the empty string but as void. For example the generated code in `BuildConfig.java` for that option is
```
  public static final String MK_API_KEY = ;
```
which is invalid Java code. We must explicitly use the empty string by escaping a pair of double quotes.