### PR TITLE
Wait for media full screen availability before entering video VR mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -39,6 +39,7 @@ import com.igalia.wolvic.audio.AudioEngine;
 import com.igalia.wolvic.browser.Media;
 import com.igalia.wolvic.browser.SessionChangeListener;
 import com.igalia.wolvic.browser.SettingsStore;
+import com.igalia.wolvic.browser.api.WMediaSession;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.api.WSessionSettings;
 import com.igalia.wolvic.browser.content.TrackingProtectionStore;
@@ -598,7 +599,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             mAutoSelectedProjection = VideoProjectionMenuWidget.getAutomaticProjection(getSession().getCurrentUri(), autoEnter);
             if (mAutoSelectedProjection != VIDEO_PROJECTION_NONE && autoEnter.get()) {
                 mViewModel.setAutoEnteredVRVideo(true);
-                postDelayed(() -> enterVRVideo(mAutoSelectedProjection), 300);
+                enterVRVideo(mAutoSelectedProjection);
             } else {
                 mViewModel.setAutoEnteredVRVideo(false);
                 if (mProjectionMenu != null) {
@@ -778,28 +779,31 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mWidgetManager.updateWidget(mAttachedWindow);
     }
 
-    private void enterVRVideo(@VideoProjectionMenuWidget.VideoProjectionFlags int aProjection) {
-        if (mViewModel.getIsInVRVideo().getValue().get()) {
-            return;
-        }
+    private void enterVRVideoInternal(@VideoProjectionMenuWidget.VideoProjectionFlags int aProjection) {
+        assert mFullScreenMedia != null;
+
         mViewModel.setIsInVRVideo(true);
         mWidgetManager.pushBackHandler(mVRVideoBackHandler);
         mProjectionMenu.setSelectedProjection(aProjection);
         // Backup the placement because the same widget is reused in FullScreen & MediaControl menus
         mProjectionMenuPlacement.copyFrom(mProjectionMenu.getPlacement());
 
-        mFullScreenMedia = getSession().getFullScreenVideo();
-
         this.setVisible(false);
-        if (mFullScreenMedia != null && mFullScreenMedia.getWidth() > 0 && mFullScreenMedia.getHeight() > 0) {
-            final boolean resetBorder = aProjection == VideoProjectionMenuWidget.VIDEO_PROJECTION_360 ||
-                    aProjection == VideoProjectionMenuWidget.VIDEO_PROJECTION_360_STEREO;
-            mAttachedWindow.enableVRVideoMode((int)mFullScreenMedia.getWidth(), (int)mFullScreenMedia.getHeight(), resetBorder);
-            // Handle video resize while in VR video playback
-            mFullScreenMedia.setResizeDelegate((width, height) -> {
-                mAttachedWindow.enableVRVideoMode(width, height, resetBorder);
-            });
+        final boolean resetBorder = aProjection == VideoProjectionMenuWidget.VIDEO_PROJECTION_360 ||
+                aProjection == VideoProjectionMenuWidget.VIDEO_PROJECTION_360_STEREO;
+        int mediaWidth = (int) mFullScreenMedia.getWidth();
+        int mediaHeight = (int) mFullScreenMedia.getHeight();
+        if (mediaWidth == 0 || mediaHeight == 0) {
+            Log.i(LOGTAG, "Unavailable media width/height. Defaulting to window sizes");
+            mediaWidth = mAttachedWindow.getWidth();
+            mediaHeight = mAttachedWindow.getHeight();
         }
+        mAttachedWindow.enableVRVideoMode(mediaWidth, mediaHeight, resetBorder);
+        // Handle video resize while in VR video playback
+        mFullScreenMedia.setResizeDelegate((width, height) -> {
+            mAttachedWindow.enableVRVideoMode(width, height, resetBorder);
+        });
+
         mAttachedWindow.setVisible(false);
 
         closeFloatingMenus();
@@ -821,6 +825,35 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mMediaControlsWidget.setProjectionSelectorEnabled(true);
         mWidgetManager.updateWidget(mMediaControlsWidget);
         mWidgetManager.showVRVideo(mAttachedWindow.getHandle(), aProjection);
+
+    }
+
+    private void enterVRVideo(@VideoProjectionMenuWidget.VideoProjectionFlags int aProjection) {
+        if (mViewModel.getIsInVRVideo().getValue().get()) {
+            return;
+        }
+
+        mFullScreenMedia = getSession().getFullScreenVideo();
+        if (mFullScreenMedia != null && mFullScreenMedia.getWidth() > 0 && mFullScreenMedia.getHeight() > 0) {
+            enterVRVideoInternal(aProjection);
+            return;
+        }
+
+        Log.d(LOGTAG, "enterVRVideo: NOT enough data -> WAITING");
+        mAttachedWindow.addWindowListener(new WindowWidget.WindowListener() {
+            @Override
+            public void onMediaFullScreen(@NonNull WMediaSession mediaSession, boolean aFullScreen) {
+                WindowWidget.WindowListener.super.onMediaFullScreen(mediaSession, aFullScreen);
+                mAttachedWindow.removeWindowListener(this);
+                if (!aFullScreen) {
+                    Log.i(LOGTAG, "enterVRVideo: got exit fullscreen while waiting for media fullscreen.");
+                    return;
+                }
+
+                mFullScreenMedia = getSession().getFullScreenVideo();
+                enterVRVideoInternal(aProjection);
+            }
+        });
     }
 
     private void exitVRVideo() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -146,6 +146,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         default void onBorderChanged(@NonNull WindowWidget aWindow) {}
         default void onSessionChanged(@NonNull Session aOldSession, @NonNull Session aSession) {}
         default void onFullScreen(@NonNull WindowWidget aWindow, boolean aFullScreen) {}
+        default void onMediaFullScreen(@NonNull final WMediaSession mediaSession, boolean aFullScreen) {}
         default void onVideoAvailabilityChanged(@NonNull WindowWidget aWindow) {}
     }
 
@@ -1732,6 +1733,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
        public void onStop(@NonNull @NotNull WSession session, @NonNull @NotNull WMediaSession mediaSession) {
            mViewModel.setIsMediaAvailable(true);
            mViewModel.setIsMediaPlaying(false);
+       }
+
+       @Override
+       public void onFullscreen(@NonNull final WSession session, @NonNull final WMediaSession mediaSession, final boolean enabled, @Nullable final WMediaSession.ElementMetadata meta) {
+           for (WindowListener listener: mListeners)
+               listener.onMediaFullScreen(mediaSession, enabled);
        }
     };
 


### PR DESCRIPTION
This fixes an issue which happened whenever the YouTube fullscreen button was clicked
before the video was available. The outcome was a fullscreen black window with no video
and no audio.

The problem was the following. NavigationBarWidget was receiving the onFullScreen() event
from the content delegate (not from the media delegate). That method was calling
enterVRVideo() using a delay (perhaps an older hacky attempt to "fix" this issue). Then
enterVRVideo() tried to get the fullscreen video by calling getSession().getFullScreenVideo().
However the fact that we get onFullScreen() from the content delegate does not imply that
the media element is in fullscreen yet. Actually in many cases it was not. The consequence was
that a later call to WindowWidget::setVisible(false) was making the Session to be marked
as inactive because mIsInVRVideoMode was false as enableVRVideoMode() had not been called yet
(because there was no getSession().getFullScreenVideo()). A inactive session is basically a
non visible session with almost no associated resources, that's why audio and video stopped.

The solution is to change enterVRVideo() so that we wait for the onFullScreen event
*from the Media object* in case getSession().getFullScreenVideo() returns null. By waiting
for the Media:onFullScreen event we can ensure that there is a valid fullscreen video.

Note that this solution is not perfect because there are some corner cases that do not work
perfectly from the UI POV. For example, sometimes we get the Media::onFullScreen event
with zero width&height from the video. Zero means unknown for Gecko. In those cases we just
use the size of the window. This might cause the video to be played with a low resolution.
Another non ideal outcome is that sometimes we never get the Media::onFullScreen event from
Gecko so video is played in a "big screen" instead of in fully immersive environment.