### PR TITLE
Rename HVR_ML_API_KEY to HVR_API_KEY

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,15 +62,15 @@ def getHVRAppId = { ->
     return ""
 }
 
-def getHVRMLApiKey = { ->
-    if (gradle.hasProperty("userProperties.HVR_ML_API_KEY")) {
-        return gradle."userProperties.HVR_ML_API_KEY"
+def getHVRApiKey = { ->
+    if (gradle.hasProperty("userProperties.HVR_API_KEY")) {
+        return gradle."userProperties.HVR_API_KEY"
     }
     return ""
 }
 
 def getHVRMLSpeechServices = { ->
-    if (getHVRMLApiKey().isEmpty()) {
+    if (getHVRApiKey().isEmpty()) {
         return "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
     } else {
         return "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI, " +
@@ -272,7 +272,7 @@ android {
                 }
             }
             buildConfigField "String", "HVR_APP_ID", "\"${getHVRAppId()}\""
-            buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
+            buildConfigField "String", "HVR_API_KEY", "\"${getHVRApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
             buildConfigField "int", "MSAA_LEVEL", "0"
             buildConfigField "String[]", "SPEECH_SERVICES", "${getHVRMLSpeechServices()}"
@@ -289,7 +289,7 @@ android {
                 }
             }
             buildConfigField "String", "HVR_APP_ID", "\"${getHVRAppId()}\""
-            buildConfigField "String", "HVR_ML_API_KEY", "\"${getHVRMLApiKey()}\""
+            buildConfigField "String", "HVR_API_KEY", "\"${getHVRApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
             buildConfigField "int", "MSAA_LEVEL", "0"
             buildConfigField "String[]", "SPEECH_SERVICES", "${getHVRMLSpeechServices()}"

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -95,7 +95,7 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
             HiAnalyticsTools.enableLog();
         }
         HiAnalyticsInstance instance = HiAnalytics.getInstance(getApplicationContext());
-        instance.setUserProfile("userKey", BuildConfig.HVR_ML_API_KEY);
+        instance.setUserProfile("userKey", BuildConfig.HVR_API_KEY);
 
         mHmsMessageBroadcastReceiver = new BroadcastReceiver() {
             @Override

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -246,11 +246,11 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
     private void initializeAGConnect() {
         try {
             String speechService = SettingsStore.getInstance(this).getVoiceSearchService();
-            if (SpeechServices.HUAWEI_ASR.equals(speechService) && StringUtils.isEmpty(BuildConfig.HVR_ML_API_KEY)) {
+            if (SpeechServices.HUAWEI_ASR.equals(speechService) && StringUtils.isEmpty(BuildConfig.HVR_API_KEY)) {
                 Log.e(TAG, "HVR API key is not available");
                 return;
             }
-            MLApplication.getInstance().setApiKey(BuildConfig.HVR_ML_API_KEY);
+            MLApplication.getInstance().setApiKey(BuildConfig.HVR_API_KEY);
             TelemetryService.setService(new HVRTelemetry(this));
             try {
                 SpeechRecognizer speechRecognizer = SpeechServices.getInstance(this, speechService);


### PR DESCRIPTION
This name is more accurate, because there is only one API key. Otherwise, it can be confusing when we start using other services apart from ML.