### PR TITLE
[HVR] Remove some HVR_6DoF ifdefs

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -222,9 +222,8 @@ std::optional<XrVector2f> OpenXRInputSource::GetAxis(OpenXRAxisType axisType) co
       axis.x = 0;
       axis.y = 0;
     }
-#ifdef HVR_6DOF
-    axis.y = -axis.y;
-#endif
+    if (mSystemProperties.trackingProperties.positionTracking == XR_TRUE)
+        axis.y = -axis.y;
 #endif
 
     return axis;


### PR DESCRIPTION
Now that we can safely detect at runtime whether we have 3DoF or 6DoF kit for HVR devices, we can convert build time checks in runtime ones.

This is another step in the process of having a single package for the HVR platform (covering both 3DoF and 6DoF hardware).