### PR TITLE
Make BUTTON_APP exit fullscreen mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -672,6 +672,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (mFocusedWindow == null) {
             return false;
         }
+        if (mFocusedWindow.getSession().isInFullScreen()) {
+            mFocusedWindow.getSession().exitFullScreen();
+            return true;
+        }
         if (mFocusedWindow.getSession().canGoBack()) {
             mFocusedWindow.getSession().goBack();
             return true;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -526,12 +526,7 @@ struct DeviceDelegateOculusVR::State {
 
           controller->SetButtonState(controllerState.index, ControllerDelegate::BUTTON_X, device::kImmersiveButtonA, xPressed, xTouched);
           controller->SetButtonState(controllerState.index, ControllerDelegate::BUTTON_Y, device::kImmersiveButtonB, yPressed, yTouched);
-
-          if (renderMode != device::RenderMode::Immersive) {
-            controller->SetButtonState(controllerState.index, ControllerDelegate::BUTTON_APP, -1, yPressed, yTouched);
-          } else {
-            controller->SetButtonState(controllerState.index, ControllerDelegate::BUTTON_APP, -1, menuPressed, menuPressed);
-          }
+          controller->SetButtonState(controllerState.index, ControllerDelegate::BUTTON_APP, -1, menuPressed, menuPressed);
         } else if (controllerState.hand == ElbowModel::HandEnum::Right) {
           const bool aPressed = (controllerState.inputState.Buttons & ovrButton_A) != 0;
           const bool aTouched = (controllerState.inputState.Touches & ovrTouch_A) != 0;


### PR DESCRIPTION
BUTTON_APP (the hamburger button on the left controller on Meta Quest2 and HVR) is used to exit WebXR sessions and go back to the 2D browser. We can export that very same behaviour to the immersive 360 videos as they're in a way a similar experience.

In the particular case of the OculusVR platform, that button was mapped to the Y hardware button when not in immersive mode. We're removing that as that behaviour was not shared by the OpenXR backend. Also the Meta browser does not do anything similar (the Y button is used to select the word that is pointed by the aim ray). So in order to unify the behaviour of the different backends we're now also treating it as a back navigation/exit XR/exit fullscreen button.

This fixes issues #275 and #276.