### PR TITLE
Remove WebExecutor dependency from SpeechRecognizer API

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
@@ -15,8 +15,6 @@ import com.meetkai.speechlibrary.ISpeechRecognitionListener;
 import com.meetkai.speechlibrary.MKSpeechService;
 import com.meetkai.speechlibrary.STTResult;
 
-import org.mozilla.geckoview.GeckoWebExecutor;
-
 public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionListener {
 
     private Context mContext;
@@ -40,7 +38,7 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
     }
 
     @Override
-    public void start(@NonNull Settings settings, @Nullable GeckoWebExecutor executor, @NonNull Callback callback) {
+    public void start(@NonNull Settings settings, @NonNull Callback callback) {
         mkSpeechService = MKSpeechService.getInstance();
         mCallback = callback;
         mkSpeechService.addListener(this);

--- a/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
@@ -4,8 +4,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.mozilla.geckoview.GeckoWebExecutor;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -37,7 +35,7 @@ public interface SpeechRecognizer {
         void onError(@ErrorType int errorType, @Nullable String error);
     }
 
-    void start(@NonNull Settings settings, @Nullable GeckoWebExecutor executor, @NonNull Callback callback);
+    void start(@NonNull Settings settings, @NonNull Callback callback);
     void stop();
     boolean shouldDisplayStoreDataPrompt();
     default boolean supportsASR(@NonNull Settings settings) {return true;}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -26,7 +26,6 @@ import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.VRBrowserApplication;
 import com.igalia.wolvic.browser.SettingsStore;
-import com.igalia.wolvic.browser.engine.EngineProvider;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.VoiceSearchDialogBinding;
 import com.igalia.wolvic.speech.SpeechRecognizer;
@@ -240,9 +239,7 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
             settings.storeData = storeData;
             settings.productTag = getContext().getString(R.string.voice_app_id);
 
-            mSpeechRecognizer.start(settings,
-                    EngineProvider.INSTANCE.getDefaultGeckoWebExecutor(getContext()),
-                    mResultCallback);
+            mSpeechRecognizer.start(settings, mResultCallback);
         }
     }
 

--- a/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
+++ b/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
@@ -12,7 +12,6 @@ import com.huawei.hms.mlsdk.asr.MLAsrConstants;
 import com.huawei.hms.mlsdk.asr.MLAsrListener;
 import com.huawei.hms.mlsdk.asr.MLAsrRecognizer;
 
-import org.mozilla.geckoview.GeckoWebExecutor;
 import com.igalia.wolvic.speech.SpeechRecognizer;
 
 public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
@@ -25,7 +24,7 @@ public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
     }
 
     @Override
-    public void start(@NonNull Settings settings, @Nullable GeckoWebExecutor executor, @NonNull Callback callback) {
+    public void start(@NonNull Settings settings, @NonNull Callback callback) {
         if (mRecognizer != null) {
             stop();
         }


### PR DESCRIPTION
WebExecutor was used in the old Mozilla based SpeechRecognizer API but it's not used anymore in the new SpeechRecognizer implementations