### PR TITLE
Add padding to the scrollbar in ControllerOptionsView of Settings UI

### DIFF
--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -27,6 +28,8 @@
             android:layout_height="0dp"
             android:layout_marginTop="10dp"
             android:layout_marginBottom="10dp"
+            android:paddingStart="0dp"
+            android:paddingEnd="30dp"
             app:layout_constraintBottom_toTopOf="@id/footer_layout"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
In some device configurations, scroll bar was shown on top of the radio buttons. This patch fixes this by adding a 30dp padding to the scroll view widget.

This is consistent with what other Settings UI dialogs do.