### PR TITLE
Remove a copy/paste error in the multi-backend implementation

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -59,7 +59,7 @@ public class RuntimeImpl implements WRuntime {
                 .screenSizeOverride(settings.getScreenWidthOverride(), settings.getScreenHeightOverride())
                 .inputAutoZoomEnabled(settings.isInputAutoZoomEnabled())
                 .doubleTapZoomingEnabled(settings.isDoubleTapZoomingEnabled())
-                .debugLogging(settings.isDoubleTapZoomingEnabled())
+                .debugLogging(settings.isConsoleServiceToLogcat())
                 .consoleOutput(settings.isConsoleOutputEnabled())
                 .loginAutofillEnabled(settings.isAutofillLoginsEnabled())
                 .configFilePath(settings.getConfigFilePath())


### PR DESCRIPTION
Debug logging was set to the isDoubleTapZoomingEnabled setting by
mistake. Enabling debug logging means sending to logcat both console
and devtools messages and also setting the log level to false. Since
there is no other way to enable sending console output to logcat
we can use that property to detect whether or not debug logging is enabled.