### PR TITLE
Request WRITE_EXTERNAL_STORAGE from the Settings

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
@@ -90,7 +90,7 @@ class PrivacyOptionsView extends SettingsView {
         mPermissionButtons.add(Pair.create(findViewById(R.id.cameraPermissionSwitch), Manifest.permission.CAMERA));
         mPermissionButtons.add(Pair.create(findViewById(R.id.microphonePermissionSwitch), Manifest.permission.RECORD_AUDIO));
         mPermissionButtons.add(Pair.create(findViewById(R.id.locationPermissionSwitch), Manifest.permission.ACCESS_FINE_LOCATION));
-        mPermissionButtons.add(Pair.create(findViewById(R.id.storagePermissionSwitch), Manifest.permission.READ_EXTERNAL_STORAGE));
+        mPermissionButtons.add(Pair.create(findViewById(R.id.storagePermissionSwitch), Manifest.permission.WRITE_EXTERNAL_STORAGE));
 
         if (DeviceType.isOculusBuild() || DeviceType.isWaveBuild() || DeviceType.isPicoVR()) {
             findViewById(R.id.cameraPermissionSwitch).setVisibility(View.GONE);


### PR DESCRIPTION
The storage permission is needed for some functionality, for example taking screenshots in HVR.

When this happens, the user can grant the storage permission in the device's settings.

Alternatively, the user can change the "storage" switch in the "Privacy & Security" section of Wolvic's settings. This will show a system dialog to confirm the change.

These two methods are supposed to be equivalent, but they are not: the first one will grant the `WRITE_EXTERNAL_STORAGE` permission, but the second one will only request `READ_EXTERNAL_STORAGE`.

This PR requests the `WRITE_EXTERNAL_STORAGE` permission from Wolvic's settings.