### PR TITLE
REGRESSION: video playing not working

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/MediaSessionDelegateImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/MediaSessionDelegateImpl.java
@@ -17,6 +17,7 @@ import org.mozilla.geckoview.GeckoSession;
     public MediaSessionDelegateImpl(WSession mSession, WMediaSession.Delegate delegate) {
         this.mSession = mSession;
         this.mDelegate = delegate;
+        mMediaSession = new WMediaSessionImpl();
     }
 
     @Override


### PR DESCRIPTION
Video played regressed after landing the multibackend abstraction. The reason is because
we were not instantiating the WMediaSessionImpl class which is the one delegating the
media commands (play, pause, seekTo...) to the MediaSession object provided by the
GeckoView backend.