### PR TITLE
Add coarse location permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="${applicationId}.CRASH_RECEIVER_PERMISSION"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
We already require the `ACCESS_FINE_LOCATION` permission.

This PR just fixes a warning that was happening because `ACCESS_FINE_LOCATION` requires having `ACCESS_COARSE_LOCATION` as well.