### PR TITLE
[HVR] Replace the package name for mainland China

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -665,7 +665,7 @@ androidComponents {
         // HVR packages for China must use different applicationIds.
         def hvrChinaBuildPattern = ~/hvr\p{Alnum}+Cn(Release|Debug)/
         if (hvrChinaBuildPattern.matcher(variant.name).matches())
-            variant.applicationId = variant.applicationId.get().replace('com.igalia','cn.igalia')
+            variant.applicationId = variant.applicationId.get().replace('com.igalia','com.cn.igalia')
     })
 }
 


### PR DESCRIPTION
The previous name was used for testing. We need a new one to submit new versions of the package in mainland China. The new package name would be com.cn.igalia.wolvic