### PR TITLE
[HVR] Remove workaround for 6DoF controllers

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -465,15 +465,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     device::CapabilityFlags flags = device::Orientation;
     vrb::Matrix pointerTransform = XrPoseToMatrix(poseLocation.pose);
 
-#ifdef HVR_6DOF
-    const bool positionTracked = true;
-    // The HVR OpenXR SDK incorrectly returns the same value for aim and grip poses, we have to workaround it in the meantime.
-    // As it actually always return the grip pose we have to generate the aim pose from it.
-    pointerTransform.PostMultiplyInPlace(vrb::Matrix::Rotation(vrb::Vector(1.0, 0.0, 0.0), -M_PI / 4));
-#else
     const bool positionTracked = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
-#endif
-
     if (positionTracked) {
       if (renderMode == device::RenderMode::StandAlone) {
         pointerTransform.TranslateInPlace(kAverageHeight);


### PR DESCRIPTION
We had a workaround for HVR's 6DoF controllers as they were incorrectly reporting the same values for aim and grip poses. The new SDK (version .79) fixes that issue so we can get rid of it.