### PR TITLE
Delete logins database file on DB corruption

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
@@ -29,8 +29,10 @@ class LoginStorage(
                 // Login database sometimes gets corrupted for unknown reasons. This has been reported
                 // to mozilla components in the past (https://github.com/mozilla-mobile/android-components/issues/6681
                 // or https://github.com/mozilla-mobile/fenix/issues/15597) but it was never really
-                // fixed so clients have to deal with that. The only thing we could do is to wipe.
-                storage.value.wipeLocal()
+                // fixed so clients have to deal with that. The only thing we could do is to delete
+                // the database file. We cannot just use wipe()/wipeLocal() because those calls also
+                // try to use the connection to the DB and thus they'll crash as well.
+                places.clearLoginsDatabaseUglyHack()
             }
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/Places.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/Places.kt
@@ -92,4 +92,15 @@ class Places(var context: Context) {
             logins.value.wipeLocal()
         }
     }
+
+    fun clearLoginsDatabaseUglyHack() {
+        // This is the ugliest part of this hack. We're using the name extracted from the sources of the
+        // mozilla-components. That database file should be totally opaque to us, but that's what it is as
+        // long as mozilla-components don't provide a better solution for clients.
+        var loginsDatabase = context.getDatabasePath("logins.sqlite")
+        if (loginsDatabase != null) {
+            if (loginsDatabase.delete())
+                Logger.warn("Force-deleted logins database ${loginsDatabase.absolutePath}")
+        }
+    }
 }


### PR DESCRIPTION
Whenever the logins database gets corrupted (for unknown reasons at this point)
every attempt to access it (even wiping it) will result in an Exception being
thrown. That exception if not handled could result in a crash.

While mozilla-components do not provide a better fix all we can do is to delete
the database file (yeah really ugly) hoping for the best.