### PR TITLE
Handle the crash reporting service work in the UI thread

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/crashreporting/CrashReporterService.java
+++ b/app/src/common/shared/com/igalia/wolvic/crashreporting/CrashReporterService.java
@@ -1,5 +1,7 @@
 package com.igalia.wolvic.crashreporting;
 
+import static org.mozilla.gecko.util.ThreadUtils.runOnUiThread;
+
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
@@ -59,8 +61,7 @@ public class CrashReporterService extends JobIntentService {
         return files;
     }
 
-    @Override
-    protected void onHandleWork(@NonNull Intent intent) {
+    private void onHandleWorkInternal(@NonNull Intent intent) {
         String action = intent.getAction();
         WRuntime.CrashReportIntent crash = EngineProvider.INSTANCE.getOrCreateRuntime(getBaseContext()).getCrashReportIntent();
         if (crash.action_crashed.equals(action)) {
@@ -134,6 +135,11 @@ public class CrashReporterService extends JobIntentService {
         }
 
         Log.d(LOGTAG, "Crash reporter job finished");
+    }
+
+    @Override
+    protected void onHandleWork(@NonNull Intent intent) {
+        runOnUiThread(() -> onHandleWorkInternal(intent));
     }
 
     public static void submitCaughtException(@NonNull Exception exception) {


### PR DESCRIPTION
The crash reporting service requires access to the GeckoRuntime. The runtime is usually
already created by the time this service executes, but in some cases (like at startup)
it might be the case that it hasn't been created yet. Creating the GeckoRuntime must be
done in the main (UI) thread, so we must ensure that we call
EngineProvider.getOrCreateRuntime() in the UI thread.