### PR TITLE
Early register the external context for GeckoView

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -857,7 +857,6 @@ BrowserWorld::InitializeJava(JNIEnv* aEnv, jobject& aActivity, jobject& aAssetMa
   VRBrowser::InitializeJava(m.env, m.activity);
   GeckoSurfaceTexture::InitializeJava(m.env, m.activity);
   m.loader->InitializeJava(aEnv, aActivity, aAssetManager);
-  VRBrowser::RegisterExternalContext((jlong)m.externalVR->GetSharedData());
   VRBrowser::SetDeviceType(m.device->GetDeviceType());
 
   if (!m.modelsLoaded) {
@@ -1467,6 +1466,9 @@ BrowserWorld::Create() {
   result->m.self = result;
   result->m.surfaceObserver = std::make_shared<SurfaceObserver>(result->m.self);
   result->m.context->GetSurfaceTextureFactory()->AddGlobalObserver(result->m.surfaceObserver);
+  // This must be initialized before using Gecko. Gecko could fail to detect XR runtimes if
+  // we try to load some URL before setting the external context for example.
+  VRBrowser::RegisterExternalContext((jlong)result->m.externalVR->GetSharedData());
   return result;
 }
 


### PR DESCRIPTION
As mentioned in the docs
https://searchfox.org/mozilla-central/source/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoVRManager.java#13
the external context (ExternalVR) must be initialized before using Gecko. Among other things
Gecko could fail detecting XR runtimes if we try to load some URL before setting
the external context, for example when quickly restoring a session at start.

Moved the registration to BrowserWorld creation so that we don't depend on
specific implementations of the native libs.