### PR TITLE
Update GeckoView maven versions after upgrading to GeckoView 103.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -621,7 +621,7 @@ if (getBackend() == 'chromium') {
     }
 } else {
     dependencies {
-        // "nightly" or "beta" or "release"
+        // "nightly" or "beta"
         def branch = "nightly"
         arm64Implementation deps.gecko_view."${branch}_arm64"
         x86_64Implementation deps.gecko_view."${branch}_x86_64"

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,9 +24,8 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view_nightly = "96.0.20211126093927"
-versions.gecko_view_beta = "79.0.20200630191632"
-versions.gecko_view_release = "78.0.20200630195452"
+versions.gecko_view_nightly = "105.0.20220822095220"
+versions.gecko_view_beta = "104.0.20220816121120"
 versions.android_components = "63.0.0"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.


### PR DESCRIPTION
Although maven builds should not be used for production (they don't have WebXR support) they could be used for hacking in Wolvic code without having to build Gecko locally. Also they're used by our CI at github.

We're also removing the "release" version as Gecko gradle substitutions don't support it. If release was specified the build code was falling back to maven builds making things really confusing.