### PR TITLE
Prevent a crash due to incompatible logins databases

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.launch
+import mozilla.appservices.logins.InvalidKeyException
 import mozilla.components.concept.storage.Login
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.sync.GlobalSyncableStoreProvider
@@ -22,7 +23,11 @@ class LoginStorage(
     init {
         EngineProvider.getOrCreateRuntime(context).setUpLoginPersistence(places.logins)
         GlobalScope.launch(Dispatchers.IO) {
-            places.logins.value.warmUp()
+            try {
+                storage.value.warmUp()
+            } catch (e: InvalidKeyException) {
+                storage.value.wipeLocal()
+            }
         }
 
         GlobalSyncableStoreProvider.configureStore(SyncEngine.Passwords to storage)

--- a/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
@@ -26,6 +26,10 @@ class LoginStorage(
             try {
                 storage.value.warmUp()
             } catch (e: InvalidKeyException) {
+                // Login database sometimes gets corrupted for unknown reasons. This has been reported
+                // to mozilla components in the past (https://github.com/mozilla-mobile/android-components/issues/6681
+                // or https://github.com/mozilla-mobile/fenix/issues/15597) but it was never really
+                // fixed so clients have to deal with that. The only thing we could do is to wipe.
                 storage.value.wipeLocal()
             }
         }


### PR DESCRIPTION
Users with old versions of Wolvic installed who are migrating to 1.0 are experiencing a crash due to incompatible Logins database. This service is provided by a Mozilla component which may have changed to use a different database format.

This patch serves as a temporary fix to avoid the crash, by clearing saved logins database if an incompatibility is found.