### PR TITLE
Do not assume that OculusTouch controllers mean Oculus Quest

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -398,7 +398,7 @@ struct DeviceDelegateOculusVR::State {
                                          controllerName, beamTransform);
             controller->SetButtonCount(controllerState.index, 7);
             controller->SetHapticCount(controllerState.index, 1);
-            controller->SetControllerType(controllerState.index, device::OculusQuest);
+            controller->SetControllerType(controllerState.index, deviceType);
 
             float offsetX = controllerState.hand == ElbowModel::HandEnum::Left ? 0.011f : -0.011f;
             const vrb::Matrix trans = vrb::Matrix::Position(vrb::Vector(offsetX, 0.025f, 0.05f));


### PR DESCRIPTION
The OculusTouch capability is advertised by both Oculus Quest and Oculus Quest 2
devices, so let's not assume that they belong to the former only. Use the deviceType
directly so that we can properly load the appropiate controller model.