### PR TITLE
Fix a crash in the selection code

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SelectionActionDelegateImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SelectionActionDelegateImpl.java
@@ -57,7 +57,9 @@ import java.util.Collection;
 
         @Override
         public void execute(@NonNull String action) {
-            mSelection.execute(action);
+            if (mSelection.isActionAvailable(action)) {
+                mSelection.execute(action);
+            }
         }
     }
 


### PR DESCRIPTION
This change fixes a crash that happens when you select text and then click the Back button.