### PR TITLE
Remove the scroll view wrapping ControllerOptionsView in Settings UI

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -38,8 +38,6 @@ class ControllerOptionsView extends SettingsView {
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_controller, this, true);
 
-        mScrollbar = mBinding.scrollbar;
-
         // Header
         mBinding.headerLayout.setBackClickListener(view -> onDismiss());
 

--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -17,46 +18,39 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:title="@string/settings_controller_options" />
+            app:title="@string/settings_controller_options">
+
+        </com.igalia.wolvic.ui.widgets.settings.SettingsHeader>
 
         <!-- ScrollView doesn't support fast scrollbar so we need to use a custom implementation -->
-        <com.igalia.wolvic.ui.views.CustomScrollView
-            android:id="@+id/scrollbar"
-            style="@style/customScrollViewStyle"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_marginTop="10dp"
-            android:layout_marginBottom="10dp"
-            app:layout_constraintBottom_toTopOf="@id/footer_layout"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/header_layout">
 
-            <LinearLayout
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@id/footer_layout"
+            app:layout_constraintTop_toBottomOf="@id/header_layout"
+            tools:layout_editor_absoluteX="30dp">
+
+            <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
+                android:id="@+id/pointer_color_radio"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                app:description="@string/developer_options_pointer_color"
+                app:layout="@layout/setting_radio_group_v"
+                app:options="@array/developer_options_pointer_colors"
+                app:values="@array/developer_options_pointer_colors_values" />
 
-                <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
-                    android:id="@+id/pointer_color_radio"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/developer_options_pointer_color"
-                    app:layout="@layout/setting_radio_group_v"
-                    app:options="@array/developer_options_pointer_colors"
-                    app:values="@array/developer_options_pointer_colors_values" />
+            <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
+                android:id="@+id/scroll_direction_radio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:description="@string/developer_options_scroll_direction"
+                app:layout="@layout/setting_radio_group_v"
+                app:options="@array/developer_options_pointer_scroll_directions"
+                app:values="@array/developer_options_pointer_scroll_direction_values" />
 
-                <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
-                    android:id="@+id/scroll_direction_radio"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/developer_options_scroll_direction"
-                    app:layout="@layout/setting_radio_group_v"
-                    app:options="@array/developer_options_pointer_scroll_directions"
-                    app:values="@array/developer_options_pointer_scroll_direction_values" />
-
-            </LinearLayout>
-        </com.igalia.wolvic.ui.views.CustomScrollView>
+        </LinearLayout>
 
         <com.igalia.wolvic.ui.widgets.settings.SettingsFooter
             android:id="@+id/footer_layout"
@@ -66,6 +60,8 @@
             app:buttonText="@string/developer_options_reset_button"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent" >
+
+        </com.igalia.wolvic.ui.widgets.settings.SettingsFooter>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
This is causing artifacts as the scroll bar is being rendered on top of the radio buttons in some device configurations.

Since the vertical space needed for the radio buttons is sufficient, the simplest solution is to remove the scroll view.