### PR TITLE
Explicitly create PendingIntents with IMMUTABLE flag

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/SystemUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/SystemUtils.java
@@ -48,7 +48,7 @@ public class SystemUtils {
         i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         PendingIntent mPendingIntent = PendingIntent.getActivity(context, 0, i,
-                PendingIntent.FLAG_CANCEL_CURRENT);
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         AlarmManager mgr = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         mgr.set(AlarmManager.RTC, System.currentTimeMillis() + delay, mPendingIntent);
 


### PR DESCRIPTION
Up until Build.VERSION_CODES.R, PendingIntents are assumed to be mutable by default, unless FLAG_IMMUTABLE is set. Starting with Build.VERSION_CODES.S, it will be required to explicitly specify the mutability of PendingIntents on creation.

Considering that docs strongly recommend using immutable intents[1] whenever there is no functionality that depends on the mutabibility of the intent, we decided to explicitly use IMMUTABLE from now on. Also it should be safe to use it also for Build.VERSION_CODES < R even though they were mutable by default.

[1] https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE