### PR TITLE
Add a new variant dimension for HVR packages in China

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        flavour: [assembleOculusvrArm64, assembleHvrArm64]
+        flavour: [assembleOculusvrArm64World, assembleHvrArm64World]
 
     steps:
       - name: Checkout Wolvic

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ android {
         buildConfigField "Boolean", "DISABLE_CRASH_RESTART", getCrashRestartDisabled()
         buildConfigField "String", "AMO_COLLECTION", "\"fxr\""
         buildConfigField "int", "MSAA_LEVEL", "1"
+        buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
@@ -157,7 +158,7 @@ android {
         disable "ExtraTranslation"
     }
 
-    flavorDimensions "platform", "abi"
+    flavorDimensions "platform", "abi", "country"
 
     productFlavors {
         // Supported platforms
@@ -252,7 +253,6 @@ android {
             }
             buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
-            buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
             buildConfigField "int", "MSAA_LEVEL", "0"
         }
 
@@ -267,8 +267,15 @@ android {
             }
             buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
-            buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
             buildConfigField "int", "MSAA_LEVEL", "0"
+        }
+
+        cn {
+            dimension "country"
+        }
+
+        world {
+            dimension "country"
         }
 
         noapi {
@@ -300,10 +307,15 @@ android {
     variantFilter { variant ->
         def platform = variant.getFlavors().get(0).name
         def abi = variant.getFlavors().get(1).name
+        def country = variant.getFlavors().get(2).name
 
         // Create x86_64 variants only for noapi platform
         if (abi == 'x86_64')
             variant.setIgnore(platform != 'noapi');
+
+        // Create variants for China only for HVR platforms
+        if (country == 'cn' && !platform.startsWith('hvr'))
+            variant.setIgnore(true);
     }
 
 
@@ -353,29 +365,29 @@ android {
             ]
         }
 
-        oculusvrArm64Debug {
+        oculusvrArm64WorldDebug {
             manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
         }
 
-        oculusvrArm64Release {
+        oculusvrArm64WorldRelease {
             manifest.srcFile getUseDebugSigningOnRelease() ? "src/oculusvrArmDebug/AndroidManifest.xml"
                                                            : "src/oculusvrArmRelease/AndroidManifest.xml"
         }
 
-        oculusvrStoreArm64Debug {
+        oculusvrStoreArm64WorldDebug {
             manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
         }
 
-        oculusvrStoreArm64Release {
+        oculusvrStoreArm64WorldRelease {
             manifest.srcFile getUseDebugSigningOnRelease() ? "src/oculusvrArmDebug/AndroidManifest.xml"
                     : "src/oculusvrArmRelease/AndroidManifest.xml"
         }
 
-        oculusvr3dofStoreArm64Debug {
+        oculusvr3dofStoreArm64WorldDebug {
             manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
         }
 
-        oculusvr3dofStoreArm64Release {
+        oculusvr3dofStoreArm64WorldRelease {
             manifest.srcFile getUseDebugSigningOnRelease() ? "src/oculusvrArmDebug/AndroidManifest.xml"
                     : "src/oculusvrArmRelease/AndroidManifest.xml"
         }
@@ -634,4 +646,9 @@ android.applicationVariants.all { variant ->
         println("X_X")
     }
 
+    def platform = variant.productFlavors.get(0).name
+    def country = variant.productFlavors.get(2).name
+
+    if (platform.toLowerCase().startsWith('hvr') && country != 'cn')
+        variant.buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -630,6 +630,15 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
     apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
 }
 
+androidComponents {
+    onVariants(selector().all(), { variant ->
+        // HVR packages for China must use different applicationIds.
+        def hvrChinaBuildPattern = ~/hvr\p{Alnum}+Cn(Release|Debug)/
+        if (hvrChinaBuildPattern.matcher(variant.name).matches())
+            variant.applicationId = variant.applicationId.get().replace('com.igalia','cn.igalia')
+    })
+}
+
 // -------------------------------------------------------------------------------------------------
 // MLS: Read token from local file if it exists
 // -------------------------------------------------------------------------------------------------

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -298,31 +298,12 @@ android {
     }
 
     variantFilter { variant ->
-        def needed = variant.name in [
-                'oculusvrArm64Debug',
-                'oculusvrArm64Release',
-                'oculusvrStoreArm64Debug',
-                'oculusvrStoreArm64Release',
-                'oculusvr3dofStoreArm64Debug',
-                'oculusvr3dofStoreArm64Release',
-                'picovrArm64Debug',
-                'picovrArm64Release',
-                'picovrStoreArm64Debug',
-                'picovrStoreArm64Release',
-                'wavevrArm64Debug',
-                'wavevrArm64Release',
-                'wavevrStoreArm64Debug',
-                'wavevrStoreArm64Release',
-                'noapiArm64Debug',
-                'noapiArm64Release',
-                'noapiX86_64Debug',
-                'noapiX86_64Release',
-                'hvrArm64Debug',
-                'hvrArm64Release',
-                'hvr3dofArm64Debug',
-                'hvr3dofArm64Release'
-        ]
-        variant.setIgnore(!needed)
+        def platform = variant.getFlavors().get(0).name
+        def abi = variant.getFlavors().get(1).name
+
+        // Create x86_64 variants only for noapi platform
+        if (abi == 'x86_64')
+            variant.setIgnore(platform != 'noapi');
     }
 
 


### PR DESCRIPTION
The mainland China release of HVR packages will have some specific configurations. We have been using different branches for that but it's unmanageable. Instead we should add a new flavor dimension for mainland China and the rest of the world.

The first difference we'll have is that the tutorial in the phone UI won't be shown for mainland China releases. The package names will be different too due to particularities of the Huawei store.

This requires a sequence of commits. First we refactor the current variant filtering. Then we add the new flavor dimension. Finally after setting an specific application id for China, we can disable showing the phone UI on that country.