### PR TITLE
[HVR] Enable antialiasing by default for Harmony OS 3.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,7 +110,6 @@ android {
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
         buildConfigField "Boolean", "DISABLE_CRASH_RESTART", getCrashRestartDisabled()
         buildConfigField "String", "AMO_COLLECTION", "\"fxr\""
-        buildConfigField "int", "MSAA_LEVEL", "1"
         buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "false"
         buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "false"
         buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
@@ -274,7 +273,6 @@ android {
             buildConfigField "String", "HVR_APP_ID", "\"${getHVRAppId()}\""
             buildConfigField "String", "HVR_API_KEY", "\"${getHVRApiKey()}\""
             buildConfigField "String", "MK_API_KEY", "\"\""
-            buildConfigField "int", "MSAA_LEVEL", "0"
             buildConfigField "String[]", "SPEECH_SERVICES", "${getHVRMLSpeechServices()}"
             buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "true"
         }

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -3,6 +3,7 @@ package com.igalia.wolvic.browser;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.StrictMode;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -92,7 +93,7 @@ public class SettingsStore {
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;
     public final static String ENV_DEFAULT = "cyberpunk";
-    public final static int MSAA_DEFAULT_LEVEL = BuildConfig.MSAA_LEVEL;
+    public final static int MSAA_DEFAULT_LEVEL = 1;
     public final static boolean AUDIO_ENABLED = false;
     public final static float CYLINDER_DENSITY_ENABLED_DEFAULT = 4680.0f;
     private final static long CRASH_RESTART_DELTA = 2000;
@@ -441,8 +442,11 @@ public class SettingsStore {
 
 
     public int getMSAALevel() {
+        // We could get the exact HarmonyOS version using the Huawei's ohos package but there is little
+        // point in adding a dependency just for that. We can do an alternate check.
+        boolean isHarmonyOS2 = DeviceType.isHVRBuild() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S;
         return mPrefs.getInt(
-                mContext.getString(R.string.settings_key_msaa), MSAA_DEFAULT_LEVEL);
+                mContext.getString(R.string.settings_key_msaa), isHarmonyOS2 ? 0 : MSAA_DEFAULT_LEVEL);
     }
 
     public void setMSAALevel(int level) {


### PR DESCRIPTION
Looks like the Harmony OS 3.0 gfx capabilities are much better than in 2.0. We'll tempatively enable MSAA 2x by default also for the HVR platform.

As we are deciding that at runtime now there is no point in having a build flag for the default MSAA level and thus, we removed that.