### PR TITLE
No download confirmation dialog while in WebXR

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1679,7 +1679,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         // so we let the system handle it.
         if (!UrlUtils.isFileUri(webResponseInfo.uri())) {
             DownloadJob job = DownloadJob.fromUri(webResponseInfo.uri());
-            startDownload(job, true);
+            // Don't show the confirmation dialog when we are in WebXR, because it will not be visible.
+            boolean showConfirmDialog = !mWidgetManager.isWebXRPresenting();
+            startDownload(job, showConfirmDialog);
 
         } else {
             File file = new File(webResponseInfo.uri().substring("file://".length()));


### PR DESCRIPTION
Don't try to show the confirmation dialog when we are in WebXR, because it will not be visible.