### PR TITLE
Let the user pick the speech recognition service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,15 @@ def getHVRMLApiKey = { ->
     return ""
 }
 
+def getHVRMLSpeechServices = { ->
+    if (getHVRMLApiKey().isEmpty()) {
+        return "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
+    } else {
+        return "{ com.igalia.wolvic.speech.SpeechServices.HUAWEI_ASR, " +
+                "com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
+    }
+}
+
 def getMKApiKey = { ->
     if (gradle.hasProperty("userProperties.MK_API_KEY")) {
         return gradle."userProperties.MK_API_KEY"
@@ -97,6 +106,7 @@ android {
         buildConfigField "int", "MSAA_LEVEL", "1"
         buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "false"
         buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "false"
+        buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
@@ -255,6 +265,7 @@ android {
             buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
             buildConfigField "int", "MSAA_LEVEL", "0"
+            buildConfigField "String[]", "SPEECH_SERVICES", "${getHVRMLSpeechServices()}"
         }
 
         hvr3dof {
@@ -269,6 +280,7 @@ android {
             buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
             buildConfigField "int", "MSAA_LEVEL", "0"
+            buildConfigField "String[]", "SPEECH_SERVICES", "${getHVRMLSpeechServices()}"
         }
 
         cn {

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -12,6 +12,7 @@ import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -27,6 +28,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Process;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Pair;
 import android.view.KeyEvent;
@@ -59,6 +61,8 @@ import com.igalia.wolvic.crashreporting.GlobalExceptionHandler;
 import com.igalia.wolvic.geolocation.GeolocationWrapper;
 import com.igalia.wolvic.input.MotionEventGenerator;
 import com.igalia.wolvic.search.SearchEngineWrapper;
+import com.igalia.wolvic.speech.SpeechRecognizer;
+import com.igalia.wolvic.speech.SpeechServices;
 import com.igalia.wolvic.telemetry.TelemetryService;
 import com.igalia.wolvic.ui.OffscreenDisplay;
 import com.igalia.wolvic.ui.adapters.Language;
@@ -99,7 +103,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
-public class VRBrowserActivity extends PlatformActivity implements WidgetManagerDelegate, ComponentCallbacks2, LifecycleOwner, ViewModelStoreOwner {
+public class VRBrowserActivity extends PlatformActivity implements WidgetManagerDelegate,
+        ComponentCallbacks2, LifecycleOwner, ViewModelStoreOwner, SharedPreferences.OnSharedPreferenceChangeListener {
 
     private BroadcastReceiver mCrashReceiver = new BroadcastReceiver() {
         @Override
@@ -186,6 +191,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private Pair<Object, Float> mCurrentBrightness;
     private SearchEngineWrapper mSearchEngineWrapper;
     private SettingsStore mSettings;
+    private SharedPreferences mPrefs;
     private boolean mConnectionAvailable = true;
     private AudioManager mAudioManager;
     private Widget mActiveDialog;
@@ -291,6 +297,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         mSettings = SettingsStore.getInstance(this);
         mSettings.initModel(this);
+
+        mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+        mPrefs.registerOnSharedPreferenceChangeListener(this);
 
         queueRunnable(() -> {
             createOffscreenDisplay();
@@ -592,6 +601,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         getServicesProvider().getConnectivityReceiver().removeListener(mConnectivityDelegate);
 
+        mPrefs.unregisterOnSharedPreferenceChangeListener(this);
+
         super.onDestroy();
         mLifeCycle.setCurrentState(Lifecycle.State.DESTROYED);
         mViewModelStore.clear();
@@ -628,6 +639,19 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         SendTabDialogWidget.getInstance(this).onConfigurationChanged(newConfig);
 
         super.onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        try {
+            if (key.equals(getString(R.string.settings_key_voice_search_service))) {
+                SpeechRecognizer speechRecognizer =
+                        SpeechServices.getInstance(this, SettingsStore.getInstance(this).getVoiceSearchService());
+                ((VRBrowserApplication) getApplication()).setSpeechRecognizer(speechRecognizer);
+            }
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+        }
     }
 
     void loadFromIntent(final Intent intent) {

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
@@ -8,7 +8,6 @@ package com.igalia.wolvic;
 import android.app.Application;
 import android.content.Context;
 import android.content.res.Configuration;
-import android.os.Looper;
 
 import androidx.annotation.NonNull;
 
@@ -17,12 +16,13 @@ import com.igalia.wolvic.browser.Addons;
 import com.igalia.wolvic.browser.LoginStorage;
 import com.igalia.wolvic.browser.Places;
 import com.igalia.wolvic.browser.Services;
+import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.db.AppDatabase;
 import com.igalia.wolvic.db.DataRepository;
 import com.igalia.wolvic.downloads.DownloadsManager;
-import com.igalia.wolvic.speech.MKSpeechRecognizer;
 import com.igalia.wolvic.speech.SpeechRecognizer;
+import com.igalia.wolvic.speech.SpeechServices;
 import com.igalia.wolvic.telemetry.TelemetryService;
 import com.igalia.wolvic.ui.adapters.Language;
 import com.igalia.wolvic.ui.widgets.AppServicesProvider;
@@ -30,7 +30,6 @@ import com.igalia.wolvic.utils.BitmapCache;
 import com.igalia.wolvic.utils.ConnectivityReceiver;
 import com.igalia.wolvic.utils.EnvironmentsManager;
 import com.igalia.wolvic.utils.LocaleUtils;
-import com.igalia.wolvic.utils.SystemUtils;
 
 public class VRBrowserApplication extends Application implements AppServicesProvider {
 
@@ -62,11 +61,17 @@ public class VRBrowserApplication extends Application implements AppServicesProv
         mSessionStore.setLocales(LocaleUtils.getPreferredLanguageTags(activityContext));
         mDownloadsManager = new DownloadsManager(activityContext);
         mDownloadsManager.init();
-        mSpeechRecognizer = new MKSpeechRecognizer(activityContext);
         mBitmapCache = new BitmapCache(activityContext, mAppExecutors.diskIO(), mAppExecutors.mainThread());
         mEnvironmentsManager = new EnvironmentsManager(activityContext);
         mEnvironmentsManager.init();
         mAddons = new Addons(activityContext, mSessionStore);
+
+        try {
+            String speechService = SettingsStore.getInstance(activityContext).getVoiceSearchService();
+            setSpeechRecognizer(SpeechServices.getInstance(activityContext, speechService));
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+        }
     }
 
     protected void onActivityDestroy() {

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -22,6 +22,7 @@ import com.igalia.wolvic.VRBrowserApplication;
 import com.igalia.wolvic.browser.api.WContentBlocking;
 import com.igalia.wolvic.browser.api.WSessionSettings;
 import com.igalia.wolvic.browser.engine.EngineProvider;
+import com.igalia.wolvic.speech.SpeechServices;
 import com.igalia.wolvic.telemetry.TelemetryService;
 import com.igalia.wolvic.ui.viewmodel.SettingsViewModel;
 import com.igalia.wolvic.ui.widgets.menus.library.SortingContextMenuWidget;
@@ -470,6 +471,17 @@ public class SettingsStore {
     public void setAudioEnabled(boolean isEnabled) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putBoolean(mContext.getString(R.string.settings_key_audio), isEnabled);
+        editor.commit();
+    }
+
+    public String getVoiceSearchService() {
+        return mPrefs.getString(
+                mContext.getString(R.string.settings_key_voice_search_service), SpeechServices.DEFAULT);
+    }
+
+    public void setVoiceSearchService(String service) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putString(mContext.getString(R.string.settings_key_voice_search_service), service);
         editor.commit();
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
@@ -55,12 +55,8 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
             key = DEBUG_API_KEY;
         }
         if (settings.locale.equals(LocaleUtils.DEFAULT_LANGUAGE_ID)) {
-            final String defaultLanguage = Locale.getDefault().getLanguage();
-            if (mSupportedLanguages.stream().noneMatch(s -> s.startsWith(defaultLanguage))) {
-                settings.locale = defaultLanguage;
-            } else {
-                settings.locale = LocaleUtils.FALLBACK_LANGUAGE_TAG;
-            }
+            settings.locale = LocaleUtils.getClosestLanguageForLocale(
+                    Locale.getDefault(), mSupportedLanguages, LocaleUtils.FALLBACK_LANGUAGE_TAG);
         }
         if (!supportsASR(settings)) {
             callback.onError(Callback.ERROR_LANGUAGE_NOT_SUPPORTED, "language not supported");

--- a/app/src/common/shared/com/igalia/wolvic/speech/SpeechServices.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/SpeechServices.java
@@ -1,0 +1,54 @@
+package com.igalia.wolvic.speech;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringDef;
+
+import com.igalia.wolvic.BuildConfig;
+import com.igalia.wolvic.R;
+
+import java.lang.reflect.Constructor;
+
+public abstract class SpeechServices {
+    // Full names of the classes that implement the connection to each speech recognition service.
+    // These classes must implement the SpeechRecognizer interface and provide a constructor
+    // that takes a Context as its only parameter.
+    public static final String MEETKAI = "com.igalia.wolvic.speech.MKSpeechRecognizer";
+    public static final String HUAWEI_ASR = "com.igalia.wolvic.HVRSpeechRecognizer";
+
+    @StringDef(value = {MEETKAI, HUAWEI_ASR})
+    @interface Service {
+    }
+
+    public static final @Service
+    String DEFAULT = BuildConfig.SPEECH_SERVICES[0];
+
+    /**
+     * @param aContext
+     * @param service
+     * @return A new instance of the chosen speech recognition service.
+     * @throws ReflectiveOperationException
+     */
+    public static SpeechRecognizer getInstance(@NonNull Context aContext, @NonNull @Service String service)
+            throws ReflectiveOperationException {
+        Class<?> recognizerClass = Class.forName(service);
+        Constructor<?> constructor = recognizerClass.getConstructor(Context.class);
+        return (SpeechRecognizer) constructor.newInstance(new Object[]{aContext});
+    }
+
+    /**
+     * @param service
+     * @return the String resource ID corresponding to the service's display name
+     */
+    public static int getNameResource(@NonNull @Service String service) {
+        switch (service) {
+            case MEETKAI:
+                return R.string.voice_service_metkai;
+            case HUAWEI_ASR:
+                return R.string.voice_service_huawei_asr;
+            default:
+                return android.R.string.unknownName;
+        }
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ContentLanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ContentLanguageOptionsView.java
@@ -80,8 +80,8 @@ public class ContentLanguageOptionsView extends SettingsView {
 
     @Override
     public Point getDimensions() {
-        return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
-                WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
+        return new Point(WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
+                WidgetPlacement.dpDimension(getContext(), R.dimen.language_options_height));
     }
 
     private LanguageItemCallback mLanguageItemCallback = new LanguageItemCallback() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayLanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayLanguageOptionsView.java
@@ -96,8 +96,8 @@ class DisplayLanguageOptionsView extends SettingsView {
 
     @Override
     public Point getDimensions() {
-        return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
-                WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
+        return new Point(WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
+                WidgetPlacement.dpDimension(getContext(), R.dimen.language_options_height));
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
@@ -20,7 +20,9 @@ import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsLanguageBinding;
+import com.igalia.wolvic.speech.SpeechServices;
 import com.igalia.wolvic.ui.adapters.Language;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
@@ -69,9 +71,11 @@ class LanguageOptionsView extends SettingsView {
         // Set listeners
         mBinding.setContentClickListener(mContentListener);
         mBinding.setDisplayClickListener(mDisplayListener);
+        mBinding.setVoiceSearchServiceClickListener(mVoiceSearchServiceListener);
         mBinding.setVoiceSearchClickListener(mVoiceSearchListener);
 
         // Set descriptions
+        setVoiceService();
         setVoiceLanguage();
         setContentLanguage();
         setDisplayLanguage();
@@ -96,6 +100,13 @@ class LanguageOptionsView extends SettingsView {
         mDisplayLanguage.reset();
         mVoiceLanguage.reset();
     };
+
+    private void setVoiceService() {
+        String service = SettingsStore.getInstance(getContext()).getVoiceSearchService();
+        mBinding.voiceSearchServiceDescription.setText(
+                getSpannedLanguageText(getContext().getString(SpeechServices.getNameResource(service))),
+                TextView.BufferType.SPANNABLE);
+    }
 
     private void setVoiceLanguage() {
         String language = LocaleUtils.getVoiceSearchLanguageId(getContext());
@@ -140,6 +151,8 @@ class LanguageOptionsView extends SettingsView {
 
     private OnClickListener mContentListener = v -> mDelegate.showView(SettingViewType.LANGUAGE_CONTENT);
 
+    private OnClickListener mVoiceSearchServiceListener = v -> mDelegate.showView(SettingViewType.LANGUAGE_VOICE_SERVICE);
+
     private OnClickListener mVoiceSearchListener = v -> mDelegate.showView(SettingViewType.LANGUAGE_VOICE);
 
     private OnClickListener mDisplayListener = v -> mDelegate.showView(SettingViewType.LANGUAGE_DISPLAY);
@@ -148,18 +161,21 @@ class LanguageOptionsView extends SettingsView {
         if (key.equals(getContext().getString(R.string.settings_key_content_languages))) {
             setContentLanguage();
 
+        } else if (key.equals(getContext().getString(R.string.settings_key_voice_search_service))) {
+            setVoiceService();
+
         } else if (key.equals(getContext().getString(R.string.settings_key_voice_search_language))) {
             setVoiceLanguage();
 
-        } else if(key.equals(getContext().getString(R.string.settings_key_display_language))) {
+        } else if (key.equals(getContext().getString(R.string.settings_key_display_language))) {
             setDisplayLanguage();
         }
     };
 
     @Override
     public Point getDimensions() {
-        return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
-                WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
+        return new Point(WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
+                WidgetPlacement.dpDimension(getContext(), R.dimen.language_options_height));
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
@@ -21,6 +21,7 @@ public abstract class SettingsView extends FrameLayout {
         LANGUAGE,
         LANGUAGE_DISPLAY,
         LANGUAGE_CONTENT,
+        LANGUAGE_VOICE_SERVICE,
         LANGUAGE_VOICE,
         DISPLAY,
         PRIVACY,

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -411,6 +411,9 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             case LANGUAGE_CONTENT:
                 showView(new ContentLanguageOptionsView(getContext(), mWidgetManager));
                 break;
+            case LANGUAGE_VOICE_SERVICE:
+                showView(new VoiceSearchServiceOptionsView(getContext(), mWidgetManager));
+                break;
             case LANGUAGE_VOICE:
                 showView(new VoiceSearchLanguageOptionsView(getContext(), mWidgetManager));
                 break;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/VoiceSearchServiceOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/VoiceSearchServiceOptionsView.java
@@ -11,24 +11,27 @@ import android.view.LayoutInflater;
 
 import androidx.databinding.DataBindingUtil;
 
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.R;
-import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsLanguageVoiceBinding;
-import com.igalia.wolvic.speech.SpeechRecognizer;
+import com.igalia.wolvic.speech.SpeechServices;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 import com.igalia.wolvic.utils.LocaleUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
-class VoiceSearchLanguageOptionsView extends SettingsView {
+class VoiceSearchServiceOptionsView extends SettingsView {
 
     private OptionsLanguageVoiceBinding mBinding;
-    private List<String> mSupportedLanguages;
+    private final List<String> mSpeechServices = Arrays.asList(BuildConfig.SPEECH_SERVICES);
 
-    public VoiceSearchLanguageOptionsView(Context aContext, WidgetManagerDelegate aWidgetManager) {
+    public VoiceSearchServiceOptionsView(Context aContext, WidgetManagerDelegate aWidgetManager) {
         super(aContext, aWidgetManager);
         initialize(aContext);
     }
@@ -42,9 +45,6 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
         super.updateUI();
 
         LayoutInflater inflater = LayoutInflater.from(getContext());
-        SpeechRecognizer speechRecognizer = mWidgetManager.getServicesProvider().getSpeechRecognizer();
-
-        mSupportedLanguages = speechRecognizer.getSupportedLanguages();
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_language_voice, this, true);
@@ -55,51 +55,47 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
         mBinding.headerLayout.setBackClickListener(view -> {
             mDelegate.showView(SettingViewType.LANGUAGE);
         });
-        mBinding.headerLayout.setHelpClickListener(view -> {
-            SessionStore.get().getActiveSession().loadUri(getResources().getString(R.string.sumo_language_voice_url));
-            mDelegate.exitWholeSettings();
-        });
 
         // Footer
         mBinding.footerLayout.setFooterButtonClickListener(mResetListener);
 
-        List<String> languageNames = new ArrayList<>(mSupportedLanguages.size());
-        for (String language : mSupportedLanguages) {
-            languageNames.add(LocaleUtils.getVoiceLanguageName(getContext(), language));
+        List<String> speechServicesNames = new ArrayList<>();
+        for (String service : mSpeechServices) {
+            speechServicesNames.add(getContext().getString(SpeechServices.getNameResource(service)));
         }
-        mBinding.languageRadio.setOptions(languageNames.toArray(new String[0]));
+        mBinding.languageRadio.setOptions(speechServicesNames.toArray(new String[0]));
 
-        String languageId = LocaleUtils.getVoiceSearchLanguageId(getContext());
-        mBinding.languageRadio.setOnCheckedChangeListener(mLanguageListener);
-        setLanguage(mSupportedLanguages.indexOf(languageId), false);
+        String serviceId = SettingsStore.getInstance(getContext()).getVoiceSearchService();
+        mBinding.languageRadio.setOnCheckedChangeListener(mServiceListener);
+        setService(mSpeechServices.indexOf(serviceId), false);
     }
 
     @Override
     protected boolean reset() {
-        String defaultLanguageId = LocaleUtils.getDefaultLanguageId();
-        setLanguage(LocaleUtils.getIndexForSupportedLanguageId(defaultLanguageId), true);
+        setService(mSpeechServices.indexOf(SpeechServices.DEFAULT), true);
         return false;
     }
 
-    private RadioGroupSetting.OnCheckedChangeListener mLanguageListener = (radioGroup, checkedId, doApply) -> {
-        String languageId = mSupportedLanguages.get(mBinding.languageRadio.getCheckedRadioButtonId());
-        String currentLanguageId = LocaleUtils.getVoiceSearchLanguageId(getContext());
+    private RadioGroupSetting.OnCheckedChangeListener mServiceListener = (radioGroup, checkedId, doApply) -> {
+        String serviceId = mSpeechServices.get(mBinding.languageRadio.getCheckedRadioButtonId());
+        String currentServiceId = SettingsStore.getInstance(getContext()).getVoiceSearchService();
 
-        if (!languageId.equalsIgnoreCase(currentLanguageId)) {
-            setLanguage(checkedId, true);
+        if (!Objects.equals(serviceId, currentServiceId)) {
+            setService(checkedId, true);
         }
     };
 
     private OnClickListener mResetListener = (view) -> reset();
 
-    private void setLanguage(int checkedId, boolean doApply) {
+    private void setService(int checkedId, boolean doApply) {
         mBinding.languageRadio.setOnCheckedChangeListener(null);
         mBinding.languageRadio.setChecked(checkedId, doApply);
-        mBinding.languageRadio.setOnCheckedChangeListener(mLanguageListener);
+        mBinding.languageRadio.setOnCheckedChangeListener(mServiceListener);
 
         if (doApply) {
-            String languageId = mSupportedLanguages.get(checkedId);
-            LocaleUtils.setVoiceSearchLanguageId(getContext(), languageId);
+            SettingsStore.getInstance(getContext()).setVoiceSearchService(mSpeechServices.get(checkedId));
+            // Changing the speech service resets the language
+            LocaleUtils.setVoiceSearchLanguageId(getContext(), LocaleUtils.DEFAULT_LANGUAGE_ID);
         }
     }
 
@@ -113,5 +109,5 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
     protected SettingViewType getType() {
         return SettingViewType.LANGUAGE_VOICE;
     }
-    
+
 }

--- a/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
@@ -411,4 +411,23 @@ public class LocaleUtils {
         return FALLBACK_LANGUAGE_TAG;
     }
 
+    // Returns the closest language (among those supported) for the given locale, or the fallback.
+    public static String getClosestLanguageForLocale(Locale locale, List<String> supported, String fallback) {
+        final String defaultLanguageTag = locale.toLanguageTag();
+        if (supported.contains(defaultLanguageTag)) {
+            return defaultLanguageTag;
+        }
+
+        final String defaultLanguage = locale.getLanguage();
+        if (supported.contains(defaultLanguage)) {
+            return defaultLanguage;
+        }
+
+        Optional<String> closestLanguage = supported.stream().filter(s -> s.startsWith(defaultLanguage)).findFirst();
+        if (closestLanguage.isPresent()) {
+            return closestLanguage.get();
+        }
+
+        return fallback;
+    }
 }

--- a/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
+++ b/app/src/hvr/java/com/igalia/wolvic/HVRSpeechRecognizer.java
@@ -18,6 +18,7 @@ import com.igalia.wolvic.utils.SystemUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
     private Context mContext;
@@ -60,6 +61,10 @@ public class HVRSpeechRecognizer implements SpeechRecognizer, MLAsrListener {
     public void start(@NonNull Settings settings, @NonNull Callback callback) {
         if (mRecognizer != null) {
             stop();
+        }
+        if (settings.locale.equals(LocaleUtils.DEFAULT_LANGUAGE_ID)) {
+            settings.locale = LocaleUtils.getClosestLanguageForLocale(
+                    Locale.getDefault(), mSupportedLanguages, LocaleUtils.FALLBACK_LANGUAGE_TAG);
         }
         mCallback = callback;
         mRecognizer = MLAsrRecognizer.createAsrRecognizer(mContext);

--- a/app/src/main/res/layout/options_language.xml
+++ b/app/src/main/res/layout/options_language.xml
@@ -10,6 +10,10 @@
             type="android.view.View.OnClickListener" />
 
         <variable
+            name="voiceSearchServiceClickListener"
+            type="android.view.View.OnClickListener" />
+
+        <variable
             name="contentClickListener"
             type="android.view.View.OnClickListener" />
 
@@ -53,6 +57,24 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
+
+                <com.igalia.wolvic.ui.views.settings.ButtonSetting
+                    android:id="@+id/voiceSearchServiceButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:onClick="@{(view) -> voiceSearchServiceClickListener.onClick(view)}"
+                    app:buttonText="@string/settings_button_edit"
+                    app:description="@string/language_options_voice_search_service_title" />
+
+                <TextView
+                    android:id="@+id/voiceSearchServiceDescription"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:gravity="center_vertical"
+                    android:textColor="@color/rhino"
+                    android:textSize="@dimen/text_medium_size"
+                    tools:text="Description" />
 
                 <com.igalia.wolvic.ui.views.settings.ButtonSetting
                     android:id="@+id/voiceSearchLanguageButton"

--- a/app/src/main/res/layout/options_language_voice_service.xml
+++ b/app/src/main/res/layout/options_language_voice_service.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/optionsLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/dialog_background"
+        android:paddingStart="30dp"
+        android:paddingEnd="30dp">
+
+        <com.igalia.wolvic.ui.widgets.settings.SettingsHeader
+            android:id="@+id/header_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:description="@string/settings_language_choose_language_voice_search_service_description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@string/settings_language_choose_language_voice_search_service_title" />
+
+        <com.igalia.wolvic.ui.views.CustomScrollView
+            android:id="@+id/scrollbar"
+            style="@style/customScrollViewStyle"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginBottom="10dp"
+            android:paddingEnd="30dp"
+            app:layout_constraintBottom_toTopOf="@+id/footer_layout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/header_layout">
+
+            <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
+                android:id="@+id/languageRadio"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layout="@layout/setting_radio_group_v" />
+        </com.igalia.wolvic.ui.views.CustomScrollView>
+
+        <com.igalia.wolvic.ui.widgets.settings.SettingsFooter
+            android:id="@+id/footer_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:buttonText="@string/developer_options_reset_button"
+            app:description="@string/language_service_options_reset"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/scrollbar" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -240,6 +240,9 @@
     <!-- Display settings -->
     <dimen name="display_options_height">420dp</dimen>
 
+    <!-- Language and voice settings -->
+    <dimen name="language_options_height">380dp</dimen>
+
     <!-- JS Prompt dialogs -->
     <item name="js_prompt_y_distance" format="float" type="dimen">1.2</item>
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -26,6 +26,7 @@
     <string name="settings_key_scroll_direction" translatable="false">settings_scroll_direction</string>
     <string name="settings_key_msaa" translatable="false">settings_gfx_msaa_v3</string>
     <string name="settings_key_audio" translatable="false">settings_audio</string>
+    <string name="settings_key_voice_search_service" translatable="false">settings_voice_search_service</string>
     <string name="settings_key_voice_search_language" translatable="false">settings_voice_search_language</string>
     <string name="settings_key_display_language" translatable="false">settings_display_language</string>
     <string name="settings_key_content_languages" translatable="false">settings_content_languages</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,6 +233,18 @@
     <string name="settings_language_choose_language_display_description">Choose the language used to display menus, messages, and notifications.</string>
 
     <!-- This string is used to label a text label that appears in the header of 'Language Settings' ->
+         'Voice Search Service' dialog window (accessible from the browser's Settings dialog window).
+         Below this string appears a list of online services for the user to choose as their
+         preferred way to carry out voice recognition. -->
+    <string name="settings_language_choose_language_voice_search_service_title">Voice Search Service</string>
+
+    <!-- This string is used to label a text label that appears in the header description of 'Language Settings' ->
+         'Voice Search Service' dialog window (accessible from the browser's Settings dialog window).
+         Below this string appears a list of online services for the user to choose as their
+         preferred way to carry out voice recognition. -->
+    <string name="settings_language_choose_language_voice_search_service_description">Choose your preferred online service for voice search.</string>
+
+    <!-- This string is used to label a text label that appears in the header of 'Language Settings' ->
          'Voice Search Language' dialog window (accessible from the browser's Settings dialog window).
          Below this string appears a list of locales for the user to choose as their preferred voice search
          language. -->
@@ -1393,6 +1405,9 @@
     <!-- This string labels the Reset button that restores the default environment settings values. -->
     <string name="environment_options_reset">Reset Environment Settings</string>
 
+    <!-- This string labels the Reset button that restores the default voice search service settings values. -->
+    <string name="language_service_options_reset">Reset Voice Search Service Settings</string>
+
     <!-- This string labels the Reset button that restores the default voice search language settings values. -->
     <string name="language_options_reset">Reset Voice Search Language Settings</string>
 
@@ -1404,6 +1419,9 @@
 
     <!-- This string labels the Reset button that restores all language settings values. -->
     <string name="all_language_options_reset">Reset All Language Settings</string>
+
+    <!-- This string labels the description in the Voice Search Service button in the main language setting dialog. -->
+    <string name="language_options_voice_search_service_title">Voice Search Service</string>
 
     <!-- This string labels the description in the Voice Search Language button in the main language setting dialog. -->
     <string name="language_options_voice_search_language_title">Voice Search Language:</string>
@@ -2278,4 +2296,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
         This Privacy Policy is subject to Spanish law. The Privacy Policy language of this application is Spanish. For this reason, any possible divergence between the original version in Spanish and its translation into another language will be considered as predominant in the Spanish version that can be found here: https://wolvic.com/es/legal/privacy/ .
     </string>
 
+    <!-- Display names for the supported voice recognition services -->
+    <string name="voice_service_metkai">MeetKai</string>
+    <string name="voice_service_huawei_asr">Huawei Automatic Speech Recognition</string>
 </resources>


### PR DESCRIPTION
Add a new section in the Settings to select the desired speech recognition service.

The services available for a particular build are specified at compilation time and will be listed in `BuildConfig.SPEECH_SERVICES`. The one in the first position will be the default.

The class SpeechServices encapsulates the necessary information to identify and instantiate each service.

New strings:

- `settings_language_choose_language_voice_search_service_title`
- `settings_language_choose_language_voice_search_service_description`
- `language_service_options_reset`
- `language_options_voice_search_service_title`
- `voice_service_metkai`
- `voice_service_huawei_asr`