### PR TITLE
Bump target SDK version to 31

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         <activity
             android:name="com.igalia.wolvic.VRBrowserActivity"
             android:launchMode="singleInstance"
+            android:exported="true"
             android:configChanges="density|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
             android:windowSoftInputMode="stateAlwaysHidden">
             <intent-filter>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <application
         android:name=".VRBrowserApplication"
         android:allowBackup="true"
+        android:exported="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -34,7 +35,7 @@
             android:resizeableActivity="false"
             android:supportsPictureInPicture="false"
             tools:node="replace"
-            >
+            android:exported="true">
             <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
             <intent-filter>

--- a/versions.gradle
+++ b/versions.gradle
@@ -185,8 +185,8 @@ ext.deps = deps
 def build_versions = [:]
 build_versions.min_sdk = 24
 build_versions.min_sdk_wave = 25
-build_versions.target_sdk = 30
-build_versions.target_sdk_wave = 30
+build_versions.target_sdk = 31
+build_versions.target_sdk_wave = 31
 build_versions.build_tools = "30.0.3"
 ext.build_versions = build_versions
 


### PR DESCRIPTION
This is required to integrate recent chromium builds which might use v31 APIs or declarations in the manifest

Adding the android:exported="true" is a requirement for the new target SDK.