### PR TITLE
Show supported languages for voice search

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
@@ -50,6 +50,7 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
             callback.onError(Callback.ERROR_LANGUAGE_NOT_SUPPORTED, "language not supported");
             stop();
         } else {
+            Log.w(LOGTAG, "start speech recognition, language =  " + settings.locale);
             mkSpeechService.start(mContext, settings.locale, key);
         }
     }
@@ -83,12 +84,10 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
             double db = (double) fftsum * -1; // the higher the value, quieter the user/environment is
             db = db == Double.POSITIVE_INFINITY ? MAX_DB : db;
             int level = (int) (MAX_CLIPPING - (((db - MIN_DB) / (MAX_DB - MIN_DB)) * MAX_CLIPPING));
-            Log.d(LOGTAG, "===> db:      " + db);
-            Log.d(LOGTAG, "===> level    " + level);
+            Log.d(LOGTAG, "onMicActivity:  db = " + db + "  level = " + level);
             mCallback.onMicActivity(level);
         }
     }
-
 
     private void dispatch(Runnable runnable) {
         ((Activity) mContext).runOnUiThread(runnable);
@@ -113,7 +112,7 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
                     break;
                 case INTERIM_STT_RESULT:
                     if (mCallback != null) {
-                        Log.w(LOGTAG, "INTERIM_STT_RESULT " + (String) aPayload);
+                        Log.w(LOGTAG, "INTERIM_STT_RESULT " + aPayload);
                         mCallback.onPartialResult((String) aPayload);
                     }
                     break;
@@ -136,7 +135,7 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
                     break;
                 case CANCELED:
                     if (mCallback != null) {
-                        mCallback.onNoVoice();
+                        mCallback.onCanceled();
                     }
                     removeListener();
                     break;

--- a/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
@@ -32,6 +32,7 @@ public interface SpeechRecognizer {
         default void onPartialResult(String transcription) {};
         void onResult(String transcription, float confidence);
         void onNoVoice();
+        void onCanceled();
         void onError(@ErrorType int errorType, @Nullable String error);
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
@@ -41,4 +41,9 @@ public interface SpeechRecognizer {
     boolean shouldDisplayStoreDataPrompt();
     default boolean supportsASR(@NonNull Settings settings) {return true;}
     boolean isSpeechError(int code);
+    // FIXME https://github.com/Igalia/wolvic/issues/151
+    String[] getSupportedLanguagesNames();
+    int getIndexForLanguage(String language);
+    String getLanguageForIndex(int index);
+    String getNameForLanguage(String language);
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -218,7 +218,7 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
 
         @Override
         public void onError(@ErrorType int errorType, @Nullable String error) {
-            Log.d(LOGTAG, "===> ERROR: " + error);
+            Log.e(LOGTAG, "===> ERROR: " + error);
             setResultState(errorType);
             if (mDelegate != null) {
                 mDelegate.OnVoiceSearchError(errorType);
@@ -233,7 +233,7 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
             ActivityCompat.requestPermissions((Activity)getContext(), new String[]{Manifest.permission.RECORD_AUDIO},
                     VOICE_SEARCH_AUDIO_REQUEST_CODE);
         } else {
-            String locale = LocaleUtils.getVoiceSearchLanguageTag(getContext());
+            String locale = LocaleUtils.getVoiceSearchLanguageId(getContext());
             boolean storeData = SettingsStore.getInstance(getContext()).isSpeechDataCollectionEnabled();
             if (SessionStore.get().getActiveSession().isPrivateMode()) {
                 storeData = false;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -207,6 +207,13 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
         public void onNoVoice() {
             // Handle when the api didn't detect any voice
             Log.d(LOGTAG, "===> NO_VOICE");
+            mBinding.voiceSearchStart.setText(getContext().getString(R.string.voice_search_error));
+        }
+
+        @Override
+        public void onCanceled() {
+            // Handle when the voice recognition was canceled
+            Log.d(LOGTAG, "===> CANCELED");
         }
 
         @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
@@ -98,7 +98,7 @@ class LanguageOptionsView extends SettingsView {
     };
 
     private void setVoiceLanguage() {
-        mBinding.voiceSearchLanguageDescription.setText(getSpannedLanguageText(LocaleUtils.getVoiceSearchLanguage(getContext()).getDisplayName()),  TextView.BufferType.SPANNABLE);
+        mBinding.voiceSearchLanguageDescription.setText(getSpannedLanguageText(LocaleUtils.getVoiceSearchLanguageName(getContext())), TextView.BufferType.SPANNABLE);
     }
 
     private void setContentLanguage() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/VoiceSearchLanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/VoiceSearchLanguageOptionsView.java
@@ -12,8 +12,10 @@ import android.view.LayoutInflater;
 import androidx.databinding.DataBindingUtil;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserApplication;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.OptionsLanguageVoiceBinding;
+import com.igalia.wolvic.speech.SpeechRecognizer;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
@@ -32,11 +34,16 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
         updateUI();
     }
 
+    private SpeechRecognizer getSpeechRecognizer() {
+        return ((VRBrowserApplication) getContext().getApplicationContext()).getSpeechRecognizer();
+    }
+
     @Override
     protected void updateUI() {
         super.updateUI();
 
         LayoutInflater inflater = LayoutInflater.from(getContext());
+        SpeechRecognizer speechRecognizer = getSpeechRecognizer();
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_language_voice, this, true);
@@ -55,11 +62,11 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
         // Footer
         mBinding.footerLayout.setFooterButtonClickListener(mResetListener);
 
-        mBinding.languageRadio.setOptions(LocaleUtils.getSupportedLocalizedLanguages());
+        mBinding.languageRadio.setOptions(speechRecognizer.getSupportedLanguagesNames());
 
         String languageId = LocaleUtils.getVoiceSearchLanguageId(getContext());
         mBinding.languageRadio.setOnCheckedChangeListener(mLanguageListener);
-        setLanguage(LocaleUtils.getIndexForSupportedLanguageId(languageId), false);
+        setLanguage(speechRecognizer.getIndexForLanguage(languageId), false);
     }
 
     @Override
@@ -70,8 +77,9 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
     }
 
     private RadioGroupSetting.OnCheckedChangeListener mLanguageListener = (radioGroup, checkedId, doApply) -> {
+        SpeechRecognizer speechRecognizer = getSpeechRecognizer();
+        String languageId = speechRecognizer.getLanguageForIndex(mBinding.languageRadio.getCheckedRadioButtonId());
         String currentLanguageId = LocaleUtils.getVoiceSearchLanguageId(getContext());
-        String languageId = LocaleUtils.getSupportedLanguageIdForIndex(mBinding.languageRadio.getCheckedRadioButtonId());
 
         if (!languageId.equalsIgnoreCase(currentLanguageId)) {
             setLanguage(checkedId, true);
@@ -86,7 +94,8 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
         mBinding.languageRadio.setOnCheckedChangeListener(mLanguageListener);
 
         if (doApply) {
-            String languageId = LocaleUtils.getSupportedLanguageIdForIndex(checkedId);
+            SpeechRecognizer speechRecognizer = getSpeechRecognizer();
+            String languageId = speechRecognizer.getLanguageForIndex(checkedId);
             LocaleUtils.setVoiceSearchLanguageId(getContext(), languageId);
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
@@ -11,8 +11,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserApplication;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.speech.SpeechRecognizer;
 import com.igalia.wolvic.ui.adapters.Language;
 
 import java.util.ArrayList;
@@ -28,8 +30,8 @@ import java.util.stream.Stream;
 
 public class LocaleUtils {
 
-    private static final String DEFAULT_LANGUAGE_ID = "default";
-    private static final String FALLBACK_LANGUAGE_TAG = "en-US";
+    public static final String DEFAULT_LANGUAGE_ID = "default";
+    public static final String FALLBACK_LANGUAGE_TAG = "en-US";
 
     private static HashMap<String, Language> mLanguagesCache;
     private static Map<String, Language> mSupportedLanguagesCache;
@@ -201,24 +203,16 @@ public class LocaleUtils {
         return languageId;
     }
 
-    @NonNull
-    public static String getVoiceSearchLanguageTag(@NonNull Context aContext) {
-        String languageId = getVoiceSearchLanguageId(aContext);
-        Language language = mSupportedLanguagesCache.get(languageId);
-        if (language != null) {
-            return language.getLanguageTag();
+    public static String getVoiceSearchLanguageName(@NonNull Context aContext) {
+        VRBrowserApplication application = (VRBrowserApplication) aContext.getApplicationContext();
+        SpeechRecognizer speechRecognizer = application.getSpeechRecognizer();
+        String language = getVoiceSearchLanguageId(aContext);
+        String name = speechRecognizer.getNameForLanguage(language);
+        if (name != null) {
+            return name;
+        } else {
+            return speechRecognizer.getNameForLanguage(FALLBACK_LANGUAGE_TAG);
         }
-
-        return getClosestSupportedLanguageTag(languageId);
-    }
-
-    public static Language getVoiceSearchLanguage(@NonNull Context aContext) {
-        String languageId = getVoiceSearchLanguageId(aContext);
-        Language language = mSupportedLanguagesCache.get(languageId);
-        if (language == null) {
-            language = mSupportedLanguagesCache.get(FALLBACK_LANGUAGE_TAG);
-        }
-        return language;
     }
 
     public static void setVoiceSearchLanguageId(@NonNull Context context, @NonNull String languageId) {


### PR DESCRIPTION
This PR moves the responsibility of returning the list of supported languages to the adapter class for each voice recognition service (`MKSpeechRecognizer` and `HVRSpeechRecognizer`).

The Voice Search setting used to display the whole list of languages supported by Wolvic. However, many of those languages were not actually supported by the services that we use on each platform.

Additional changes to voice recognition:

- Add a callback method `onCanceled()` for when voice recognition is canceled. This corresponds to MeetKai's `CANCELED` state.


