### PR TITLE
Reverse scroll direction on HVR

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -960,7 +960,13 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 return;
             }
             if (widget != null) {
-                float scrollDirection = mSettings.getScrollDirection() == 0 ? 1.0f : -1.0f;
+                float scrollDirection = (mSettings.getScrollDirection() == SettingsStore.SCROLL_DIRECTION_DEFAULT) ? 1.0f : -1.0f;
+
+                // Joystick scrolling is inverted on HVR
+                if (DeviceType.isHVRBuild()) {
+                    scrollDirection *= -1.0;
+                }
+
                 MotionEventGenerator.dispatchScroll(widget, aDevice, true,aX * scrollDirection, aY * scrollDirection);
             } else {
                 Log.e(LOGTAG, "Failed to find widget for scroll event: " + aHandle);


### PR DESCRIPTION
The HVR SDK is sending scroll events from joystick in opposite direction compared to the default, natural direction where joystick down means scrolling down (e.g, what Oculus does).

This PR fixes the behavior by reversing the direction on HVR. Tested on Huawei VR (6dof) and Oculus Quest 2.