### PR TITLE
Bring back controllers

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -116,13 +116,10 @@ struct DeviceDelegateOculusVR::State {
     float fovX = vrapi_GetSystemPropertyFloat(&java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_X);
     float fovY = vrapi_GetSystemPropertyFloat(&java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_Y);
 
-    ovrMatrix4f fov = ovrMatrix4f_CreateProjectionFov(fovX, fovY, 0.0, 0.0, near, far);
-    auto fovMatrix = vrb::Matrix::FromRowMajor(fov.M);
+    ovrMatrix4f projection = ovrMatrix4f_CreateProjectionFov(fovX, fovY, 0.0, 0.0, near, far);
+    auto matrix = vrb::Matrix::FromRowMajor(projection.M);
     for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {
-      ovrMatrix4f projection = predictedTracking.Eye[i].ProjectionMatrix;
-      auto projectionMatrix = vrb::Matrix::FromRowMajor(projection.M);
-      auto perspectiveMatrix = projectionMatrix.PostMultiply(fovMatrix);
-      cameras[i]->SetPerspective(perspectiveMatrix);
+      cameras[i]->SetPerspective(matrix);
     }
 
     if (immersiveDisplay) {
@@ -1034,8 +1031,6 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
     }
     m.immersiveDisplay->SetCapabilityFlags(caps);
   }
-
-  m.UpdatePerspective();
 
   int lastReorientCount = m.reorientCount;
   m.UpdateControllers(head);

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -111,6 +111,7 @@ struct DeviceDelegateOculusVR::State {
   vrb::Matrix reorientMatrix = vrb::Matrix::Identity();
   device::CPULevel minCPULevel = device::CPULevel::Normal;
   device::DeviceType deviceType = device::UnknownType;
+  float ipd = 0.0f;
 
   void UpdatePerspective() {
     float fovX = vrapi_GetSystemPropertyFloat(&java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_X);
@@ -1030,6 +1031,13 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
       caps |= device::PositionEmulated;
     }
     m.immersiveDisplay->SetCapabilityFlags(caps);
+  }
+
+  // Changes in IPD might cause distortions in WebXR when rotating the headset unless we update
+  // the perspective projection.
+  if (ipd != m.ipd) {
+    m.ipd = ipd;
+    m.UpdatePerspective();
   }
 
   int lastReorientCount = m.reorientCount;


### PR DESCRIPTION
This is a partial revert of 6c8a61c103ffd832d77e943649702d4ff4a1f207. In order to
fix the distortions it's enough with updating the perspective matrix whenever the
ipd changes.

From now on we no longer call UpdatePerspective() on every call, and instead,
we just do it whenever the ipd changes.