### PR TITLE
Add support for haptic feedback in OpenXR backend

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -622,7 +622,7 @@ DeviceDelegateOpenXR::ProcessEvents() {
       }
       case XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED: {
         if (m.input) {
-          m.input->UpdateInteractionProfile();
+          m.input->UpdateInteractionProfile(*m.controller);
           if (m.controllersReadyCallback && m.input->AreControllersReady()) {
             m.controllersReadyCallback();
             m.controllersReadyCallback = nullptr;

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -35,6 +35,10 @@ XrResult OpenXRInput::Initialize(ControllerDelegate& delegate)
     if (auto inputSource = OpenXRInputSource::Create(mInstance, mSession, *mActionSet, mSystemProperties, handeness, index)) {
       mInputSources.push_back(std::move(inputSource));
       delegate.CreateController(index, index, "Oculus");
+
+      // @FIXME: Do check that actual controller supports haptics.
+      delegate.SetHapticCount(index, 1);
+
       index++;
     }
   }

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -35,10 +35,6 @@ XrResult OpenXRInput::Initialize(ControllerDelegate& delegate)
     if (auto inputSource = OpenXRInputSource::Create(mInstance, mSession, *mActionSet, mSystemProperties, handeness, index)) {
       mInputSources.push_back(std::move(inputSource));
       delegate.CreateController(index, index, "Oculus");
-
-      // @FIXME: Do check that actual controller supports haptics.
-      delegate.SetHapticCount(index, 1);
-
       index++;
     }
   }
@@ -64,7 +60,7 @@ XrResult OpenXRInput::Initialize(ControllerDelegate& delegate)
   attachInfo.actionSets = &mActionSet->ActionSet();
   RETURN_IF_XR_FAILED(xrAttachSessionActionSets(mSession, &attachInfo));
 
-  UpdateInteractionProfile();
+  UpdateInteractionProfile(delegate);
 
   return XR_SUCCESS;
 }
@@ -111,10 +107,10 @@ std::string OpenXRInput::GetControllerModelName(const int32_t aModelIndex) const
   return mInputSources.at(aModelIndex)->ControllerModelName();
 }
 
-void OpenXRInput::UpdateInteractionProfile()
+void OpenXRInput::UpdateInteractionProfile(ControllerDelegate& delegate)
 {
   for (auto& input : mInputSources) {
-    input->UpdateInteractionProfile();
+    input->UpdateInteractionProfile(delegate);
   }
 }
 

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -36,7 +36,7 @@ public:
   XrResult Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, float offsetY, device::RenderMode renderMode, ControllerDelegate& delegate);
   int32_t GetControllerModelCount() const;
   std::string GetControllerModelName(const int32_t aModelIndex) const;
-  void UpdateInteractionProfile();
+  void UpdateInteractionProfile(ControllerDelegate&);
   bool AreControllersReady() const;
 
   ~OpenXRInput();

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -107,6 +107,11 @@ namespace crow {
         OpenXRHandFlags hand;
     };
 
