### PR TITLE
[HVR] Add some required permissions and queries for Harmony 3.0

### DIFF
--- a/app/src/hvr/AndroidManifest.xml
+++ b/app/src/hvr/AndroidManifest.xml
@@ -15,6 +15,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="com.huawei.vrhandle.permission.DEVICE_MANAGER" />
     <uses-permission android:name="com.huawei.android.permission.VR"/>
+    <!-- We don't use alarms. It's a SDK bug, see https://github.com/hms-ecosystem/OpenXR-SDK/issues/41 -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <application
         android:allowBackup="true"
         android:label="@string/app_name" >

--- a/app/src/hvr3dof/AndroidManifest.xml
+++ b/app/src/hvr3dof/AndroidManifest.xml
@@ -15,6 +15,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="com.huawei.vrhandle.permission.DEVICE_MANAGER" />
     <uses-permission android:name="com.huawei.android.permission.VR"/>
+    <!-- We don't use alarms. It's a SDK bug, see https://github.com/hms-ecosystem/OpenXR-SDK/issues/41 -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <application
         android:allowBackup="true"
         android:label="@string/app_name" >
@@ -48,5 +50,12 @@
             </intent-filter>
         </activity>
     </application>
+    <queries>
+        <package android:name="com.huawei.vrhandle" />
+        <package android:name="com.huawei.hvrsdkserverapp" />
+        <intent>
+            <action android:name="com.huawei.vrhandle.service.vrdeviceservice"/>
+        </intent>
+    </queries>
 
 </manifest>


### PR DESCRIPTION
The update to Harmony 3.0 requires some additional permissions and also specifying the applications that will interact with Wolvic, in this case the systems VR services.