### PR TITLE
Fix HVR thumbsticks' y-axis

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -960,13 +960,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 return;
             }
             if (widget != null) {
-                float scrollDirection = (mSettings.getScrollDirection() == SettingsStore.SCROLL_DIRECTION_DEFAULT) ? 1.0f : -1.0f;
-
-                // Joystick scrolling is inverted on HVR
-                if (DeviceType.isHVRBuild()) {
-                    scrollDirection *= -1.0;
-                }
-
+                float scrollDirection = mSettings.getScrollDirection() == 0 ? 1.0f : -1.0f;
                 MotionEventGenerator.dispatchScroll(widget, aDevice, true,aX * scrollDirection, aY * scrollDirection);
             } else {
                 Log.e(LOGTAG, "Failed to find widget for scroll event: " + aHandle);

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -194,6 +194,9 @@ std::optional<XrVector2f> OpenXRInputSource::GetAxis(OpenXRAxisType axisType) co
       axis.x = 0;
       axis.y = 0;
     }
+#ifdef HVR_6DOF
+    axis.y = -axis.y;
+#endif
 #endif
 
     return axis;
@@ -526,11 +529,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
         }
       } else if (axis.type == OpenXRAxisType::Thumbstick) {
         axesContainer[device::kImmersiveAxisThumbstickX] = state->x;
-#ifdef HVR_6DOF
-        axesContainer[device::kImmersiveAxisThumbstickY] = state->y;
-#else
         axesContainer[device::kImmersiveAxisThumbstickY] = -state->y;
-#endif
         delegate.SetScrolledDelta(mIndex, state->x, state->y);
       } else {
         axesContainer.push_back(state->x);


### PR DESCRIPTION
The HVR SDK has been sending us different wrong values for the y axis scroll from thumbsticks. This PR tunes the current workarounds we have for the 6DoF controllers after the latest changes in the SDK.

Apart from that we're reverting the previous attempt to fix the scrolling inversion as the VRBrowserActivity file is not the most precise place to do that.