### PR TITLE
Fix wovlic git clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more info on localization, how it works in the Wolvic XR project, and how to
 *Clone Wolvic.*
 
 ```bash
-git clone git@github.com:wolvic/wolvic.git
+git clone git@github.com:Igalia/wolvic.git
 cd wolvic
 ```
 


### PR DESCRIPTION
git@github.com:wolvic/wolvic.git doesn't point to anything. The clone url is git@github.com:Igalia/wolvic.git, at least for members of the public.