### PR TITLE
Fix simultaneousDevProduction developer suffix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ def getCrashRestartDisabled = { ->
 
 def getDevApplicationIdSuffix = { ->
     if (gradle.hasProperty("userProperties.simultaneousDevProduction")) {
-        return gradle."userProperties.simultaneousDevProduction" == "true" ? "" : ""
+        return gradle."userProperties.simultaneousDevProduction" == "true" ? "dev" : ""
     }
     return ""
 }


### PR DESCRIPTION
This was removed due to conflicts with the the agconnect-services.json HVR plugin, which checks the used bundle id. Providing a json with multi-bundleid definition doesn't cause this problem anymore