### PR TITLE
Don't rebuild the Search Engine UI if not needed

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
@@ -111,8 +111,8 @@ public class SearchEngineView extends SettingsView implements SharedPreferences.
             int checkedId = mBinding.searchEngineRadio.getCheckedRadioButtonId();
             if (checkedId >= 0 && checkedId < mSearchEngines.size()) {
                 SearchEngine selected = mSearchEngines.get(checkedId);
-                String preferenceValue = sharedPreferences.getString(key, "");
-                if (selected != null && preferenceValue.equals(selected.getIdentifier())) {
+                String storedSearchEngineId = sharedPreferences.getString(key, "");
+                if (storedSearchEngineId.equals(selected.getIdentifier())) {
                     // The selected radio button is already the correct one, so we are done.
                     return;
                 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
@@ -108,6 +108,16 @@ public class SearchEngineView extends SettingsView implements SharedPreferences.
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         if (key.equals(getContext().getString(R.string.settings_key_search_engine_id))) {
+            int checkedId = mBinding.searchEngineRadio.getCheckedRadioButtonId();
+            if (checkedId >= 0 && checkedId < mSearchEngines.size()) {
+                SearchEngine selected = mSearchEngines.get(checkedId);
+                String preferenceValue = sharedPreferences.getString(key, "");
+                if (selected != null && preferenceValue.equals(selected.getIdentifier())) {
+                    // The selected radio button is already the correct one, so we are done.
+                    return;
+                }
+            }
+            // Otherwise, update the UI.
             updateUI();
         }
     }


### PR DESCRIPTION
The Search Engine selector is updating its UI unnecessarily whenever the user selects a new value.

The problem is that we rebuild the UI whenever the stored preference changes, but this is not needed most of the time because the list of available search engines remains the same.

With this PR, the Search Engine UI will only rebuild its UI when the selected radio button does not match the current stored preference.