### PR TITLE
Crash when the selected language is removed from the list of supported languages

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayLanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayLanguageOptionsView.java
@@ -59,7 +59,13 @@ class DisplayLanguageOptionsView extends SettingsView {
 
         String languageId = LocaleUtils.getDisplayLanguageId(getContext());
         mBinding.languageRadio.setOnCheckedChangeListener(mLanguageListener);
-        setLanguage(LocaleUtils.getIndexForSupportedLanguageId(languageId), false);
+        try {
+            setLanguage(LocaleUtils.getIndexForSupportedLanguageId(languageId), false);
+        } catch (IllegalStateException e) {
+            // This is very unlikely and should only happen when the language selected in the
+            // settings is removed from the list of supported languages.
+            reset();
+        }
     }
 
     @Override


### PR DESCRIPTION
In the event of removing a language from the list of supported languages (unlikely)
Wolvic might crash with IllegalStateException being thrown because the index
for the language stored in Settings does no longer exist. This situation normally
should only happen while developing and testing code but it's better to be safe.
In the event of having this issue we can just reset to the default language.