### PR TITLE
Improve HVR speech recognizer error handling

### DIFF
--- a/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
+++ b/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
@@ -95,7 +95,17 @@ public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
     public void onError(int code, String msg) {
         dispatch(() -> {
             if (mCallback != null) {
-                mCallback.onError(Callback.SPEECH_ERROR, msg);
+                switch (code) {
+                    case MLAsrConstants.ERR_NO_NETWORK:
+                        mCallback.onError(Callback.ERROR_NETWORK, msg);
+                        break;
+                    case MLAsrConstants.ERR_SERVICE_UNAVAILABLE:
+                        mCallback.onError(Callback.ERROR_SERVER, msg);
+                        break;
+                    case MLAsrConstants.ERR_NO_UNDERSTAND:
+                    default:
+                        mCallback.onError(Callback.SPEECH_ERROR, msg);
+                }
             }
         });
     }


### PR DESCRIPTION
The current code was always advertising SPEECH_ERROR. We can do it better by using the error code returned by the service