### PR TITLE
Update the list of languages Wolvic support

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
@@ -285,8 +285,6 @@ public class LocaleUtils {
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_english_us, locale)));
             locale = new Locale("en","GB");
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_english_uk, locale)));
-            locale = new Locale.Builder().setLanguage("zh").setScript("Hant").setRegion("TW").build();
-            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_traditional_chinese, locale)));
             locale = new Locale.Builder().setLanguage("zh").setScript("Hans").setRegion("CN").build();
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_simplified_chinese, locale)));
             locale = new Locale("ja","JP");
@@ -303,22 +301,12 @@ public class LocaleUtils {
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_russian, locale)));
             locale = new Locale("ko","KR");
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_korean, locale)));
-            locale = new Locale("it","IT");
-            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_italian, locale)));
             locale = new Locale("da","DK");
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_danish, locale)));
-            locale = new Locale("pl","PL");
-            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_polish, locale)));
-            locale = new Locale("nb","NO");
-            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_norwegian_bokmaal, locale)));
-            locale = new Locale("nn","NO");
-            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_norwegian_nynorsk, locale)));
-            locale = new Locale("sv","SE");
-            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_swedish, locale)));
             locale = new Locale("fi","FI");
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_finnish, locale)));
-            locale = new Locale("nl","NL");
-            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_dutch, locale)));
+            locale = new Locale("gl", "ES");
+            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_galician, locale)));
         }};
 
         Locale locale = getDeviceLocale();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,6 +305,12 @@
     <string name="settings_language_french">French</string>
 
     <!-- This string is used to label a radio button in the 'Settings' Voice Search and the Display Language dialogs that, when pressed,
+    changes the app and the language of the speech-recognition-based search to 'Galician'.
+    The string is also used in the keyboard space bar to show the current keyboard language and in
+    the keyboard languages panel list. -->
+    <string name="settings_language_galician">Galician</string>
+
+    <!-- This string is used to label a radio button in the 'Settings' Voice Search and the Display Language dialogs that, when pressed,
     changes the app and the language of the speech-recognition-based search to 'German'.
     The string is also used in the keyboard space bar to show the current keyboard language and in
     the keyboard languages panel list. -->


### PR DESCRIPTION
The new list is:

- Danish (da)
- English UK (en-GB)
- English US (en-US)
- European Spanish (es-ES)
- French (fr)
- Finnish (fi)
- Galician (es-GL)
- German (de)
- Japanese (ja)
- Korean (ko)
- Russian (ru)
- Simplified Chinese (zh-rCN)
- Spanish (es)
