### PR TITLE
Do not instantiate the Runtime in crash reporter service

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/CrashReporterServiceImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/CrashReporterServiceImpl.java
@@ -1,0 +1,15 @@
+package com.igalia.wolvic.browser.api.impl;
+
+import androidx.annotation.NonNull;
+
+import com.igalia.wolvic.browser.api.WRuntime;
+import com.igalia.wolvic.crashreporting.CrashReporterService;
+
+public class CrashReporterServiceImpl extends CrashReporterService {
+    @NonNull
+    @Override
+    protected WRuntime.CrashReportIntent createCrashReportIntent() {
+        // TODO: implement this.
+        return new WRuntime.CrashReportIntent("", "", "", "");
+    }
+}

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/CrashReporterServiceImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/CrashReporterServiceImpl.java
@@ -1,0 +1,16 @@
+package com.igalia.wolvic.browser.api.impl;
+
+import androidx.annotation.NonNull;
+
+import com.igalia.wolvic.browser.api.WRuntime;
+import com.igalia.wolvic.crashreporting.CrashReporterService;
+
+import org.mozilla.geckoview.GeckoRuntime;
+
+public class CrashReporterServiceImpl extends CrashReporterService {
+    @NonNull
+    @Override
+    protected WRuntime.CrashReportIntent createCrashReportIntent() {
+        return new WRuntime.CrashReportIntent(GeckoRuntime.ACTION_CRASHED, GeckoRuntime.EXTRA_MINIDUMP_PATH, GeckoRuntime.EXTRA_EXTRAS_PATH, GeckoRuntime.EXTRA_CRASH_PROCESS_TYPE);
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -59,7 +59,7 @@ import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.engine.EngineProvider;
 import com.igalia.wolvic.browser.engine.Session;
 import com.igalia.wolvic.browser.engine.SessionStore;
-import com.igalia.wolvic.crashreporting.CrashReporterService;
+import com.igalia.wolvic.browser.api.impl.CrashReporterServiceImpl;
 import com.igalia.wolvic.crashreporting.GlobalExceptionHandler;
 import com.igalia.wolvic.geolocation.GeolocationWrapper;
 import com.igalia.wolvic.input.MotionEventGenerator;
@@ -131,12 +131,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private BroadcastReceiver mCrashReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if((intent.getAction() != null) && intent.getAction().equals(CrashReporterService.CRASH_ACTION)) {
+            if((intent.getAction() != null) && intent.getAction().equals(CrashReporterServiceImpl.CRASH_ACTION)) {
                 Intent crashIntent;
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.S_V2) {
-                    crashIntent = intent.getParcelableExtra(CrashReporterService.DATA_TAG, Intent.class);
+                    crashIntent = intent.getParcelableExtra(CrashReporterServiceImpl.DATA_TAG, Intent.class);
                 } else {
-                    crashIntent = intent.getParcelableExtra(CrashReporterService.DATA_TAG);
+                    crashIntent = intent.getParcelableExtra(CrashReporterServiceImpl.DATA_TAG);
                 }
                 handleContentCrashIntent(crashIntent);
             }
@@ -289,7 +289,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         ((VRBrowserApplication)getApplication()).onActivityCreate(this);
         // Fix for infinite restart on startup crashes.
         long count = SettingsStore.getInstance(getBaseContext()).getCrashRestartCount();
-        boolean cancelRestart = count > CrashReporterService.MAX_RESTART_COUNT;
+        boolean cancelRestart = count > CrashReporterServiceImpl.MAX_RESTART_COUNT;
         if (cancelRestart) {
             super.onCreate(savedInstanceState);
             Log.e(LOGTAG, "Cancel Restart");
@@ -313,7 +313,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         // Create broadcast receiver for getting crash messages from crash process
         IntentFilter intentFilter = new IntentFilter();
-        intentFilter.addAction(CrashReporterService.CRASH_ACTION);
+        intentFilter.addAction(CrashReporterServiceImpl.CRASH_ACTION);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             registerReceiver(mCrashReceiver, intentFilter, BuildConfig.APPLICATION_ID + "." + getString(R.string.app_permission_name), null, Context.RECEIVER_NOT_EXPORTED);
         } else {
@@ -901,7 +901,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     };
 
     private void checkForCrash() {
-        final ArrayList<String> files = CrashReporterService.findCrashFiles(getBaseContext());
+        final ArrayList<String> files = CrashReporterServiceImpl.findCrashFiles(getBaseContext());
         if (files.isEmpty()) {
             Log.d(LOGTAG, "No crash files found.");
             return;

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
@@ -13,7 +13,7 @@ import com.igalia.wolvic.browser.api.WRuntime
 import com.igalia.wolvic.browser.api.WRuntimeSettings
 import com.igalia.wolvic.browser.content.TrackingProtectionPolicy
 import com.igalia.wolvic.browser.content.TrackingProtectionStore
-import com.igalia.wolvic.crashreporting.CrashReporterService
+import com.igalia.wolvic.browser.api.impl.CrashReporterServiceImpl
 import mozilla.components.concept.fetch.Client
 
 object EngineProvider {
@@ -28,7 +28,7 @@ object EngineProvider {
             val settingsStore = SettingsStore.getInstance(context)
 
             val policy : TrackingProtectionPolicy = TrackingProtectionStore.getTrackingProtectionPolicy(context);
-            builder.crashHandler(CrashReporterService::class.java)
+            builder.crashHandler(CrashReporterServiceImpl::class.java)
             builder.contentBlocking(
                 WContentBlocking.Settings.Builder()
                     .antiTracking(policy.antiTrackingPolicy)

--- a/app/src/common/shared/com/igalia/wolvic/crashreporting/GlobalExceptionHandler.java
+++ b/app/src/common/shared/com/igalia/wolvic/crashreporting/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import com.igalia.wolvic.browser.api.WRuntime;
 import com.igalia.wolvic.browser.engine.EngineProvider;
 import com.igalia.wolvic.utils.SystemUtils;
+import com.igalia.wolvic.browser.api.impl.CrashReporterServiceImpl;
 
 public class GlobalExceptionHandler {
 
@@ -20,7 +21,7 @@ public class GlobalExceptionHandler {
         if (mInstance == null) {
             mInstance = new GlobalExceptionHandler();
             WRuntime runtime = EngineProvider.INSTANCE.getOrCreateRuntime(aContext);
-            mInstance.mCrashHandler = runtime.createCrashHandler(aContext, CrashReporterService.class);
+            mInstance.mCrashHandler = runtime.createCrashHandler(aContext, CrashReporterServiceImpl.class);
             Log.d(LOGTAG, "======> GlobalExceptionHandler registered");
         }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
             </intent-filter>
         </activity>
         <service
-            android:name="com.igalia.wolvic.crashreporting.CrashReporterService"
+            android:name="com.igalia.wolvic.browser.api.impl.CrashReporterServiceImpl"
             android:exported="false"
             android:process=":crash"
             android:permission="android.permission.BIND_JOB_SERVICE">


### PR DESCRIPTION
Currently the CrashReporter service uses the runtime to create a CrashReportIntent. The reason why it does that is because the CrashReportIntent receives some parameters that depend on the backend (Gecko,Chromium) which cannot be resolved at build time.

By the time the CrashReporter creates that intent the runtime might not exist (like after a crash in the application). This means that the service will try to create it. The problem is that creating the runtime might not be possible, for example the GeckoRuntime must be created in the main thread but the crash reporter service is run in an async task as it can be see in this backtrace:

2022-09-08 14:15:38.005 20233-20267/com.igalia.wolvic.dev E/AndroidRuntime: FATAL EXCEPTION: AsyncTask #1
    Process: com.igalia.wolvic.dev:crash, PID: 20233
    java.lang.RuntimeException: An error occurred while executing doInBackground()
        at android.os.AsyncTask$4.done(AsyncTask.java:399)
        at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
        at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
        at java.util.concurrent.FutureTask.run(FutureTask.java:271)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.IllegalThreadStateException: Expected thread 2 ("main"), but running on thread 930 ("AsyncTask #1")
        at org.mozilla.gecko.util.ThreadUtils.assertOnThreadComparison(ThreadUtils.java:127)
        at org.mozilla.gecko.util.ThreadUtils.assertOnThread(ThreadUtils.java:93)
        at org.mozilla.gecko.util.ThreadUtils.assertOnUiThread(ThreadUtils.java:84)
        at org.mozilla.geckoview.GeckoRuntime.create(GeckoRuntime.java:552)
        at com.igalia.wolvic.browser.api.impl.RuntimeImpl.<init>(RuntimeImpl.java:72)
        at com.igalia.wolvic.browser.api.WFactory.createRuntime(WFactory.java:14)
        at com.igalia.wolvic.browser.engine.EngineProvider.getOrCreateRuntime(EngineProvider.kt:67)
        at com.igalia.wolvic.crashreporting.CrashReporterService.onHandleWork(CrashReporterService.java:65)
        at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:392)
        at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:383)
        at android.os.AsyncTask$3.call(AsyncTask.java:378)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:919) 

This is why we have to add an extra class per backend that is able to create those intents without having to instantiate the runtime.