### PR TITLE
[l10n] Update translations to various languages

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1624,4 +1624,5 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="language_options_voice_search_service_title">Stemmesøgningstjeneste</string>
     <string name="settings_language_galician">Galicisk</string>
     <string name="permissions_dialog_remember_choice">Husk denne beslutning</string>
+    <string name="settings_language_portuguese_br">Portugisisk (Brasilien)</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1721,4 +1721,5 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="language_options_voice_search_service_title">Service de recherche vocale</string>
     <string name="settings_language_galician">Galicien</string>
     <string name="permissions_dialog_remember_choice">Se souvenir de cette décision</string>
+    <string name="settings_language_portuguese_br">Portugais (Brésil)</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -700,4 +700,5 @@
     <string name="voice_service_huawei_asr">Huawei Automatic Speech Recognition</string>
     <string name="permissions_dialog_remember_choice">Lembrar esta decisión</string>
     <string name="settings_language_galician">Galego</string>
+    <string name="settings_language_portuguese_br">Portugués (Brasil)</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1722,4 +1722,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="language_service_options_reset">음성 검색 서비스 설정 초기화</string>
     <string name="voice_service_metkai">MeetKai</string>
     <string name="voice_service_huawei_asr">HUAWEI 자동 음성 인식</string>
+    <string name="permissions_dialog_remember_choice">이 결정을 기억함</string>
+    <string name="settings_language_galician">갈리시아어</string>
 </resources>


### PR DESCRIPTION
Galician and French end up translated at 100%. Danish and Korean add translations for recently added strings.

In the case of French, the translation was made by an external contributor, but I have checked that it is correct.