### PR TITLE
Speech recognition: use Meetkai for non-China HVR builds

### DIFF
--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -115,7 +115,8 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
             }
             MLApplication.getInstance().setApiKey(BuildConfig.HVR_ML_API_KEY);
             TelemetryService.setService(new HVRTelemetry(this));
-            ((VRBrowserApplication)getApplicationContext()).setSpeechRecognizer(new HVRSpeechRecognizer(this));
+            if (BuildConfig.FLAVOR_country == "cn")
+                ((VRBrowserApplication)getApplicationContext()).setSpeechRecognizer(new HVRSpeechRecognizer(this));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
The Meetkai speech recognition service provides much better results
in general than the HVR one, so let's use it for non China builds by
default as we do for the Oculus builds for example.

In the future we'll likely have an UI selection mechanism for that.