### PR TITLE
Add support for fragmentManager

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -4,8 +4,10 @@ import android.app.Service;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
 
 import com.igalia.wolvic.browser.api.WContentBlocking;
 import com.igalia.wolvic.browser.api.WResult;
@@ -110,6 +112,11 @@ public class RuntimeImpl implements WRuntime {
     @Override
     public void setExternalVRContext(long aContext) {
         GeckoVRManager.setExternalContext(aContext);
+    }
+
+    @Override
+    public void setFragmentManager(@NonNull FragmentManager fragmentManager, @NonNull ViewGroup container) {
+        // No op. Gecko doesn't require views to render GeckoSessions. See GeckoDisplay.
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/FragmentControllerCallbacks.java
+++ b/app/src/common/shared/com/igalia/wolvic/FragmentControllerCallbacks.java
@@ -1,0 +1,98 @@
+package com.igalia.wolvic;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.os.Bundle;
+import android.os.Handler;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentHostCallback;
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+
+public class FragmentControllerCallbacks extends FragmentHostCallback {
+    private VRBrowserActivity mActivity;
+
+    public FragmentControllerCallbacks(@NonNull Context context, @NonNull Handler handler, int windowAnimations) {
+        super(context, handler, windowAnimations);
+        mActivity = (VRBrowserActivity) context;
+    }
+
+    @Override
+    public void onDump(@NonNull String prefix, @Nullable FileDescriptor fd, @NonNull PrintWriter writer, @Nullable String[] args) {
+        super.onDump(prefix, fd, writer, args);
+    }
+
+    @Override
+    public boolean onShouldSaveFragmentState(@NonNull Fragment fragment) {
+        return super.onShouldSaveFragmentState(fragment);
+    }
+
+    @NonNull
+    @Override
+    public LayoutInflater onGetLayoutInflater() {
+        return mActivity.getLayoutInflater().cloneInContext(mActivity);
+    }
+
+    @Nullable
+    @Override
+    public Object onGetHost() {
+        return mActivity;
+    }
+
+    @Override
+    public void onSupportInvalidateOptionsMenu() {
+        super.onSupportInvalidateOptionsMenu();
+    }
+
+    @Override
+    public void onStartActivityFromFragment(@NonNull Fragment fragment, Intent intent, int requestCode) {
+        super.onStartActivityFromFragment(fragment, intent, requestCode);
+    }
+
+    @Override
+    public void onStartActivityFromFragment(@NonNull Fragment fragment, Intent intent, int requestCode, @Nullable Bundle options) {
+        super.onStartActivityFromFragment(fragment, intent, requestCode, options);
+    }
+
+    @Override
+    public void onStartIntentSenderFromFragment(@NonNull Fragment fragment, IntentSender intent, int requestCode, @Nullable Intent fillInIntent, int flagsMask, int flagsValues, int extraFlags, @Nullable Bundle options) throws IntentSender.SendIntentException {
+        super.onStartIntentSenderFromFragment(fragment, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags, options);
+    }
+
+    @Override
+    public void onRequestPermissionsFromFragment(@NonNull Fragment fragment, @NonNull String[] permissions, int requestCode) {
+        super.onRequestPermissionsFromFragment(fragment, permissions, requestCode);
+    }
+
+    @Override
+    public boolean onShouldShowRequestPermissionRationale(@NonNull String permission) {
+        return super.onShouldShowRequestPermissionRationale(permission);
+    }
+
+    @Override
+    public boolean onHasWindowAnimations() {
+        return super.onHasWindowAnimations();
+    }
+
+    @Override
+    public int onGetWindowAnimations() {
+        return super.onGetWindowAnimations();
+    }
+
+    @Nullable
+    @Override
+    public View onFindViewById(int id) {
+        return mActivity.getWidgetContainer().findViewById(id);
+    }
+
+    @Override
+    public boolean onHasView() {
+        return super.onHasView();
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WRuntime.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WRuntime.java
@@ -3,11 +3,15 @@ package com.igalia.wolvic.browser.api;
 import android.app.Service;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.AnyThread;
 import androidx.annotation.LongDef;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
+import androidx.fragment.app.FragmentManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -139,6 +143,11 @@ public interface WRuntime {
      * externalContext – A pointer to the external VR context.
      */
     void setExternalVRContext(long externalContext);
+
+    /*
+     * Sets the fragment manager. Some engines need it to add sessions/tabs into a view to display them.
+     */
+    void setFragmentManager(@NonNull FragmentManager fragmentManager, @NonNull ViewGroup container);
 
 
     /**


### PR DESCRIPTION
Some engines need a FragmentManager instance add sessions/tabs into a view to display them. The usual way to get it is to inherit from FragmentActivity or AppCompatActivity but that's a very inconvenient approach for us as Wolvic uses NativeActivity or in some platforms inherits from a SDK Activity.

By using a custom FragmentController we can mimic what FragmentActivity does internally, and get a custom working FragmentManager