### PR TITLE
Dismiss file dialog prompts by default

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/PromptDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/PromptDelegate.java
@@ -119,6 +119,15 @@ public class PromptDelegate implements
 
     @Nullable
     @Override
+    public WResult<PromptResponse> onFilePrompt(@NonNull final WSession session, @NonNull final WSession.PromptDelegate.FilePrompt prompt) {
+        // TODO: we don't support File dialogs yet
+        final WResult<PromptResponse> result = WResult.create();
+        result.complete(prompt.dismiss());
+        return result;
+    }
+
+    @Nullable
+    @Override
     public WResult<PromptResponse> onAlertPrompt(@NonNull WSession session, @NonNull AlertPrompt alertPrompt) {
         final WResult<PromptResponse> result = WResult.create();
 


### PR DESCRIPTION
We don't support file dialogs yet, so dismiss the prompt request whenever
made without even showing any UI. This fixes a crash whenever a file prompt
was triggered because we were returning a null WResult in a place where it
was not expected.

This is a regression from the multi-backend patch.

This fixes #253 