### PR TITLE
Add support for favicons

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -510,6 +510,7 @@ dependencies {
     implementation deps.android_components.browser_state
     implementation deps.android_components.browser_storage
     implementation deps.android_components.browser_domains
+    implementation deps.android_components.browser_icons
     implementation deps.android_components.service_accounts
     implementation deps.android_components.service_sync_logins
     implementation deps.android_components.mozilla_service_location

--- a/app/src/common/shared/com/igalia/wolvic/browser/components/BrowserIconsHelper.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/BrowserIconsHelper.kt
@@ -1,0 +1,39 @@
+package com.igalia.wolvic.browser.components
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.widget.ImageView
+import com.igalia.wolvic.browser.engine.EngineProvider
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.IconRequest
+
+// Small helper class to simplify getting favicons.
+object BrowserIconsHelper {
+
+    @SuppressLint("StaticFieldLeak")
+    private lateinit var browserIcons: BrowserIcons;
+
+    @JvmStatic
+    fun get(context: Context): BrowserIcons {
+        if (!::browserIcons.isInitialized) {
+            browserIcons =
+                BrowserIcons(context.applicationContext, EngineProvider.createClient(context))
+        }
+        return browserIcons
+    }
+
+    @JvmStatic
+    fun loadIntoView(
+        context: Context,
+        view: ImageView,
+        url: String,
+        size: IconRequest.Size = IconRequest.Size.DEFAULT
+    ) {
+        if (!::browserIcons.isInitialized) {
+            browserIcons =
+                BrowserIcons(context.applicationContext, EngineProvider.createClient(context))
+        }
+        val request = IconRequest(url, size, emptyList(), null, false)
+        browserIcons.loadIntoView(view, request, null, null)
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -53,7 +53,8 @@ public class SessionStore implements
 
     private static final List<Pair<String, String>> BUILTIN_WEB_EXTENSIONS = Arrays.asList(
             new Pair<>("fxr-webcompat_youtube@mozilla.org", "resource://android/assets/extensions/fxr_youtube/"),
-            new Pair<>("fxr-webcompat_mediasession@mozilla.org", "resource://android/assets/extensions/fxr_mediasession/")
+            new Pair<>("fxr-webcompat_mediasession@mozilla.org", "resource://android/assets/extensions/fxr_mediasession/"),
+            new Pair<>("icons@mozac.org", "resource://android/assets/extensions/browser-icons/")
     );
 
     private static SessionStore mInstance;

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/BookmarkAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/BookmarkAdapter.java
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.components.BrowserIconsHelper;
 import com.igalia.wolvic.databinding.BookmarkItemBinding;
 import com.igalia.wolvic.databinding.BookmarkItemFolderBinding;
 import com.igalia.wolvic.databinding.BookmarkSeparatorBinding;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 
 import mozilla.appservices.places.BookmarkRoot;
+import mozilla.components.browser.icons.IconRequest;
 import mozilla.components.concept.storage.BookmarkNode;
 import mozilla.components.concept.storage.BookmarkNodeType;
 
@@ -198,6 +200,10 @@ public class BookmarkAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             BookmarkItemBinding binding = bookmarkHolder.binding;
             binding.setItem(item);
             binding.setIsNarrow(mIsNarrowLayout);
+
+            // Load favicon
+            BrowserIconsHelper.loadIntoView(binding.favicon.getContext(), binding.favicon, item.getUrl(), IconRequest.Size.DEFAULT);
+
             binding.layout.setOnHoverListener((view, motionEvent) -> {
                 int ev = motionEvent.getActionMasked();
                 switch (ev) {

--- a/app/src/main/res/layout/bookmark_item.xml
+++ b/app/src/main/res/layout/bookmark_item.xml
@@ -55,20 +55,35 @@
                 android:addStatesFromChildren="true"
                 android:orientation="@{isNarrow ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}">
 
-                <TextView
-                    android:id="@+id/title"
-                    android:layout_width="match_parent"
+                <LinearLayout
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:ellipsize="middle"
-                    android:paddingEnd="20dp"
-                    android:scrollHorizontally="true"
-                    android:singleLine="true"
-                    android:text="@{item.title}"
-                    android:textColor="@color/library_panel_title_text_color"
-                    android:textSize="@dimen/library_item_title_text_size"
-                    android:textStyle="bold"
-                    tools:text="Item Title" />
+                    android:addStatesFromChildren="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <ImageView
+                        android:id="@+id/favicon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:paddingEnd="10dp"
+                        android:src="@drawable/ic_icon_globe" />
+
+                    <TextView
+                        android:id="@+id/title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:ellipsize="middle"
+                        android:paddingEnd="20dp"
+                        android:scrollHorizontally="true"
+                        android:singleLine="true"
+                        android:text="@{item.title}"
+                        android:textColor="@color/library_panel_title_text_color"
+                        android:textSize="@dimen/library_item_title_text_size"
+                        android:textStyle="bold"
+                        tools:text="Item Title" />
+                </LinearLayout>
 
                 <TextView
                     android:id="@+id/url"

--- a/versions.gradle
+++ b/versions.gradle
@@ -75,6 +75,7 @@ android_components.browser_search = "org.mozilla.components:browser-search:$vers
 android_components.browser_state = "org.mozilla.components:browser-state:$versions.android_components"
 android_components.browser_storage = "org.mozilla.components:browser-storage-sync:$versions.android_components"
 android_components.browser_domains = "org.mozilla.components:browser-domains:$versions.android_components"
+android_components.browser_icons = "org.mozilla.components:browser-icons:$versions.android_components"
 android_components.service_accounts = "org.mozilla.components:service-firefox-accounts:$versions.android_components"
 android_components.service_sync_logins = "org.mozilla.components:service-sync-logins:$versions.android_components"
 android_components.mozilla_service_location = "org.mozilla.components:service-location:${versions.android_components}"


### PR DESCRIPTION
This PR uses the [browser-icons](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/icons) component to store and display the favicons of the pages that we visit.

As a way to test that this functionality is working properly, this PR also adds favicons to bookmark items.