### PR TITLE
Decouple SpeechRecognizer from the UI code

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
@@ -8,7 +8,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.BuildConfig;
-import com.igalia.wolvic.R;
 import com.igalia.wolvic.ui.widgets.dialogs.VoiceSearchWidget;
 import com.igalia.wolvic.utils.LocaleUtils;
 import com.igalia.wolvic.utils.StringUtils;
@@ -17,7 +16,6 @@ import com.meetkai.speechlibrary.ISpeechRecognitionListener;
 import com.meetkai.speechlibrary.MKSpeechService;
 import com.meetkai.speechlibrary.STTResult;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -41,21 +39,10 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
             "en-US", "zh-CN", "ja-JP", "fr-FR", "de-DE", "es-ES", "ru-RU", "ko-KR",
             "it-IT", "pl-PL", "sv-SE", "fi-FI", "ar-SA", "id-ID", "th-TH", "he-IL");
 
-    private static final List<String> mSupportedLanguagesNames = new ArrayList<>();
-
     private static final String DEBUG_API_KEY = "WOLVIC_DEBUG";
 
     public MKSpeechRecognizer(Context context) {
         mContext = context;
-
-        for (String language : mSupportedLanguages) {
-            if (language.equals(LocaleUtils.DEFAULT_LANGUAGE_ID)) {
-                mSupportedLanguagesNames.add(mContext.getString(R.string.settings_language_follow_device));
-            } else {
-                Locale locale = Locale.forLanguageTag(language);
-                mSupportedLanguagesNames.add(StringUtils.capitalize(locale.getDisplayLanguage(locale)));
-            }
-        }
     }
 
     @Override
@@ -102,28 +89,8 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
     }
 
     @Override
