### PR TITLE
Remove unused code

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1590,40 +1590,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
         return GeckoResult.fromValue(autocompleteRequest.dismiss());
     }
-
-    // MediaDelegate
-
-    /*@Override
-    public void onMediaAdd(@NonNull GeckoSession aSession, @NonNull MediaElement element) {
-        if (mState.mSession != aSession) {
-            return;
-        }
-        Media media = new Media(element);
-        mState.mMediaElements.add(media);
-
-        for (VideoAvailabilityListener listener: mVideoAvailabilityListeners) {
-            listener.onVideoAvailabilityChanged(media, true);
-        }
-    }
-
-    @Override
-    public void onMediaRemove(@NonNull GeckoSession aSession, @NonNull MediaElement element) {
-        if (mState.mSession != aSession) {
-            return;
-        }
-        for (int i = 0; i < mState.mMediaElements.size(); ++i) {
-            Media media = mState.mMediaElements.get(i);
-            if (media.getMediaElement() == element) {
-                media.unload();
-                mState.mMediaElements.remove(i);
-                for (VideoAvailabilityListener listener: mVideoAvailabilityListeners) {
-                    listener.onVideoAvailabilityChanged(media, false);
-                }
-                return;
-            }
-        }
-    }*/
-
+    
     // HistoryDelegate
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ContextElement;
-import org.mozilla.geckoview.GeckoSession.WebResponseInfo;
 
 import java.io.File;
 import java.net.URL;
@@ -49,28 +48,6 @@ public class DownloadJob {
         job.mTitle = filename;
         job.mDescription = filename;
         job.mOutputPath = outputPath;
-        return job;
-    }
-
-    public static DownloadJob from(@NonNull WebResponseInfo response) {
-        DownloadJob job = new DownloadJob();
-        job.mUri = response.uri;
-        job.mContentType = response.contentType;
-        job.mContentLength = response.contentLength;
-        if (response.filename != null && !response.filename.isEmpty()) {
-            job.mFilename = response.filename;
-
-        } else {
-            try {
-                File f = new File(new URL(response.uri).getPath());
-                job.mFilename = f.getName();
-
-            } catch (Exception e) {
-                job.mFilename = "Unknown";
-            }
-        }
-        job.mTitle = response.filename;
-        job.mDescription = response.filename;
         return job;
     }
 


### PR DESCRIPTION
- WebResponseInfo was used in older Gecko builds but it's unused now
- Removed commented methods from the deprecated MediaElement Gecko API