### PR TITLE
Enable MSAA in GeckoView

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,7 @@ android {
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
         buildConfigField "Boolean", "DISABLE_CRASH_RESTART", getCrashRestartDisabled()
         buildConfigField "String", "AMO_COLLECTION", "\"fxr\""
+        buildConfigField "int", "MSAA_LEVEL", "1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
@@ -252,6 +253,7 @@ android {
             buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
             buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
+            buildConfigField "int", "MSAA_LEVEL", "0"
         }
 
         hvr3dof {
@@ -266,6 +268,7 @@ android {
             buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
             buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
+            buildConfigField "int", "MSAA_LEVEL", "0"
         }
 
         noapi {

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -91,7 +91,7 @@ public class SettingsStore {
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;
     public final static String ENV_DEFAULT = "wolvic";
-    public final static int MSAA_DEFAULT_LEVEL = 1;
+    public final static int MSAA_DEFAULT_LEVEL = BuildConfig.MSAA_LEVEL;
     public final static boolean AUDIO_ENABLED = false;
     public final static float CYLINDER_DENSITY_ENABLED_DEFAULT = 4680.0f;
     private final static long CRASH_RESTART_DELTA = 2000;

--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -13,6 +13,9 @@ prefs:
   dom.vr.external.enable: true
   dom.vr.webxr.enabled: true
   webgl.enable-draft-extensions: true
+  # This does not really "force" MSAA in WebGL but instead, in the case of WebXR,
+  # it respects what the client (Wolvic) has specified in the Gecko session settings.
+  webgl.msaa-force: true
   dom.webcomponents.customelements.enabled: true
   javascript.options.ion: true
   media.webspeech.synth.enabled: false


### PR DESCRIPTION
This PR sets webgl.msaa-force to true in GeckoView. This does not really "force" MSAA but instead, it allows it in WebXR
content as long as the JS application creates the WebGL content with antialias:enabled. See
https://searchfox.org/mozilla-central/source/dom/canvas/XRWebGLLayer.cpp#123 for additional details.

MSAA has been disabled for a while. After some initial testing enabling MSAA 2x by default provides great results in
Oculus with minimum impact in performance. However that is not the case for Huawei Glass devices, the quality is indeed
much better but there is a significant drop in performance. That's the reason why a new build setting was added to have
different default settings for MSAA (2x for all the cases but Huawei).