### PR TITLE
Combine field-of-vision and projection matrix, to fix Oculus distortions

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -116,10 +116,13 @@ struct DeviceDelegateOculusVR::State {
     float fovX = vrapi_GetSystemPropertyFloat(&java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_X);
     float fovY = vrapi_GetSystemPropertyFloat(&java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_Y);
 
-    ovrMatrix4f projection = ovrMatrix4f_CreateProjectionFov(fovX, fovY, 0.0, 0.0, near, far);
-    auto matrix = vrb::Matrix::FromRowMajor(projection.M);
+    ovrMatrix4f fov = ovrMatrix4f_CreateProjectionFov(fovX, fovY, 0.0, 0.0, near, far);
+    auto fovMatrix = vrb::Matrix::FromRowMajor(fov.M);
     for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {
-      cameras[i]->SetPerspective(matrix);
+      ovrMatrix4f projection = predictedTracking.Eye[i].ProjectionMatrix;
+      auto projectionMatrix = vrb::Matrix::FromRowMajor(projection.M);
+      auto perspectiveMatrix = projectionMatrix.PostMultiply(fovMatrix);
+      cameras[i]->SetPerspective(perspectiveMatrix);
     }
 
     if (immersiveDisplay) {
@@ -1031,6 +1034,8 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
     }
     m.immersiveDisplay->SetCapabilityFlags(caps);
   }
+
+  m.UpdatePerspective();
 
   int lastReorientCount = m.reorientCount;
   m.UpdateControllers(head);


### PR DESCRIPTION
This PR is another step along the road to fix distortions on the Oculus.

The main change is that the call to `CameraEye::SetPerspective()` receives a combination of the field-of-vision projection and the projection matrix provided by the Oculus SDK. Furthermore, this now happens on each frame.

This change is able to fix the distortions in WebXR that happen when the user sets the inter-eye distance to `1` or `3` and then starts a WebXR experience.

The only remaining problem happens when the user changes the inter-eye distance *while* in the middle of a WebXR experience. My suspicion is that Gecko gets the correct values when WebXR is launched, but those values are not updated afterwards.