### PR TITLE
Add support for browser density

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -120,6 +120,12 @@ public class RuntimeImpl implements WRuntime {
     }
 
     @Override
+    public float getDensity() {
+        // GeckoDisplay uses 1.0 density and internally scales the devicePixelRatio to provided Surface.
+        return 1.0f;
+    }
+
+    @Override
     public void configurationChanged(@NonNull Configuration newConfig) {
         mRuntime.configurationChanged(newConfig);
     }

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1418,6 +1418,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    public void recreateWidgetSurface(Widget aWidget) {
+        queueRunnable(() -> recreateWidgetSurfaceNative(aWidget.getHandle()));
+    }
+
+    @Override
     public void startWidgetResize(final Widget aWidget, float aMaxWidth, float aMaxHeight, float minWidth, float minHeight) {
         if (aWidget == null) {
             return;
@@ -1727,6 +1732,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void updateWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateVisibleWidgetsNative();
     private native void removeWidgetNative(int aHandle);
+    private native void recreateWidgetSurfaceNative(int aHandle);
     private native void startWidgetResizeNative(int aHandle, float maxWidth, float maxHeight, float minWidth, float minHeight);
     private native void finishWidgetResizeNative(int aHandle);
     private native void startWidgetMoveNative(int aHandle, int aMoveBehaviour);

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WRuntime.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WRuntime.java
@@ -150,6 +150,12 @@ public interface WRuntime {
     void setFragmentManager(@NonNull FragmentManager fragmentManager, @NonNull ViewGroup container);
 
 
+    /*
+     * Returns the view density (devicePixelRatio) that should be used to display browser engine session.
+     */
+    @UiThread
+    float getDensity();
+
     /**
      * Notify that the device configuration has changed.
      *

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -65,6 +65,7 @@ public interface WidgetManagerDelegate {
     void updateWidget(Widget aWidget);
     void removeWidget(Widget aWidget);
     void updateVisibleWidgets();
+    void recreateWidgetSurface(Widget aWidget);
     void startWidgetResize(Widget aWidget, float maxWidth, float maxHeight, float minWidth, float minHeight);
     void finishWidgetResize(Widget aWidget);
     void startWidgetMove(Widget aWidget, @WidgetMoveBehaviourFlags int aMoveBehaviour);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -393,6 +393,15 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
+    private void recreateWidgetSurfaceIfNeeded(float prevDensity) {
+        if (prevDensity != mWidgetPlacement.density || !isLayer())
+            return;
+
+        // If the densities are the same updateWidget won't generate a new surface as the resulting
+        // texture sizes are equal. We need to force a new surface creation when using layers.
+        mWidgetManager.recreateWidgetSurface(this);
+    }
+
     private void setView(View view, boolean switchSurface) {
         Runnable setView = () -> {
             if (switchSurface) {
@@ -419,12 +428,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 setWillNotDraw(false);
                 postInvalidate();
 
-                if (prevDensity == mWidgetPlacement.density && isLayer()) {
-                    // If the densities are the same updateWidget won't generate a new surface
-                    // as the resulting texture sizes are equal. We need to force a new surface
-                    // creation when using layers.
-                    mWidgetManager.recreateWidgetSurface(this);
-                }
+                recreateWidgetSurfaceIfNeeded(prevDensity);
             }
         };
 
@@ -462,12 +466,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 if (mTexture != null) {
                     resumeCompositor();
                 }
-                if (prevDensity == mWidgetPlacement.density && isLayer()) {
-                    // If the densities are the same updateWidget won't generate a new surface
-                    // as the resulting texture sizes are equal. We need to force a new surface
-                    // creation when using layers.
-                    mWidgetManager.recreateWidgetSurface(this);
-                }
+                recreateWidgetSurfaceIfNeeded(prevDensity);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -51,6 +51,7 @@ import com.igalia.wolvic.browser.api.WMediaSession;
 import com.igalia.wolvic.browser.api.WResult;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.api.WWebResponse;
+import com.igalia.wolvic.browser.engine.EngineProvider;
 import com.igalia.wolvic.browser.engine.Session;
 import com.igalia.wolvic.browser.engine.SessionState;
 import com.igalia.wolvic.browser.engine.SessionStore;
@@ -140,6 +141,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private CopyOnWriteArrayList<Runnable> mSetViewQueuedCalls;
     private SharedPreferences mPrefs;
     private DownloadsManager mDownloadsManager;
+    private float mBrowserDensity;
 
     public interface WindowListener {
         default void onFocusRequest(@NonNull WindowWidget aWindow) {}
@@ -240,7 +242,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         aPlacement.height = SettingsStore.getInstance(getContext()).getWindowHeight() + mBorderWidth * 2;
         aPlacement.worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) *
                 (float)windowWidth / (float)SettingsStore.WINDOW_WIDTH_DEFAULT;
-        aPlacement.density = 1.0f;
+        aPlacement.density = getBrowserDensity();
         aPlacement.visible = true;
         aPlacement.cylinder = true;
         aPlacement.textureScale = 1.0f;
@@ -403,6 +405,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             addView(mView);
 
             if (switchSurface) {
+                float prevDensity = mWidgetPlacement.density;
                 mWidgetPlacement.density = getContext().getResources().getDisplayMetrics().density;
                 if (mTexture != null && mSurface != null && mRenderer == null) {
                     // Create the UI Renderer for the current surface.
@@ -415,6 +418,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 mWidgetManager.pushBackHandler(mBackHandler);
                 setWillNotDraw(false);
                 postInvalidate();
+
+                if (prevDensity == mWidgetPlacement.density && isLayer()) {
+                    // If the densities are the same updateWidget won't generate a new surface
+                    // as the resulting texture sizes are equal. We need to force a new surface
+                    // creation when using layers.
+                    mWidgetManager.recreateWidgetSurface(this);
+                }
             }
         };
 
@@ -444,12 +454,19 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                     }
                     mSurface = new Surface(mTexture);
                 }
-                mWidgetPlacement.density = 1.0f;
+                float prevDensity = mWidgetPlacement.density;
+                mWidgetPlacement.density = getBrowserDensity();
                 mWidgetManager.updateWidget(WindowWidget.this);
                 mWidgetManager.popWorldBrightness(WindowWidget.this);
                 mWidgetManager.popBackHandler(mBackHandler);
                 if (mTexture != null) {
                     resumeCompositor();
+                }
+                if (prevDensity == mWidgetPlacement.density && isLayer()) {
+                    // If the densities are the same updateWidget won't generate a new surface
+                    // as the resulting texture sizes are equal. We need to force a new surface
+                    // creation when using layers.
+                    mWidgetManager.recreateWidgetSurface(this);
                 }
             }
         }
@@ -2139,5 +2156,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
             return true;
         }
+    }
+
+    private float getBrowserDensity() {
+        if (mBrowserDensity == 0) {
+            mBrowserDensity = EngineProvider.INSTANCE.getOrCreateRuntime(getContext()).getDensity();
+        }
+        return mBrowserDensity;
     }
 }

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1211,6 +1211,15 @@ BrowserWorld::RemoveWidget(int32_t aHandle) {
 }
 
 void
+BrowserWorld::RecreateWidgetSurface(int32_t aHandle) {
+  ASSERT_ON_RENDER_THREAD();
+  WidgetPtr widget = m.GetWidget(aHandle);
+  if (widget) {
+    widget->RecreateSurface();
+  }
+}
+
+void
 BrowserWorld::StartWidgetResize(int32_t aHandle, const vrb::Vector& aMaxSize, const vrb::Vector& aMinSize) {
   ASSERT_ON_RENDER_THREAD();
   WidgetPtr widget = m.GetWidget(aHandle);
@@ -1767,6 +1776,12 @@ JNI_METHOD(void, updateVisibleWidgetsNative)
 JNI_METHOD(void, removeWidgetNative)
 (JNIEnv*, jobject, jint aHandle) {
   crow::BrowserWorld::Instance().RemoveWidget(aHandle);
+}
+
+
+JNI_METHOD(void, recreateWidgetSurfaceNative)
+(JNIEnv*, jobject, jint aHandle) {
+  crow::BrowserWorld::Instance().RecreateWidgetSurface(aHandle);
 }
 
 JNI_METHOD(void, startWidgetResizeNative)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -54,6 +54,7 @@ public:
   void UpdateWidget(int32_t aHandle, const WidgetPlacementPtr& aPlacement);
   void UpdateWidgetRecursive(int32_t aHandle, const WidgetPlacementPtr& aPlacement);
   void RemoveWidget(int32_t aHandle);
+  void RecreateWidgetSurface(int32_t aHandle);
   void StartWidgetResize(int32_t aHandle, const vrb::Vector& aMaxSize, const vrb::Vector& aMinSize);
   void FinishWidgetResize(int32_t aHandle);
   void StartWidgetMove(int32_t aHandle, const int32_t aMoveBehavour);

--- a/app/src/main/cpp/Cylinder.cpp
+++ b/app/src/main/cpp/Cylinder.cpp
@@ -280,6 +280,13 @@ Cylinder::SetTextureSize(int32_t aWidth, int32_t aHeight) {
   }
   m.updateTextureLayout();
 }
+void
+Cylinder::RecreateSurface() {
+  if (m.layer) {
+    bool force = true;
+    m.layer->Resize(m.textureWidth , m.textureHeight, force);
+  }
+}
 
 void
 Cylinder::SetTexture(const vrb::TexturePtr& aTexture, int32_t aWidth, int32_t aHeight) {

--- a/app/src/main/cpp/Cylinder.h
+++ b/app/src/main/cpp/Cylinder.h
@@ -34,6 +34,7 @@ public:
   void UpdateProgram(const std::string& aCustomFragmentShader);
   void GetTextureSize(int32_t& aWidth, int32_t& aHeight) const;
   void SetTextureSize(int32_t aWidth, int32_t aHeight);
+  void RecreateSurface();
   void SetTexture(const vrb::TexturePtr& aTexture, int32_t aWidth, int32_t aHeight);
   void SetTextureScale(const float aScaleX, const float aScaleY);
   void SetMaterial(const vrb::Color& aAmbient, const vrb::Color& aDiffuse, const vrb::Color& aSpecular, const float aSpecularExponent);

--- a/app/src/main/cpp/Quad.cpp
+++ b/app/src/main/cpp/Quad.cpp
@@ -337,6 +337,13 @@ Quad::SetTextureSize(int32_t aWidth, int32_t aHeight) {
   }
 }
 
+void Quad::RecreateSurface() {
+  if (m.layer) {
+    bool force = true;
+    m.layer->Resize(m.textureWidth , m.textureHeight, force);
+  }
+}
+
 void
 Quad::GetWorldMinAndMax(vrb::Vector& aMin, vrb::Vector& aMax) const {
   aMin = m.worldMin;

--- a/app/src/main/cpp/Quad.h
+++ b/app/src/main/cpp/Quad.h
@@ -44,6 +44,7 @@ public:
   void SetBackgroundColor(const vrb::Color& aColor);
   void GetTextureSize(int32_t& aWidth, int32_t& aHeight) const;
   void SetTextureSize(int32_t aWidth, int32_t aHeight);
+  void RecreateSurface();
   void GetWorldMinAndMax(vrb::Vector& aMin, vrb::Vector& aMax) const;
   const vrb::Vector& GetWorldMin() const;
   const vrb::Vector& GetWorldMax() const;

--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -301,8 +301,8 @@ VRLayerSurface::SetWorldSize(const float aWidth, const float aHeight) {
 }
 
 void
-VRLayerSurface::Resize(const int32_t aWidth, const int32_t aHeight) {
-  if (m.width == aWidth && m.height == aHeight) {
+VRLayerSurface::Resize(const int32_t aWidth, const int32_t aHeight, bool force) {
+  if (m.width == aWidth && m.height == aHeight && !force) {
     return;
   }
   m.width = aWidth;

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -103,7 +103,7 @@ public:
   void Unbind();
 
   void SetWorldSize(const float aWidth, const float aHeight);
-  void Resize(const int32_t aWidth, const int32_t aHeight);
+  void Resize(const int32_t aWidth, const int32_t aHeight, bool force = false);
   void SetResizeDelegate(const ResizeDelegate& aDelegate);
   void SetBindDelegate(const BindDelegate& aDelegate);
   void SetSurface(jobject aSurface);

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -277,6 +277,15 @@ Widget::SetSurfaceTextureSize(int32_t aWidth, int32_t aHeight) {
 }
 
 void
+Widget::RecreateSurface() {
+  if (m.quad) {
+    m.quad->RecreateSurface();
+  } else {
+    m.cylinder->RecreateSurface();
+  }
+}
+
+void
 Widget::GetWidgetMinAndMax(vrb::Vector& aMin, vrb::Vector& aMax) const {
   aMin = m.min;
   aMax = m.max;

--- a/app/src/main/cpp/Widget.h
+++ b/app/src/main/cpp/Widget.h
@@ -48,6 +48,7 @@ public:
   const vrb::TextureSurfacePtr GetSurfaceTexture() const;
   void GetSurfaceTextureSize(int32_t& aWidth, int32_t& aHeight) const;
   void SetSurfaceTextureSize(int32_t aWidth, int32_t aHeight);
+  void RecreateSurface();
   void GetWidgetMinAndMax(vrb::Vector& aMin, vrb::Vector& aMax) const;
   void SetWorldWidth(float aWorldWidth) const;
   void GetWorldSize(float& aWidth, float& aHeight) const;


### PR DESCRIPTION
This PRs adds support for using a different density to render a WSession. Historically we have been using 1.0 because GeckoSession handled it internally but as we integrate new backends there is a difference in sizes between the pixel size and the browser dpi/point size, leading to really small browser viewports with 1.0.

One complexity added with this change is that in the WindowWidget we relied on a surface size change caused by different densities between the UI and the browser to generate new Surfaces when switching between the Browser Display and the custom Library UI (bookmarks, history, etc) that are shown on the same quad. We need to force a new surface creation when using layers if the densities between both are equal.