### PR TITLE
Update a few links and the build string in Settings dialog

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -191,7 +191,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             e.printStackTrace();
         }
 
-        mBinding.buildText.setText(StringUtils.versionCodeToDate(getContext(), BuildConfig.VERSION_CODE));
+        mBinding.buildText.setText("versionCode " + BuildConfig.VERSION_CODE);
 
         final GestureDetector gd = new GestureDetector(getContext(), new VersionGestureListener());
         mBinding.settingsMasthead.setOnTouchListener((view, motionEvent) -> {

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -71,7 +71,7 @@
     <string name="private_policy_url" translatable="false">https://wolvic.com/legal/privacy/</string>
     <string name="private_report_url" translatable="false">https://www.igalia.com/privacy/&amp;url=%1$s</string>
     <string name="terms_service_url" translatable="false">https://wolvic.com/legal/terms/</string>
-    <string name="help_url" translatable="false">https://www.wolvic.com</string>
+    <string name="help_url" translatable="false">https://wolvic.com/support/</string>
     <string name="sumo_language_voice_url" translatable="false">https://support.mozilla.org/kb/using-voice-search-firefox-reality</string>
     <string name="sumo_language_display_url" translatable="false">https://support.mozilla.org/kb/use-firefox-another-language?as=u&amp;utm_source=inproduct</string>
     <string name="sumo_language_content_url" translatable="false">https://support.mozilla.org/kb/choose-display-languages-multilingual-web-pages?as=u&amp;utm_source=inproduct</string>
@@ -208,5 +208,5 @@
     <string name="keyboard_nl_NL_popup_i" translatable="false">ìíiïîįī</string>
 
     <!-- Settings Survey link -->
-    <string name="survey_link" translatable="false">https://www.wolvic.com</string>
+    <string name="survey_link" translatable="false">https://github.com/Igalia/wolvic/issues/</string>
 </resources>


### PR DESCRIPTION
Point  `Send us Feedback` to <https://github.com/Igalia/wolvic/issues/> and `Help` to <https://wolvic.com/support/>.
The build version shown when clicking Wolvic logo in the Settings dialog has also been updated to something more meaningful.

See #84. 