+    struct OpenXRHaptic {
+        OpenXRButtonPath path;
+        OpenXRHandFlags hand;
+    };
+
     struct OpenXRInputMapping {
         const char* const path { nullptr };
         const char* const systemFilter {nullptr };
@@ -116,6 +121,7 @@ namespace crow {
         std::vector<OpenXRInputProfile> profiles;
         std::vector<OpenXRButton> buttons;
         std::vector<OpenXRAxis> axes;
+        std::vector<OpenXRHaptic> haptics;
     };
 
     /*
@@ -143,7 +149,10 @@ namespace crow {
         },
         std::vector<OpenXRAxis> {
             { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
-        }
+        },
+        std::vector<OpenXRHaptic> {
+            { kPathHaptic, OpenXRHandFlags::Right },
+        },
     };
 
     // Oculus Touch v3:  https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/oculus/oculus-touch-v3.json
@@ -167,7 +176,10 @@ namespace crow {
             },
             std::vector<OpenXRAxis> {
                     { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
-            }
+            },
+            std::vector<OpenXRHaptic> {
+                    { kPathHaptic, OpenXRHandFlags::Both },
+            },
     };
     
     // HVR 3DOF: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-trigger-touchpad.json
@@ -185,7 +197,10 @@ namespace crow {
             },
             std::vector<OpenXRAxis> {
                 { OpenXRAxisType::Trackpad, "input/trackpad/value",  OpenXRHandFlags::Both },
-            }
+            },
+            std::vector<OpenXRHaptic> {
+                { kPathHaptic, OpenXRHandFlags::Both },
+            },
     };
 
   const OpenXRInputMapping Hvr6DOF {
@@ -211,7 +226,10 @@ namespace crow {
       },
       std::vector<OpenXRAxis> {
           { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
-      }
+      },
+      std::vector<OpenXRHaptic> {
+          { kPathHaptic, OpenXRHandFlags::Both },
+      },
   };
 
     // Default fallback: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-button.json
@@ -225,7 +243,10 @@ namespace crow {
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::Click, OpenXRHandFlags::Both },
             },
-            {}
+            {},
+            std::vector<OpenXRHaptic> {
+                    { kPathHaptic, OpenXRHandFlags::Both },
+            },
     };
 
 #if defined(HVR_6DOF)

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -33,6 +33,7 @@ namespace crow {
     constexpr const char* kPathTrackpad { "input/trackpad" };
     constexpr const char* kPathSelect { "/input/select" };
     constexpr const char* kPathMenu { "input/menu" };
+    constexpr const char* kPathHaptic { "output/haptic" };
     constexpr const char* kPathButtonA { "input/a" };
     constexpr const char* kPathButtonB { "input/b" };
     constexpr const char* kPathButtonX { "input/x" };

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -37,6 +37,9 @@ private:
     XrResult GetActionState(XrAction, XrVector2f*) const;
     ControllerDelegate::Button GetBrowserButton(const OpenXRButton&) const;
     std::optional<uint8_t> GetImmersiveButton(const OpenXRButton&) const;
+    XrResult applyHapticFeedback(XrAction, XrDuration, float = XR_FREQUENCY_UNSPECIFIED, float = 0.0) const;
+    XrResult stopHapticFeedback(XrAction) const;
+    void UpdateHaptics(ControllerDelegate &controller);
 
     XrInstance mInstance { XR_NULL_HANDLE };
     XrSession mSession { XR_NULL_HANDLE };
@@ -51,6 +54,8 @@ private:
     XrSpace mPointerSpace { XR_NULL_HANDLE };
     std::unordered_map<OpenXRButtonType, OpenXRActionSet::OpenXRButtonActions> mButtonActions;
     std::unordered_map<OpenXRAxisType, XrAction> mAxisActions;
+    XrAction mHapticAction;
+    uint64_t mStartHapticFrameId;
     XrSystemProperties mSystemProperties;
     std::vector<OpenXRInputMapping> mMappings;
     OpenXRInputMapping* mActiveMapping { XR_NULL_HANDLE };

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -39,7 +39,7 @@ private:
     std::optional<uint8_t> GetImmersiveButton(const OpenXRButton&) const;
     XrResult applyHapticFeedback(XrAction, XrDuration, float = XR_FREQUENCY_UNSPECIFIED, float = 0.0) const;
     XrResult stopHapticFeedback(XrAction) const;
-    void UpdateHaptics(ControllerDelegate &controller);
+    void UpdateHaptics(ControllerDelegate&);
 
     XrInstance mInstance { XR_NULL_HANDLE };
     XrSession mSession { XR_NULL_HANDLE };
@@ -70,7 +70,7 @@ public:
 
     XrResult SuggestBindings(SuggestedBindings&) const;
     void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, float offsetY, device::RenderMode, ControllerDelegate& delegate);
-    XrResult UpdateInteractionProfile();
+    XrResult UpdateInteractionProfile(ControllerDelegate&);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }
 };


### PR DESCRIPTION
This fixes #222 and the [Magical Reflextions](https://www.magische-spiegelungen.de/) experience on HVR; and greatly improves all other content that use haptic feedback (e.g Moonrider). 

For now we assume all controllers using the OpenXR backend have at least one haptic actuator; which is the case for Huawei VR and Oculus.

We leave the frequency unspecified since the JS API doesn't provide it. The OpenXR spec states that the runtime will choose an appropriate value in this case.
