### PR TITLE
Revert "Use eye transform instead of translation in external_vr"

### DIFF
--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -39,7 +39,6 @@ public:
                               const double aTopDegrees,
                               const double aBottomDegrees) = 0;
   virtual void SetEyeOffset(const device::Eye aEye, const float aX, const float aY, const float aZ) = 0;
-  virtual void SetEyeTransform(const device::Eye aEye, const vrb::Matrix& aTransform) = 0;
   virtual void SetEyeResolution(const int32_t aWidth, const int32_t aHeight) = 0;
   virtual void SetNativeFramebufferScaleFactor(const float aScale) = 0;
   virtual void SetStageSize(const float aWidth, const float aDepth) = 0;

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -124,7 +124,7 @@ struct ExternalVR::State {
   mozilla::gfx::VRSystemState system = {};
   mozilla::gfx::VRBrowserState browser = {};
   // device::CapabilityFlags deviceCapabilities = 0;
-  vrb::Matrix eyeTransforms[device::EyeCount];
+  vrb::Vector eyeOffsets[device::EyeCount];
   uint64_t lastFrameId = 0;
   bool firstPresentingFrame = false;
   bool compositorEnabled = true;
@@ -325,16 +325,13 @@ ExternalVR::SetFieldOfView(const device::Eye aEye, const double aLeftDegrees,
 
 void
 ExternalVR::SetEyeOffset(const device::Eye aEye, const float aX, const float aY, const float aZ) {
-  SetEyeTransform(aEye, vrb::Matrix::Translation(vrb::Vector(aX, aY, aZ)));
-}
-
-void
-ExternalVR::SetEyeTransform(const device::Eye aEye, const vrb::Matrix& aTransform) {
   mozilla::gfx::VRDisplayState::Eye which = (aEye == device::Eye::Right
                                              ? mozilla::gfx::VRDisplayState::Eye_Right
                                              : mozilla::gfx::VRDisplayState::Eye_Left);
-  memcpy(&(m.system.displayState.eyeTransform[which]), aTransform.Data(), sizeof(m.system.displayState.eyeTransform[which]));
-  m.eyeTransforms[device::EyeIndex(aEye)] = aTransform;
+  m.system.displayState.eyeTranslation[which].x = aX;
+  m.system.displayState.eyeTranslation[which].y = aY;
+  m.system.displayState.eyeTranslation[which].z = aZ;
+  m.eyeOffsets[device::EyeIndex(aEye)].Set(aX, aY, aZ);
 }
 
 void
@@ -469,8 +466,8 @@ ExternalVR::PushFramePoses(const vrb::Matrix& aHeadTransform, const std::vector<
   m.system.sensorState.inputFrameID++;
   m.system.displayState.lastSubmittedFrameId = m.lastFrameId;
 
-  vrb::Matrix leftView = m.eyeTransforms[device::EyeIndex(device::Eye::Left)].Inverse().PostMultiply(inverseHeadTransform);
-  vrb::Matrix rightView = m.eyeTransforms[device::EyeIndex(device::Eye::Right)].Inverse().PostMultiply(inverseHeadTransform);
+  vrb::Matrix leftView = vrb::Matrix::Position(-m.eyeOffsets[device::EyeIndex(device::Eye::Left)]).PostMultiply(inverseHeadTransform);
+  vrb::Matrix rightView = vrb::Matrix::Position(-m.eyeOffsets[device::EyeIndex(device::Eye::Right)]).PostMultiply(inverseHeadTransform);
   memcpy(&(m.system.sensorState.leftViewMatrix), leftView.Data(),
          sizeof(m.system.sensorState.leftViewMatrix));
   memcpy(&(m.system.sensorState.rightViewMatrix), rightView.Data(),

--- a/app/src/main/cpp/ExternalVR.h
+++ b/app/src/main/cpp/ExternalVR.h
@@ -45,7 +45,6 @@ public:
                       const double aBottomDegrees) override;
   void SetEyeOffset(const device::Eye aEye, const float aX, const float aY, const float aZ) override;
   void SetEyeResolution(const int32_t aX, const int32_t aY) override;
-  void SetEyeTransform(const device::Eye aEye, const vrb::Matrix& aTransform) override;
   void SetNativeFramebufferScaleFactor(const float aScale) override;
   void SetStageSize(const float aWidth, const float aDepth) override;
   void SetSittingToStandingTransform(const vrb::Matrix& aTransform) override;

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -48,7 +48,7 @@ namespace gfx {
 // running at the same time? Or...what if we have multiple
 // release builds running on same machine? (Bug 1563232)
 #define SHMEM_VERSION "0.0.11"
-static const int32_t kVRExternalVersion = 19;
+static const int32_t kVRExternalVersion = 18;
 
 // We assign VR presentations to groups with a bitmask.
 // Currently, we will only display either content or chrome.
@@ -344,7 +344,7 @@ struct VRDisplayState {
   VRDisplayCapabilityFlags capabilityFlags;
   VRDisplayBlendMode blendMode;
   VRFieldOfView eyeFOV[VRDisplayState::NumEyes];
-  float eyeTransform[VRDisplayState::NumEyes][16];
+  Point3D_POD eyeTranslation[VRDisplayState::NumEyes];
   IntSize_POD eyeResolution;
   float nativeFramebufferScaleFactor;
   bool suppressFrames;

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -729,7 +729,7 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
     }
   }
 
-  // Query eyeTransform and perspective for each view
+  // Query eyeTransform ans perspective for each view
   XrViewState viewState{XR_TYPE_VIEW_STATE};
   uint32_t viewCapacityInput = (uint32_t) m.views.size();
   uint32_t viewCountOutput = 0;
@@ -744,10 +744,9 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
     for (int i = 0; i < m.views.size(); ++i) {
       const XrView &view = m.views[i];
       const device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
-      vrb::Matrix eyeTransform = XrPoseToMatrix(view.pose);
-      m.cameras[i]->SetEyeTransform(eyeTransform);
+      m.cameras[i]->SetEyeTransform(XrPoseToMatrix(view.pose));
       if (m.immersiveDisplay) {
-        m.immersiveDisplay->SetEyeTransform(eye, eyeTransform);
+        m.immersiveDisplay->SetEyeOffset(eye, view.pose.position.x, view.pose.position.y, view.pose.position.z);
       }
     }
   }


### PR DESCRIPTION
This reverts commit bb776dd67d1b4deff272d347ab1136f1c13a9747.

This was an attempt to fix some distortions we were seeing in some devices.
However it didn't make any difference in the end as the problem was in some
other place. In practice it was changing nothing so we could live with it
but the fact is that it's a barrier for new developers because it forces
devs to build our fork of Gecko to support WebXR sessions (as we were
bumping the version of the protocol used by GeckoView).