### PR TITLE
[HVR] Exit app when clicking exit on the confirmation dialog

### DIFF
--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -314,6 +314,17 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
     }
 
     @Override
+    public void onBackPressed() {
+        queueRunnable(new Runnable() {
+            @Override
+            public void run() {
+                finish();
+                System.exit(0);
+            }
+        });
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
         Log.i(TAG, "PlatformActivity onResume");


### PR DESCRIPTION
For Pico and HVR builds we show an exit confirmation dialog whenever back action is triggered and we cannot go backwards in history. We don't do that in Meta for example because the system does it for us.

In the case of HVR clicking on exit was not doing anything because the onBackPressed() method was not implemented for that platform. We do invoke finish now and exit the application properly.