### PR TITLE
Update Notifications UI after first message

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/SystemNotificationsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/SystemNotificationsView.java
@@ -103,6 +103,7 @@ public class SystemNotificationsView extends LibraryView implements SystemNotifi
         }
         mAdapter.setItems(SystemNotificationsManager.getInstance().getSystemNotifications());
         SystemNotificationsManager.getInstance().addChangeListener(this);
+        mViewModel.setIsEmpty(mAdapter.getItemCount() == 0);
     }
 
     @Override


### PR DESCRIPTION
A small change to ensure that we don't show the "empty" UI In the Notifications list in the Library after the **first** notification arrives.