-    public String[] getSupportedLanguagesNames() {
-        return mSupportedLanguagesNames.toArray(new String[0]);
-    }
-
-    @Override
-    public int getIndexForLanguage(String language) {
-        return mSupportedLanguages.indexOf(language);
-    }
-
-    @Override
-    public String getLanguageForIndex(int index) {
-        return mSupportedLanguages.get(index);
-    }
-
-    @Override
-    public String getNameForLanguage(String language) {
-        int index = getIndexForLanguage(language);
-        if (index < 0) {
-            return null;
-        } else {
-            return mSupportedLanguagesNames.get(index);
-        }
+    public List<String> getSupportedLanguages() {
+        return mSupportedLanguages;
     }
 
     // SpeechResultCallback

--- a/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/SpeechRecognizer.java
@@ -6,6 +6,7 @@ import androidx.annotation.Nullable;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.List;
 
 public interface SpeechRecognizer {
     class Settings {
@@ -41,9 +42,5 @@ public interface SpeechRecognizer {
     boolean shouldDisplayStoreDataPrompt();
     default boolean supportsASR(@NonNull Settings settings) {return true;}
     boolean isSpeechError(int code);
-    // FIXME https://github.com/Igalia/wolvic/issues/151
-    String[] getSupportedLanguagesNames();
-    int getIndexForLanguage(String language);
-    String getLanguageForIndex(int index);
-    String getNameForLanguage(String language);
+    List<String> getSupportedLanguages();
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
@@ -98,7 +98,10 @@ class LanguageOptionsView extends SettingsView {
     };
 
     private void setVoiceLanguage() {
-        mBinding.voiceSearchLanguageDescription.setText(getSpannedLanguageText(LocaleUtils.getVoiceSearchLanguageName(getContext())), TextView.BufferType.SPANNABLE);
+        String language = LocaleUtils.getVoiceSearchLanguageId(getContext());
+        mBinding.voiceSearchLanguageDescription.setText(
+                getSpannedLanguageText(LocaleUtils.getVoiceLanguageName(getContext(), language)),
+                TextView.BufferType.SPANNABLE);
     }
 
     private void setContentLanguage() {

--- a/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
@@ -11,10 +11,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.R;
-import com.igalia.wolvic.VRBrowserApplication;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.engine.SessionStore;
-import com.igalia.wolvic.speech.SpeechRecognizer;
 import com.igalia.wolvic.ui.adapters.Language;
 
 import java.util.ArrayList;
@@ -203,15 +201,12 @@ public class LocaleUtils {
         return languageId;
     }
 
-    public static String getVoiceSearchLanguageName(@NonNull Context aContext) {
-        VRBrowserApplication application = (VRBrowserApplication) aContext.getApplicationContext();
-        SpeechRecognizer speechRecognizer = application.getSpeechRecognizer();
-        String language = getVoiceSearchLanguageId(aContext);
-        String name = speechRecognizer.getNameForLanguage(language);
-        if (name != null) {
-            return name;
+    public static String getVoiceLanguageName(@NonNull Context aContext, @NonNull String language) {
+        if (language.equals(LocaleUtils.DEFAULT_LANGUAGE_ID)) {
+            return aContext.getString(R.string.settings_language_follow_device);
         } else {
-            return speechRecognizer.getNameForLanguage(FALLBACK_LANGUAGE_TAG);
+            Locale locale = Locale.forLanguageTag(language);
+            return StringUtils.capitalize(locale.getDisplayLanguage(locale));
         }
     }
 

--- a/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
+++ b/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
@@ -13,13 +13,11 @@ import com.huawei.hms.mlsdk.asr.MLAsrListener;
 import com.huawei.hms.mlsdk.asr.MLAsrRecognizer;
 import com.igalia.wolvic.speech.SpeechRecognizer;
 import com.igalia.wolvic.utils.LocaleUtils;
-import com.igalia.wolvic.utils.StringUtils;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
     private Context mContext;
@@ -33,7 +31,6 @@ public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
     private static final List<String> DEFAULT_SUPPORTED_LANGUAGES = Collections.singletonList(MLAsrConstants.LAN_EN_US);
     // The first element in these two lists corresponds to "Follow device language"
     private final List<String> mSupportedLanguages = new ArrayList<>();
-    private final List<String> mSupportedLanguagesNames = new ArrayList<>();
 
     public HVRSpeechRecognizer(Context context) {
         mContext = context;
@@ -57,13 +54,6 @@ public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
         mSupportedLanguages.clear();
         mSupportedLanguages.add(LocaleUtils.DEFAULT_LANGUAGE_ID);
         mSupportedLanguages.addAll(supportedLanguages);
-
-        mSupportedLanguagesNames.clear();
-        mSupportedLanguagesNames.add(mContext.getString(R.string.settings_language_follow_device));
-        for (String language : supportedLanguages) {
-            Locale locale = new Locale(language);
-            mSupportedLanguagesNames.add(StringUtils.capitalize(locale.getDisplayLanguage(locale)));
-        }
     }
 
     @Override
@@ -108,28 +98,8 @@ public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
     }
 
     @Override
-    public String[] getSupportedLanguagesNames() {
-        return mSupportedLanguagesNames.toArray(new String[0]);
-    }
-
-    @Override
-    public int getIndexForLanguage(String language) {
-        return mSupportedLanguages.indexOf(language);
-    }
-
-    @Override
-    public String getLanguageForIndex(int index) {
-        return mSupportedLanguages.get(index);
-    }
-
-    @Override
-    public String getNameForLanguage(String language) {
-        int index = getIndexForLanguage(language);
-        if (index < 0) {
-            return null;
-        } else {
-            return mSupportedLanguagesNames.get(index);
-        }
+    public List<String> getSupportedLanguages() {
+        return mSupportedLanguages;
     }
 
     private void dispatch(Runnable runnable) {


### PR DESCRIPTION
Remove a few methods in the `SpeechRecognizer` interface that were only needed because of the UI code.

Now that functionality happens at a higher level, in `LocaleUtils` and the options UI classes.

Fixes https://github.com/Igalia/wolvic/issues/151