### PR TITLE
[HVR] Do not exit app when going back in immersive mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1099,14 +1099,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 onBackPressed();
                 return;
             }
-            // FIXME: remove this once https://github.com/hms-ecosystem/OpenXR-SDK/issues/43 is fixed
-            // HVR lifecycle is so broken that it isn't impossible to differentiate between exiting
-            // the security zone and the application being closed by pressing the right controller
-            // menu button. We detect the latter here and force the application to exit.
-            if (DeviceType.isHVRBuild()) {
-                finish();
-                return;
-            }
             dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
             dispatchKeyEvent(new KeyEvent (KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
         });

--- a/app/src/hvr/cpp/native-lib.cpp
+++ b/app/src/hvr/cpp/native-lib.cpp
@@ -145,6 +145,12 @@ JNI_METHOD(void, nativeOnPause)
   BrowserWorld::Instance().Pause();
 }
 
+JNI_METHOD(void, nativeOnStop)
+(JNIEnv *aEnv, jobject) {
+  LOGD("onStop");
+  sAppContext->mShouldExitRenderThread = BrowserWorld::Instance().WasButtonAppPressed();
+}
+
 JNI_METHOD(void, nativeOnResume)
 (JNIEnv *aEnv, jobject) {
   LOGD("onResume");

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -314,6 +314,7 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
     protected void onStop() {
         super.onStop();
         Log.i(TAG, "PlatformActivity onStop");
+        queueRunnable(this::nativeOnStop);
     }
 
     @Override
@@ -366,6 +367,7 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
     protected native void nativeOnCreate();
     protected native void nativeOnDestroy();
     protected native void nativeOnPause();
+    protected native void nativeOnStop();
     protected native void nativeOnResume();
     protected native void nativeOnSurfaceChanged(Surface surface);
     protected native void nativeOnSurfaceDestroyed();

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -74,6 +74,9 @@ public:
   void SetIsServo(const bool aIsServo);
   void SetCPULevel(const device::CPULevel aLevel);
   JNIEnv* GetJNIEnv() const;
+#if HVR
+  bool WasButtonAppPressed();
+#endif
 protected:
   struct State;
   static BrowserWorldPtr Create();


### PR DESCRIPTION
This is a regression of the patch that allowed Wolvic not to close when exiting the security zone. The menu button of the R controller was mapped to BUTTON_APP in order to properly detect it and exit the render loop. The problem is that BUTTON_APP is also used to simulate a back action. That's why clicking on the L menu button in immersive experiences was making Wolvic to exit instead of just closing the WebXR immersive session.

The solution is to keep track when the user presses that button and exit the application if we get the onStop call (we could also get the onStop call when exiting the security zone but in that case we won't get the button press, so we won't exit).