### PR TITLE
Use the external storage for downloads

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -107,7 +107,7 @@ public class SettingsStore {
     public final static long FXA_LAST_SYNC_NEVER = 0;
     public final static boolean RESTORE_TABS_ENABLED = true;
     public final static boolean BYPASS_CACHE_ON_RELOAD = false;
-    public final static int DOWNLOADS_STORAGE_DEFAULT = INTERNAL;
+    public final static int DOWNLOADS_STORAGE_DEFAULT = EXTERNAL;
     public final static int DOWNLOADS_SORTING_ORDER_DEFAULT = SortingContextMenuWidget.SORT_DATE_ASC;
     public final static boolean AUTOCOMPLETE_ENABLED = true;
     public final static boolean WEBGL_OUT_OF_PROCESS = false;

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -107,7 +107,6 @@ public class SettingsStore {
     public final static long FXA_LAST_SYNC_NEVER = 0;
     public final static boolean RESTORE_TABS_ENABLED = true;
     public final static boolean BYPASS_CACHE_ON_RELOAD = false;
-    public final static int DOWNLOADS_STORAGE_DEFAULT = EXTERNAL;
     public final static int DOWNLOADS_SORTING_ORDER_DEFAULT = SortingContextMenuWidget.SORT_DATE_ASC;
     public final static boolean AUTOCOMPLETE_ENABLED = true;
     public final static boolean WEBGL_OUT_OF_PROCESS = false;
@@ -738,16 +737,6 @@ public class SettingsStore {
 
     public boolean isBypassCacheOnReloadEnabled() {
         return mPrefs.getBoolean(mContext.getString(R.string.settings_key_bypass_cache_on_reload), BYPASS_CACHE_ON_RELOAD);
-    }
-
-    public void setDownloadsStorage(@Storage int storage) {
-        SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putInt(mContext.getString(R.string.settings_key_downloads_external), storage);
-        editor.commit();
-    }
-
-    public @Storage int getDownloadsStorage() {
-        return mPrefs.getInt(mContext.getString(R.string.settings_key_downloads_external), DOWNLOADS_STORAGE_DEFAULT);
     }
 
     public void setDownloadsSortingOrder(@SortingContextMenuWidget.Order int order) {

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -111,7 +111,13 @@ public class DownloadsManager {
         request.setVisibleInDownloadsUi(false);
 
         if (job.getOutputPath() == null) {
-            request.setDestinationInExternalFilesDir(mContext, Environment.DIRECTORY_DOWNLOADS, job.getFilename());
+            try {
+                request.setDestinationInExternalFilesDir(mContext, Environment.DIRECTORY_DOWNLOADS, job.getFilename());
+            } catch (IllegalStateException e) {
+                e.printStackTrace();
+                notifyDownloadError(mContext.getString(R.string.download_error_output), job.getFilename());
+                return;
+            }
         } else {
             request.setDestinationUri(Uri.parse("file://" + job.getOutputPath()));
         }
@@ -120,6 +126,7 @@ public class DownloadsManager {
             try {
                 mDownloadManager.enqueue(request);
             } catch (SecurityException e) {
+                e.printStackTrace();
                 notifyDownloadError(mContext.getString(R.string.download_error_output), job.getFilename());
                 return;
             }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1572,30 +1572,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 mDownloadsManager.startDownload(downloadJob);
             }
         };
-        @SettingsStore.Storage int storage = SettingsStore.getInstance(getContext()).getDownloadsStorage();
-        if (storage == SettingsStore.EXTERNAL) {
-            mWidgetManager.requestPermission(
-                    downloadJob.getUri(),
-                    android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    new WSession.PermissionDelegate.Callback() {
-                        @Override
-                        public void grant() {
-                            download.run();
-                        }
 
-                        @Override
-                        public void reject() {
-                            mWidgetManager.getFocusedWindow().showAlert(
-                                    getContext().getString(R.string.download_error_title_v1),
-                                    getContext().getString(R.string.download_error_external_storage),
-                                    null
-                            );
-                        }
-                    });
-
-        } else {
-            download.run();
-        }
+        download.run();
     }
 
     private boolean isContextMenuVisible() {
@@ -1844,25 +1822,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         } else {
             hideLibraryPanel();
-        }
-
-        if ("file".equalsIgnoreCase(uri.getScheme()) &&
-                !mWidgetManager.isPermissionGranted(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            mWidgetManager.requestPermission(
-                    aRequest.uri,
-                    android.Manifest.permission.READ_EXTERNAL_STORAGE,
-                    new WSession.PermissionDelegate.Callback() {
-                        @Override
-                        public void grant() {
-                            result.complete(WAllowOrDeny.ALLOW);
-                        }
-
-                        @Override
-                        public void reject() {
-                            result.complete(WAllowOrDeny.DENY);
-                        }
-                    });
-            return result;
         }
 
         result.complete(WAllowOrDeny.ALLOW);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -17,7 +17,6 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.SurfaceTexture;
 import android.net.Uri;
-import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Pair;
@@ -1553,49 +1552,22 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public void startDownload(@NonNull DownloadJob downloadJob, boolean showConfirmDialog) {
-        Runnable download = () -> {
-            if (showConfirmDialog) {
-                mWidgetManager.getFocusedWindow().showConfirmPrompt(
-                        R.drawable.ic_icon_downloads,
-                        getResources().getString(R.string.download_confirm_title),
-                        downloadJob.getFilename(),
-                        new String[]{
-                                getResources().getString(R.string.download_confirm_cancel),
-                                getResources().getString(R.string.download_confirm_download)},
-                        (index, isChecked) ->  {
-                            if (index == PromptDialogWidget.POSITIVE) {
-                                mDownloadsManager.startDownload(downloadJob);
-                            }
+        if (showConfirmDialog) {
+            mWidgetManager.getFocusedWindow().showConfirmPrompt(
+                    R.drawable.ic_icon_downloads,
+                    getResources().getString(R.string.download_confirm_title),
+                    downloadJob.getFilename(),
+                    new String[]{
+                            getResources().getString(R.string.download_confirm_cancel),
+                            getResources().getString(R.string.download_confirm_download)},
+                    (index, isChecked) -> {
+                        if (index == PromptDialogWidget.POSITIVE) {
+                            mDownloadsManager.startDownload(downloadJob);
                         }
-                );
-
-            } else {
-                mDownloadsManager.startDownload(downloadJob);
-            }
-        };
-
-        // In Android >= Q we don't need additional permissions to write to our own external dir.
-        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            mWidgetManager.requestPermission(
-                    downloadJob.getUri(),
-                    android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    new WSession.PermissionDelegate.Callback() {
-                        @Override
-                        public void grant() {
-                            download.run();
-                        }
-
-                        @Override
-                        public void reject() {
-                            mWidgetManager.getFocusedWindow().showAlert(
-                                    getContext().getString(R.string.download_error_title_v1),
-                                    getContext().getString(R.string.download_error_external_storage),
-                                    null
-                            );
-                        }
-                    });
+                    }
+            );
         } else {
-            download.run();
+            mDownloadsManager.startDownload(downloadJob);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
@@ -154,10 +154,6 @@ class PrivacyOptionsView extends SettingsView {
         mBinding.trackingProtectionRadio.setOnCheckedChangeListener(mTrackingProtectionListener);
         setTrackingProtection(mBinding.trackingProtectionRadio.getIdForValue(etpLevel), false);
 
-        @SettingsStore.Storage int downloadsStorage = SettingsStore.getInstance(getContext()).getDownloadsStorage();
-        mBinding.downloadsStorage.setOnCheckedChangeListener(mDownloadsStorageListener);
-        setDownloadsStorage(mBinding.downloadsStorage.getIdForValue(downloadsStorage), false);
-
         mBinding.loginsAndPasswords.setOnClickListener(view -> mDelegate.showView(SettingViewType.LOGINS_AND_PASSWORDS));
     }
 
@@ -220,10 +216,6 @@ class PrivacyOptionsView extends SettingsView {
         setWebXR(value, doApply);
     };
 
-    private RadioGroupSetting.OnCheckedChangeListener mDownloadsStorageListener = (radioGroup, checkedId, doApply) -> {
-        setDownloadsStorage(checkedId, true);
-    };
-
     private void resetOptions() {
         if (mBinding.drmContentPlaybackSwitch.isChecked() != SettingsStore.DRM_PLAYBACK_DEFAULT) {
             setDrmContent(SettingsStore.DRM_PLAYBACK_DEFAULT, true);
@@ -264,10 +256,6 @@ class PrivacyOptionsView extends SettingsView {
 
         if (mBinding.webxrSwitch.isChecked() != SettingsStore.WEBXR_ENABLED_DEFAULT) {
             setWebXR(SettingsStore.WEBXR_ENABLED_DEFAULT, true);
-        }
-
-        if (!mBinding.downloadsStorage.getValueForId(mBinding.downloadsStorage.getCheckedRadioButtonId()).equals(SettingsStore.DOWNLOADS_STORAGE_DEFAULT)) {
-            setDownloadsStorage(mBinding.downloadsStorage.getIdForValue(SettingsStore.DOWNLOADS_STORAGE_DEFAULT), true);
         }
     }
 
@@ -372,14 +360,6 @@ class PrivacyOptionsView extends SettingsView {
                 window.getSession().reload(WSession.LOAD_FLAGS_BYPASS_CACHE);
             }
         }
-    }
-
-    private void setDownloadsStorage(int checkId, boolean doApply) {
-        mBinding.downloadsStorage.setOnCheckedChangeListener(null);
-        mBinding.downloadsStorage.setChecked(checkId, doApply);
-        mBinding.downloadsStorage.setOnCheckedChangeListener(mDownloadsStorageListener);
-
-        SettingsStore.getInstance(getContext()).setDownloadsStorage((Integer)mBinding.downloadsStorage.getValueForId(checkId));
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
@@ -133,21 +133,21 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
                 // In Android >= Q we don't need additional permissions to write to our own external dir.
                 if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                     mApplicationDelegate.requestPermission(
-                            job.getUri(),
-                            android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                            new WSession.PermissionDelegate.Callback() {
-                                @Override
-                                public void grant() {
-                                    mDownloadManager.startDownload(job);
-                                }
+                                job.getUri(),
+                                android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                                new WSession.PermissionDelegate.Callback() {
+                                    @Override
+                                    public void grant() {
+                                        mDownloadManager.startDownload(job);
+                                    }
 
-                                @Override
-                                public void reject() {
-                                    mListeners.forEach(listener -> listener.onEnvironmentSetError(
-                                            mContext.getString(R.string.environment_download_permission_error_body)
-                                    ));
-                                }
-                            });
+                                    @Override
+                                    public void reject() {
+                                        mListeners.forEach(listener -> listener.onEnvironmentSetError(
+                                                mContext.getString(R.string.environment_download_permission_error_body)
+                                        ));
+                                    }
+                                });
 
                 } else {
                     mDownloadManager.startDownload(job);

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
@@ -3,7 +3,6 @@ package com.igalia.wolvic.utils;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
@@ -11,7 +10,6 @@ import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
-import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.downloads.Download;
 import com.igalia.wolvic.downloads.DownloadJob;
 import com.igalia.wolvic.downloads.DownloadsManager;
@@ -129,29 +127,7 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
             if (!isDownloading) {
                 // If the env is not being downloaded, start downloading it
                 DownloadJob job = DownloadJob.create(environment.getPayload());
-
-                // In Android >= Q we don't need additional permissions to write to our own external dir.
-                if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                    mApplicationDelegate.requestPermission(
-                                job.getUri(),
-                                android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                                new WSession.PermissionDelegate.Callback() {
-                                    @Override
-                                    public void grant() {
-                                        mDownloadManager.startDownload(job);
-                                    }
-
-                                    @Override
-                                    public void reject() {
-                                        mListeners.forEach(listener -> listener.onEnvironmentSetError(
-                                                mContext.getString(R.string.environment_download_permission_error_body)
-                                        ));
-                                    }
-                                });
-
-                } else {
-                    mDownloadManager.startDownload(job);
-                }
+                mDownloadManager.startDownload(job);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
@@ -128,29 +128,7 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
             if (!isDownloading) {
                 // If the env is not being downloaded, start downloading it
                 DownloadJob job = DownloadJob.create(environment.getPayload());
-                @SettingsStore.Storage int storage = SettingsStore.getInstance(mContext).getDownloadsStorage();
-                if (storage == SettingsStore.EXTERNAL &&
-                        !mApplicationDelegate.isPermissionGranted(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                    mApplicationDelegate.requestPermission(
-                                job.getUri(),
-                                android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                                new WSession.PermissionDelegate.Callback() {
-                                    @Override
-                                    public void grant() {
-                                        mDownloadManager.startDownload(job);
-                                    }
-
-                                    @Override
-                                    public void reject() {
-                                        mListeners.forEach(listener -> listener.onEnvironmentSetError(
-                                                mContext.getString(R.string.environment_download_permission_error_body)
-                                        ));
-                                    }
-                                });
-
-                } else {
-                    mDownloadManager.startDownload(job);
-                }
+                mDownloadManager.startDownload(job);
             }
         }
     }

--- a/app/src/main/res/layout/options_privacy.xml
+++ b/app/src/main/res/layout/options_privacy.xml
@@ -99,10 +99,12 @@
                     android:layout_height="wrap_content"
                     app:description="@string/security_options_restore_tabs" />
 
+                <!-- Hidden -->
                 <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
                     android:id="@+id/downloads_storage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:visibility="gone"
                     app:description="@string/security_options_downloads_storage"
                     app:options="@array/privacy_options_downloads_storage"
                     app:values="@array/privacy_options_downloads_storage_values" />

--- a/app/src/main/res/layout/options_privacy.xml
+++ b/app/src/main/res/layout/options_privacy.xml
@@ -99,16 +99,6 @@
                     android:layout_height="wrap_content"
                     app:description="@string/security_options_restore_tabs" />
 
-                <!-- Hidden -->
-                <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
-                    android:id="@+id/downloads_storage"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    app:description="@string/security_options_downloads_storage"
-                    app:options="@array/privacy_options_downloads_storage"
-                    app:values="@array/privacy_options_downloads_storage_values" />
-
                 <com.igalia.wolvic.ui.views.settings.SwitchSetting
                     android:id="@+id/popUpsBlockingSwitch"
                     android:layout_width="match_parent"


### PR DESCRIPTION
Always use the external storage for downloads. Specifically, the folder returned by 

```java
context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
```

It turns out that this is already the existing behaviour, because we were saving the downloaded files to the same folder regardless of the value of the `downloads storage` setting (this PR also removes that option).

We don't need additional permissions [when writing to the location returned by `getExternalFilesDir()`](https://developer.android.com/reference/android/content/Context#getExternalFilesDir(java.lang.String)), so those permission requests have been removed.

Note that in Android >= Q this location is not accessible to other apps.

I have been trying to integrate Wolvic with the system's `Downloads` folder but I could not get `DownloadManager` to work well with Android's new storage management API: we can save files to that public folder, but not open them inside Wolvic.

