### PR TITLE
[HVR] Remove a workaround for positional tracking detection

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -381,12 +381,7 @@ struct DeviceDelegateOpenXR::State {
   }
 
   bool Is6DOF() const {
-#if defined(HVR_6DOF)
-    // Workaround for systemProperties.trackingProperties.positionTracking always 0.
-    return true;
-#else
     return systemProperties.trackingProperties.positionTracking != 0;
-#endif
   }
 
   const XrEventDataBaseHeader* PollEvent() {


### PR DESCRIPTION
The HVR SDK was always claiming not to have positional tracking support. The value of systemProperties.trackingProperties.positionTracking was always 0, meaning that we were not able to know whether or not the user was using a 3DoF or a 6DoF controller. That forced us to use defines and to have two different packages.

With the new SDK version (.79) this is no longer an issue so we can remove the workaround. This paves the way towards having a single package for the HVR platform.