### PR TITLE
Use multiple threads to compress textures

### DIFF
--- a/tools/compressor/gulpfile.js
+++ b/tools/compressor/gulpfile.js
@@ -3,6 +3,7 @@ const path = require('path');
 const gulp = require('gulp');
 const sharp = require('sharp');
 const tmp = require('tmp');
+const os = require('os');
 const execSync = require('child_process').execSync;
 const readdirp = require('readdirp');
 
@@ -40,7 +41,8 @@ function compressAsset(source, target, srgb, alpha, done) {
         } else {
             format = alpha  ? "RGBA8" : "RGB8"
         }
-        var out = execSync(`EtcTool ${source} -output ${target} -format ${format} -effort 100 -v`).toString();
+        var numberOfCPUs = os.cpus().length
+        var out = execSync(`EtcTool ${source} -output ${target} -format ${format} -effort 100 -j ${numberOfCPUs} -v`).toString();
         console.log(out);
         done();
     } catch (err) {


### PR DESCRIPTION
We use a software called EtcTool to generate compressed .ktx textures
from diverse bitmap files, for example from the cubemap that generates
the skybox. That tool has a parametter that allows you to specify the
number of threads to be used in the compression. By default it's 1.
Since it's a very expensive operation we should try to squeeze the
computer to use all the available CPUs.

For reference, in a 20 core machine, generating the texture for the
Meta Quest2 controller goes from 9.02s to 3.66s.