### PR TITLE
Filter out incompatible controllers based on DoF

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -112,9 +112,15 @@ namespace crow {
         OpenXRHandFlags hand;
     };
 
+    enum DoF {
+        IS_3DOF,
+        IS_6DOF,
+    };
+
     struct OpenXRInputMapping {
         const char* const path { nullptr };
         const char* const systemFilter {nullptr };
+        DoF systemDoF;
         const char* const leftControllerModel { nullptr };
         const char* const rightControllerModel { nullptr };
         device::DeviceType controllerType { device::OculusQuest };
@@ -132,6 +138,7 @@ namespace crow {
     const OpenXRInputMapping OculusTouch {
         "/interaction_profiles/oculus/touch_controller",
         "Oculus Quest",
+        IS_6DOF,
         "vr_controller_oculusquest_left.obj",
         "vr_controller_oculusquest_right.obj",
         device::OculusQuest,
@@ -159,6 +166,7 @@ namespace crow {
     const OpenXRInputMapping OculusTouch2 {
             "/interaction_profiles/oculus/touch_controller",
             "Oculus Quest2",
+            IS_6DOF,
             "vr_controller_oculusquest2_left.obj",
             "vr_controller_oculusquest2_right.obj",
             device::OculusQuest2,
@@ -186,6 +194,7 @@ namespace crow {
     const OpenXRInputMapping Hvr3DOF {
             "/interaction_profiles/huawei/controller",
             "Haliday: G3HMD by Huawei",
+            IS_3DOF,
             nullptr,
             "vr_controller_focus.obj",
             device::ViveFocus,
@@ -206,6 +215,7 @@ namespace crow {
   const OpenXRInputMapping Hvr6DOF {
       "/interaction_profiles/huawei/6dof_controller",
       "Haliday: G3HMD by Huawei",
+      IS_6DOF,
       "hvr_6dof_left.obj",
       "hvr_6dof_right.obj",
       device::OculusQuest,
@@ -235,6 +245,7 @@ namespace crow {
     const OpenXRInputMapping KHRSimple {
             "/interaction_profiles/khr/simple_controller",
             nullptr,
+            IS_3DOF,
             "vr_controller_oculusgo.obj",
             "vr_controller_oculusgo.obj",
             device::OculusGo,
@@ -248,14 +259,8 @@ namespace crow {
             },
     };
 
-#if defined(HVR_6DOF)
-#define HVR_MAPPING Hvr6DOF
-#else
-#define HVR_MAPPING Hvr3DOF
-#endif
-
-    const std::array<OpenXRInputMapping, 4> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, HVR_MAPPING, KHRSimple
+    const std::array<OpenXRInputMapping, 5> OpenXRInputMappings {
+        OculusTouch, OculusTouch2, Hvr6DOF, Hvr3DOF, KHRSimple
     };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -52,6 +52,10 @@ XrResult OpenXRInputSource::Initialize()
       if (mapping.systemFilter && strcmp(mapping.systemFilter, mSystemProperties.systemName) != 0) {
         continue;
       }
+      bool systemIs6DoF = mSystemProperties.trackingProperties.positionTracking == XR_TRUE;
+      bool mappingIs6DoF = mapping.systemDoF == DoF::IS_6DOF;
+      if (mappingIs6DoF != systemIs6DoF)
+          continue;
       mMappings.push_back(mapping);
     }
 


### PR DESCRIPTION
In general each XR system is either 3DoF or 6DoF so it's enough with having a single OpenXR input profile. That's why we used to filter out mappings based on the name of the XR system.

However in the case of the HVR platform, you can easily convert your 3DoF system in a 6DoF one by attaching a 6DoF kit to the glasses. This means that filtering by name is not enough. We should also have a way to specify different mappings for the same system depending on whether they're either 3DoF or 6DoF.

This allows us to remove an #ifdef in the mappings. This will allow us to eventually remove one of the two HVR flavours.