### PR TITLE
Fix saving state of SessionState

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionState.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionState.java
@@ -83,7 +83,7 @@ public class SessionState {
     public static class ISessionStateAdapter extends TypeAdapter<WSessionState> {
         @Override
         public void write(JsonWriter out, WSessionState state) throws IOException {
-            out.jsonValue(state.toString());
+            out.jsonValue(state.toJson());
         }
 
         @Override


### PR DESCRIPTION
This is a regression from the multi-backend patch. In order to save the SessionState
object we need to call toJson() instead of toString(). The confusion came
from the fact that before the multi-backend patch we were directly calling
GeckoSessionState.toString() which actually generates a JSON. But now we need to use
the WSessionState::toJson() method to achieve the same result.

This was detected because the GeckoSession was issuing "String does not represent
valid session state." errors on startup.