### PR TITLE
Add a new UA override for walkofchampions.vodafone.co.uk

### DIFF
--- a/app/src/main/assets/userAgentOverride.json
+++ b/app/src/main/assets/userAgentOverride.json
@@ -10,6 +10,7 @@
   "3083eab5795791459f69071ce0c1633f3c8e87642d1b09aac9f37900a3571d95674cef03aa2c9da8e311264b1597fe6cb100d824a383dcd8de44858317d382db": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
   "4616a533b40cd2b4bc133589b9350f4747ef7746d064dc7e87ee11cae33a12e5c199d31a8e273db0dc950b56e51157a2b705c6324e274b32178ec7c74781e2af": "Mozilla/5.0 (X11; LinuxX86_64; rv:96.0) Gecko/20100101 Firefox/96.0",
   "4d4ab964e718f69785a8b0b708d43a757770f245c83b78d749ed901174d0e49eff597811d39be4df4b5fa929f03dcb718cee4cbfe51f5e388eb3ee4fe0e5dd67": "Mozilla/5.0 (X11; LinuxX86_64; rv:105.0) Gecko/20100101 Firefox/105.0",
-  "3ea7a4815f1fb9d3a7da08cfde65e2aa547ff1d7399a5015adbc36a19a7893f7e1dae7db39f43a631dc43bcd634be8ef1b7ce7f7c22bd3ff36e7d6c7b5038ebd": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36"
+  "3ea7a4815f1fb9d3a7da08cfde65e2aa547ff1d7399a5015adbc36a19a7893f7e1dae7db39f43a631dc43bcd634be8ef1b7ce7f7c22bd3ff36e7d6c7b5038ebd": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
+  "fefc763e01648e0c5ca3b67306b9d66212e8d30af3f91e15763c07d53cda9c08ad884be9e52df7f15f0243da10ff25fe24ffdaa72a11934301c6b4799e22eab5": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36"
 }
 


### PR DESCRIPTION
It requires a Meta Browser to allow VR experiences.