### PR TITLE
Fix ground height when headset tracking is off

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -1010,7 +1010,8 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
   ovrMatrix4f matrix = vrapi_GetTransformFromPose(&m.predictedTracking.HeadPose.Pose);
   vrb::Matrix head = vrb::Matrix::FromRowMajor(matrix.M[0]);
 
-  if (m.renderMode == device::RenderMode::StandAlone) {
+  if (m.renderMode == device::RenderMode::StandAlone &&
+      (m.predictedTracking.Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED)) {
     head.TranslateInPlace(kAverageHeight);
   }
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -697,8 +697,7 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
     head.TranslateInPlace(vrb::Vector(-m.firstPose->position.x, -m.firstPose->position.y, -m.firstPose->position.z));
   #endif
 
-  if (m.renderMode == device::RenderMode::StandAlone &&
-      (location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT)) {
+  if (m.renderMode == device::RenderMode::StandAlone) {
     head.TranslateInPlace(kAverageHeight);
   }
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -697,7 +697,8 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
     head.TranslateInPlace(vrb::Vector(-m.firstPose->position.x, -m.firstPose->position.y, -m.firstPose->position.z));
   #endif
 
-  if (m.renderMode == device::RenderMode::StandAlone) {
+  if (m.renderMode == device::RenderMode::StandAlone &&
+      (location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT)) {
     head.TranslateInPlace(kAverageHeight);
   }
 


### PR DESCRIPTION
This change fixes a bug that happens when `Headset tracking` is turned off in the Oculus settings.

Issue: https://github.com/Igalia/wolvic/issues/89