### PR TITLE
HVR: improve android activity lifecycle handling

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -815,7 +815,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             return;
         }
         if (!mWindows.handleBack()) {
-            if (DeviceType.isPicoVR() || DeviceType.isHVRBuild()) {
+            if (DeviceType.isPicoVR()) {
                 mWindows.getFocusedWindow().showConfirmPrompt(
                         getString(R.string.app_name),
                         getString(R.string.exit_confirm_dialog_body, getString(R.string.app_name)),

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -173,6 +173,15 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
         queueRunnable(this::nativeOnSurfaceDestroyed);
     }
 
+    @Override
+    public void onBackPressed() {
+        // HVR SDK does a pretty bad job handling presses on the Menu button of the R controller.
+        // Instead of letting applications handle their own termination it just kills the activities.
+        // That's why we need to handle this event to let the render thread know that it should stop
+        // because the activity is about to be destroyed (we cannot rely on things like onDestroy().
+        queueRunnable(this::onBackPressedNative);
+    }
+
     protected boolean platformExit() {
         return false;
     }
@@ -183,6 +192,7 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
     protected native void nativeOnResume();
     protected native void nativeOnSurfaceChanged(Surface surface);
     protected native void nativeOnSurfaceDestroyed();
+    protected native void onBackPressedNative();
 }
 
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -57,6 +57,7 @@ public:
   VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;
   // Custom methods for NativeActivity render loop based devices.
+  void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);
   void LeaveVR();
   void OnDestroy();


### PR DESCRIPTION
Wolvic used to exit whenever we got a onSurfaceDestroyed() event. That
does indeed happen when the activity is destroyed, but it does also
happen in situations in which we don't want to exit Wolvic but just
put it "in background". Examples of those are the system showing a
confirmation dialog (for example a permission request dialog) or when
the user moves out of the security zone.

From now on, whenever the onSurfaceDestroyed event is received, we
just invoke xrRequestExitSession() so the XR session transitions to
STOPPED and EXITING states. The render loop is not exited but throttled,
meaning that instead of render anything it just activelly waits for
new events.

Later on, if the session is resumed (for example when the user
re-enters the security zone, or by closing a system permission dialog)
we just have to invoke xrBeginSession() to get the OpenXR machinery
working.

The problem is that when the user clicks on the menu button of the R
controller (in order to exit the application) we basically get the same
sequence of activity calls (onPause, onSurfaceDestroyed, onStop). So we
should come up with some way of differentiate the cases of exiting the
application and stopping the render loop for a while.

The HVR SDK does a pretty bad job in those situations. Instead of letting
the activities handle their termination, it basically just abruptly
terminate them and go back to the system environment. That's why we
had to add an extra JNI method to inform the native-lib that the
application is going to be destroyed. The native-lib then will use
that information in the next render loop cycle to terminate the render
thread and free all the allocated graphic resources.