### PR TITLE
Replace FxR references from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Restart Wolvic XR and close and re-open the WebIDE page.
 
 - When using the native debugger you can ignore the first SIGSEGV: address access protected stop in GV thread. It's not a crash; you can click *Resume* to continue debugging.
 - On some platforms such as Oculus Go the native debugger stops on each input event. You can set this LLDB post-attach command in Android Studio to fix the problem: `pro hand -p true -s false SIGILL`
-- You can use `adb shell am start -a android.intent.action.VIEW -d "https://aframe.io" org.mozilla.vrbrowser/org.mozilla.vrbrowser.VRBrowserActivity` to load a URL from the command line
-- You can use `adb shell am start -a android.intent.action.VIEW  -n org.mozilla.vrbrowser/org.mozilla.vrbrowser.VRBrowserActivity -e homepage "https://example.com"` to override the homepage
+- You can use `adb shell am start -a android.intent.action.VIEW -d "https://aframe.io" com.igalia.wolvic/com.igalia.wolvic.VRBrowserActivity` to load a URL from the command line
+- You can use `adb shell am start -a android.intent.action.VIEW  -n com.igalia.wolvic/com.igalia.wolvic.VRBrowserActivity -e homepage "https://example.com"` to override the homepage
 - You can use `adb shell setprop debug.oculus.enableVideoCapture 1` to record a video on the Oculus Go. Remember to run `adb shell setprop debug.oculus.enableVideoCapture 0` to stop recording the video.
     - You can also record videos on the Oculus Go by exiting to the system library, and from the Oculus tray menu (toggle with the Oculus button on the controller): **`Sharing > Record Video`**
 - You can set `disableCrashRestart=true` in the gradle `user.properties` to disable app relaunch on crash.


### PR DESCRIPTION
The README file (which is the github's frontage) had some leftovers
from Firefox Reality. There were a couple of references to FxR java
package names in the Debugging tips section. Replaced them by the
Wolvic package names.