### PR TITLE
[l10n] Add Portuguese (Brazil) as an official app language

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
@@ -307,6 +307,8 @@ public class LocaleUtils {
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_finnish, locale)));
             locale = new Locale("gl", "ES");
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_galician, locale)));
+            locale = new Locale("pt","BR");
+            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_portuguese_br, locale)));
         }};
 
         Locale locale = getDeviceLocale();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,6 +390,12 @@
     the keyboard languages panel list. -->
     <string name="settings_language_thai">Thai</string>
 
+    <!-- This string is used to label a radio button in the 'Settings' Voice Search and the Display Language dialogs that, when pressed,
+    changes the app and the language of the speech-recognition-based search to 'Portuguese (Brazil)'.
+    The string is also used in the keyboard space bar to show the current keyboard language and in
+    the keyboard languages panel list. -->
+    <string name="settings_language_portuguese_br">Portuguese (Brazil)</string>
+
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
         opens a dialog box that contains display-related settings: window size, pixel density, etc. -->
     <string name="settings_display">Display</string>


### PR DESCRIPTION
We have this locale currently translated at 100%, and a motivated maintainer, so it is time to enable it in Wolvic.

Thanks, @tiagovignatti!