### PR TITLE
Regression: Fix unused displayAction argument in WindowWidget.setSession

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1058,7 +1058,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public void setSession(@NonNull Session aSession, @OldSessionDisplayAction int aDisplayAction, @SetSessionActiveState int previousSessionState) {
-        setSession(aSession, SESSION_RELEASE_DISPLAY, previousSessionState, true);
+        setSession(aSession, aDisplayAction, previousSessionState, true);
     }
 
     public void setSession(@NonNull Session aSession, @OldSessionDisplayAction int aDisplayAction, @SetSessionActiveState int previousSessionState, boolean hidePanel) {


### PR DESCRIPTION
Regression from 3afa6fa16e33d2edf7509465a6056c80da5137da