### PR TITLE
Parse data URLs of the form "wolvic://com.igalia.wolvic/"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,6 +115,7 @@ android {
         buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "false"
         buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "false"
+        buildConfigField "Boolean", "KIOSK_MODE_ALWAYS", "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
@@ -298,6 +299,7 @@ android {
         cn {
             dimension "country"
             buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "true"
+            buildConfigField "Boolean", "KIOSK_MODE_ALWAYS", "true"
         }
 
         world {

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -705,8 +705,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         }
 
         if (extras != null) {
-            // If there is no data uri and there is a url parameter we get that
-            if (extras.containsKey("url")) {
+            // targetUri will be null here if the data URI is empty or contains a custom URI;
+            // in that case, we will use the "url" parameter if it exists
+            if (targetUri == null && extras.containsKey("url")) {
                 targetUri = Uri.parse(extras.getString("url"));
             }
             // SEND Actions received WebBrowser share dialogs

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -699,10 +699,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                     continue;
 
                 // all supported parameters are booleans, except "url"
-                if (key.equalsIgnoreCase("url"))
-                    extras.putString(key, queryParameter);
+                String lowerCaseKey = key.toLowerCase();
+                if (lowerCaseKey.equals("url"))
+                    extras.putString(lowerCaseKey, queryParameter);
                 else
-                    extras.putBoolean(key, Boolean.parseBoolean(queryParameter));
+                    extras.putBoolean(lowerCaseKey, Boolean.parseBoolean(queryParameter));
             }
         } else {
             targetUri = intent.getData();

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -199,6 +199,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private float mCurrentCylinderDensity = 0;
     private boolean mHideWebXRIntersitial = false;
     private FragmentController mFragmentController;
+    private boolean mIsKioskMode = false;
 
     private boolean callOnAudioManager(Consumer<AudioManager> fn) {
         if (mAudioManager == null) {
@@ -468,10 +469,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     private void showWhatsNewDialogIfNeeded() {
-        if (SettingsStore.getInstance(this).isWhatsNewDisplayed()) {
+        if (SettingsStore.getInstance(this).isWhatsNewDisplayed() || mWindows.getFocusedWindow().isKioskMode()) {
             return;
         }
-        // TODO do not show in kiosk mode?
+
         mWhatsNewWidget = new WhatsNewWidget(this);
         mWhatsNewWidget.setLoginOrigin(Accounts.LoginOrigin.NONE);
         mWhatsNewWidget.getPlacement().parentHandle = mWindows.getFocusedWindow().getHandle();

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -694,10 +694,14 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             extras = new Bundle();
             Set<String> keys = dataUri.getQueryParameterNames();
             for (String key : keys) {
-                if (key.equals("url") || key.equals("homepage"))
-                    extras.putString(key, dataUri.getQueryParameter(key));
+                String queryParameter = dataUri.getQueryParameter(key);
+                if (queryParameter == null)
+                    continue;
+
+                if (key.equalsIgnoreCase("url") || key.equalsIgnoreCase("homepage"))
+                    extras.putString(key, queryParameter);
                 else
-                    extras.putBoolean(key, Boolean.parseBoolean(dataUri.getQueryParameter(key)));
+                    extras.putBoolean(key, Boolean.parseBoolean(queryParameter));
             }
         } else {
             targetUri = intent.getData();

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -323,6 +323,13 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mPoorPerformanceAllowList = new HashSet<>();
         checkForCrash();
 
+        // Show the launch dialogs, if needed.
+        if (!showTermsServiceDialogIfNeeded()) {
+            if (!showPrivacyDialogIfNeeded()) {
+                showWhatsNewDialogIfNeeded();
+            }
+        }
+
         mLifeCycle.setCurrentState(Lifecycle.State.CREATED);
     }
 
@@ -390,13 +397,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         attachToWindow(mWindows.getFocusedWindow(), null);
 
         addWidgets(Arrays.asList(mRootWidget, mNavigationBar, mKeyboard, mTray, mWebXRInterstitial));
-
-        // Show the launch dialogs, if needed.
-        if (!showTermsServiceDialogIfNeeded()) {
-            if (!showPrivacyDialogIfNeeded()) {
-                showWhatsNewDialogIfNeeded();
-            }
-        }
 
         mWindows.restoreSessions();
     }

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -761,6 +761,13 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             openInKioskMode = extras.getBoolean("kiosk", false);
         }
 
+        // In some variants Wolvic will always open in kiosk mode.
+        if (BuildConfig.KIOSK_MODE_ALWAYS) {
+            openInKioskMode = true;
+            if (targetUri == null)
+                targetUri = Uri.parse(getString(R.string.homepage_url));
+        }
+
         // If there is a URI we open it
         if (targetUri != null) {
             Log.d(LOGTAG, "Loading URI from intent: " + targetUri);

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -699,7 +699,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 if (queryParameter == null)
                     continue;
 
-                if (key.equalsIgnoreCase("url") || key.equalsIgnoreCase("homepage"))
+                // all supported parameters are booleans, except "url"
+                if (key.equalsIgnoreCase("url"))
                     extras.putString(key, queryParameter);
                 else
                     extras.putBoolean(key, Boolean.parseBoolean(queryParameter));
@@ -725,12 +726,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 if (i >= 0) {
                     targetUri = Uri.parse(text.substring(i));
                 }
-            }
-
-            // Overwrite the stored homepage
-            if (extras.containsKey("homepage")) {
-                Uri homepageUri = Uri.parse(extras.getString("homepage"));
-                SettingsStore.getInstance(this).setHomepage(homepageUri.toString());
             }
 
             // Open the tab in background/foreground, if there is no URL provided we just open the homepage

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
@@ -469,6 +469,7 @@ public class WindowViewModel extends AndroidViewModel {
 
     public void setIsKioskMode(boolean isKioskMode) {
         // setValue changes the data immediately, but must be called from the main thread
+        // FIXME rework the execution flow so only postValue() is needed
         if (Looper.getMainLooper().isCurrentThread()) {
             this.isKioskMode.setValue(new ObservableBoolean(isKioskMode));
         } else {

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
@@ -2,6 +2,7 @@ package com.igalia.wolvic.ui.viewmodel;
 
 import android.app.Application;
 import android.content.res.Resources;
+import android.os.Looper;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
@@ -467,7 +468,12 @@ public class WindowViewModel extends AndroidViewModel {
     }
 
     public void setIsKioskMode(boolean isKioskMode) {
-        this.isKioskMode.postValue(new ObservableBoolean(isKioskMode));
+        // setValue changes the data immediately, but must be called from the main thread
+        if (Looper.getMainLooper().isCurrentThread()) {
+            this.isKioskMode.setValue(new ObservableBoolean(isKioskMode));
+        } else {
+            this.isKioskMode.postValue(new ObservableBoolean(isKioskMode));
+        }
     }
 
     @NonNull

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -379,11 +379,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
-    public void loadHomeIfBlank() {
+    public boolean isCurrentUriBlank() {
         final String currentUri = mSession.getCurrentUri();
-        if ((currentUri == null) || currentUri.isEmpty() || UrlUtils.isBlankUri(getContext(), mSession.getCurrentUri())) {
-            loadHome();
-        }
+        return (currentUri == null) || currentUri.isEmpty() || UrlUtils.isBlankUri(getContext(), currentUri);
     }
 
     public void loadHome() {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,9 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="http" />
                 <data android:scheme="https" />
+                <data
+                    android:scheme="wolvic"
+                    android:host="com.igalia.wolvic" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
This PR allows Wolvic to gets its parameters from a custom data URI that begins with `"wolvic://com.igalia.wolvic"`.

It can be tested from the command line.
This is the command to open `"moonrider.xyz"` in kiosk mode, encapsulating all the parameters in the custom data URI `wolvic://com.igalia.wolvic/?kiosk=true&url=moonrider.xyz`:

```sh
adb shell am start -a android.intent.action.VIEW -d "wolvic://com.igalia.wolvic/\?kiosk=true\&url=moonrider.xyz"
```

For comparison,  this is the command to launch Wolvic to open `"moonrider.xyz"` with the boolean extra `"kiosk"` set to `true`:

```sh
adb shell am start -a android.intent.action.MAIN -d "https://moonrider.xyz" --ez "kiosk" true com.igalia.wolvic/com.igalia.wolvic.VRBrowserActivity
```
