### PR TITLE
Do not assume the app name is composed by at least two words

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -181,9 +181,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
         try {
             PackageInfo pInfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
             String app_name = getResources().getString(R.string.app_name);
-            String[] app_name_parts = app_name.split(" ");
-            mBinding.versionText.setText(Html.fromHtml("<b>" + app_name_parts[0] + "</b>" +
-                            " " + app_name_parts[1] + " " +
+            mBinding.versionText.setText(Html.fromHtml("<b>" + app_name + "</b>" +
                             " <b>" + pInfo.versionName + "</b>",
                     Html.FROM_HTML_MODE_LEGACY));
 


### PR DESCRIPTION
Using a single word (like Wolvic) application name in the non_L10n.xml file was causing
the settings dialog to crash the application. The problem was that there was some code
incorrectly assuming that the application name was composed by at least two words.