### PR TITLE
Remove the mapping for /input/home in HVR 6DoF controllers

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -217,7 +217,6 @@ namespace crow {
 
           { OpenXRButtonType::ButtonA, kPathButtonA, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
           { OpenXRButtonType::ButtonB, kPathButtonB, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
-          { OpenXRButtonType::Menu, "input/home", OpenXRButtonFlags::Click, OpenXRHandFlags::Right, ControllerDelegate::Button::BUTTON_APP, true },
 
           { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ClickValue | OpenXRButtonFlags::Touch, OpenXRHandFlags::Both },
           { OpenXRButtonType::Thumbstick, kPathThumbstick, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Both },


### PR DESCRIPTION
There is no point in having a mapping for that button (in our case it was mapped to BUTTON_APP) because that button is captured by the system. The default (and only) action is to close the currently run application, and there is nothing that apps can do ATM to change that.

That was causing, that sometimes when the user clicked that button a glimpse of a confirmation dialog was shown while the application was exiting.