### PR TITLE
Add support for remembering location permission requests

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -479,7 +479,7 @@ public class SessionStore implements
 
     public void addPermissionException(@NonNull String uri, @SitePermission.Category int category) {
         if (mPermissionDelegate != null) {
-            mPermissionDelegate.addPermissionException(uri, category);
+            mPermissionDelegate.addPermissionException(uri, category, false);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/db/SitePermission.java
+++ b/app/src/common/shared/com/igalia/wolvic/db/SitePermission.java
@@ -8,13 +8,15 @@ import androidx.room.PrimaryKey;
 
 @Entity
 public class SitePermission {
-    @IntDef(value = { SITE_PERMISSION_POPUP, SITE_PERMISSION_WEBXR, SITE_PERMISSION_TRACKING, SITE_PERMISSION_DRM, SITE_PERMISSION_AUTOFILL})
+    @IntDef(value = { SITE_PERMISSION_NONE, SITE_PERMISSION_POPUP, SITE_PERMISSION_WEBXR, SITE_PERMISSION_TRACKING, SITE_PERMISSION_DRM, SITE_PERMISSION_AUTOFILL, SITE_PERMISSION_LOCATION})
     public @interface Category {}
+    public static final int SITE_PERMISSION_NONE = -1;
     public static final int SITE_PERMISSION_POPUP = 0;
     public static final int SITE_PERMISSION_WEBXR = 1;
     public static final int SITE_PERMISSION_TRACKING = 2;
     public static final int SITE_PERMISSION_DRM = 3;
     public static final int SITE_PERMISSION_AUTOFILL = 4;
+    public static final int SITE_PERMISSION_LOCATION = 5;
 
     public SitePermission(@NonNull String url, @NonNull String principal, @Category int category) {
         this.url = url;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PermissionWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PermissionWidget.java
@@ -53,7 +53,9 @@ public class PermissionWidget extends PromptDialogWidget {
                 handlePermissionResult(true);
             }
         });
-        setCheckboxVisible(false);
+        setCheckboxVisible(true);
+        setChecked(false);
+        setCheckboxText(R.string.permissions_dialog_remember_choice);
         setDescriptionVisible(false);
 
         if (isVisible()) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
@@ -267,6 +267,10 @@ public class PromptDialogWidget extends UIDialog {
         return mBinding.checkbox.isChecked();
     }
 
+    public void setChecked(boolean checked) {
+        mBinding.checkbox.setChecked(checked);
+    }
+
     public void setBodyGravity(int gravity) {
         mBinding.body.setGravity(gravity);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2305,4 +2305,9 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <!-- Display names for the supported voice recognition services -->
     <string name="voice_service_metkai">MeetKai</string>
     <string name="voice_service_huawei_asr">Huawei Automatic Speech Recognition</string>
+
+    <!-- This string labels a checkbox in the permissions dialog. When checked, the user will no longer
+     be prompted for that specific permission in that same web page. -->
+    <string name="permissions_dialog_remember_choice">Remember this decision</string>
+
 </resources>


### PR DESCRIPTION
Every time users visit a page which asks for location permissions a
prompt dialog is shown. This is suboptimal as it forces users to
accept/decline the offer every single time.

Most browsers out there include a checkbox in the permission dialog
offering users to remember their decision. We're basically adding
that functionality.

We're only storing location permissions. We considered adding
desktop notifications (as it should be straightforward from now on)
but we aren't doing it because we don't really support them (we don't
show desktop notifications at the moment).