### PR TITLE
Don't force fullscreen in kiosk mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -721,7 +721,8 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
         mWidgetManager.popWorldBrightness(this);
         AnimationHelper.fadeOut(mBinding.navigationBarFullscreen.fullScreenModeContainer, 0, null);
-        mTrayViewModel.setShouldBeVisible(true);
+        // if we are in kiosk mode, don't show the tray
+        mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isKioskMode());
         closeFloatingMenus();
         mWidgetManager.popWorldBrightness(mBrightnessWidget);
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -1371,7 +1371,6 @@ public void selectTab(@NonNull Session aTab) {
         setFirstPaint(mFocusedWindow, session);
         mFocusedWindow.setSession(session, WindowWidget.DEACTIVATE_CURRENT_SESSION);
         mFocusedWindow.setKioskMode(true);
-        mFocusedWindow.setIsFullScreen(true);
     }
 
     public void addTab(@NonNull WindowWidget targetWindow, @Nullable String aUri) {


### PR DESCRIPTION
Forcing fullscreen in kiosk mode is not really needed and introduces a bunch of small bugs.

This PR decouples kiosk mode and fullscreen. Apart from that, the only necessary change was to ensure that the tray is not shown in kiosk mode when the current session leaves fullscreen.