### PR TITLE
Add new favicons as we browse the Web

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/components/BrowserIconsHelper.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/BrowserIconsHelper.kt
@@ -1,38 +1,29 @@
 package com.igalia.wolvic.browser.components
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.widget.ImageView
 import com.igalia.wolvic.browser.engine.EngineProvider
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.Engine
 
 // Small helper class to simplify getting favicons.
-object BrowserIconsHelper {
+class BrowserIconsHelper(context: Context, engine: Engine, store: BrowserStore) {
 
-    @SuppressLint("StaticFieldLeak")
-    private lateinit var browserIcons: BrowserIcons;
+    private val browserIcons: BrowserIcons;
 
-    @JvmStatic
-    fun get(context: Context): BrowserIcons {
-        if (!::browserIcons.isInitialized) {
-            browserIcons =
-                BrowserIcons(context.applicationContext, EngineProvider.createClient(context))
-        }
-        return browserIcons
+    init {
+        browserIcons =
+            BrowserIcons(context.applicationContext, EngineProvider.createClient(context))
+        browserIcons.install(engine, store)
     }
 
-    @JvmStatic
     fun loadIntoView(
-        context: Context,
         view: ImageView,
         url: String,
         size: IconRequest.Size = IconRequest.Size.DEFAULT
     ) {
-        if (!::browserIcons.isInitialized) {
-            browserIcons =
-                BrowserIcons(context.applicationContext, EngineProvider.createClient(context))
-        }
         val request = IconRequest(url, size, emptyList(), null, false)
         browserIcons.loadIntoView(view, request, null, null)
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
@@ -6,20 +6,22 @@
 package com.igalia.wolvic.browser.components
 
 import android.content.Context
+import android.util.AttributeSet
 import com.igalia.wolvic.browser.api.*
 import com.igalia.wolvic.browser.engine.Session
 import com.igalia.wolvic.browser.engine.SessionStore
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate
-import mozilla.components.concept.engine.CancellableOperation
-import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.base.profiler.Profiler
+import mozilla.components.concept.engine.*
+import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.*
 import mozilla.components.support.ktx.kotlin.isResourceUrl
+import org.json.JSONObject
 
 class WolvicWebExtensionRuntime(
         private val context: Context,
         private val runtime: WRuntime
-): WebExtensionRuntime {
+) : WebExtensionRuntime, Engine {
 
     private var webExtensionDelegate: WebExtensionDelegate? = null
     private val webExtensionActionHandler = object : ActionHandler {
@@ -254,6 +256,35 @@ class WolvicWebExtensionRuntime(
             onError(throwable)
             WResult.create<Void>()
         })
+    }
+
+    // Functionality specific to the Engine interface.
+
+    override val profiler: Profiler?
+        get() = TODO("Not yet implemented")
+    override val settings: Settings
+        get() = TODO("Not yet implemented")
+    override val version: EngineVersion
+        get() = TODO("Not yet implemented")
+
+    override fun name(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun createSession(private: Boolean, contextId: String?): EngineSession {
+        TODO("Not yet implemented")
+    }
+
+    override fun createSessionState(json: JSONObject): EngineSessionState {
+        TODO("Not yet implemented")
+    }
+
+    override fun createView(context: Context, attrs: AttributeSet?): EngineView {
+        TODO("Not yet implemented")
+    }
+
+    override fun speculativeConnect(url: String) {
+        TODO("Not yet implemented")
     }
 
 }

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -21,6 +21,7 @@ import com.igalia.wolvic.browser.adapter.ComponentsAdapter;
 import com.igalia.wolvic.browser.api.WResult;
 import com.igalia.wolvic.browser.api.WRuntime;
 import com.igalia.wolvic.browser.api.WSession;
+import com.igalia.wolvic.browser.components.BrowserIconsHelper;
 import com.igalia.wolvic.browser.components.WolvicWebExtensionRuntime;
 import com.igalia.wolvic.browser.content.TrackingProtectionStore;
 import com.igalia.wolvic.browser.extensions.BuiltinExtension;
@@ -80,6 +81,7 @@ public class SessionStore implements
     private WolvicWebExtensionRuntime mWebExtensionRuntime;
     private FxaWebChannelFeature mWebChannelsFeature;
     private Store.Subscription mStoreSubscription;
+    private BrowserIconsHelper mBrowserIconsHelper;
 
     private SessionStore() {
         mSessions = new ArrayList<>();
@@ -119,13 +121,15 @@ public class SessionStore implements
 
         mWebExtensionRuntime = new WolvicWebExtensionRuntime(mContext, mRuntime);
 
-        mServices = ((VRBrowserApplication)context.getApplicationContext()).getServices();
+        mServices = ((VRBrowserApplication) context.getApplicationContext()).getServices();
 
         mBookmarksStore = new BookmarksStore(context);
         mHistoryStore = new HistoryStore(context);
 
         // Web Extensions initialization
         BUILTIN_WEB_EXTENSIONS.forEach(extension -> BuiltinExtension.install(mWebExtensionRuntime, extension.first, extension.second));
+        mBrowserIconsHelper = new BrowserIconsHelper(context, mWebExtensionRuntime, ComponentsAdapter.get().getStore());
+
         WebCompatFeature.INSTANCE.install(mWebExtensionRuntime);
         WebCompatReporterFeature.INSTANCE.install(mWebExtensionRuntime, context.getString(R.string.app_name));
         mWebChannelsFeature = new FxaWebChannelFeature(
@@ -380,8 +384,13 @@ public class SessionStore implements
         return mWebExtensionRuntime;
     }
 
+    @NonNull
+    public BrowserIconsHelper getBrowserIcons() {
+        return mBrowserIconsHelper;
+    }
+
     public void purgeSessionHistory() {
-        for (Session session: mSessions) {
+        for (Session session : mSessions) {
             session.purgeHistory();
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/BookmarkAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/BookmarkAdapter.java
@@ -15,7 +15,7 @@ import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.igalia.wolvic.R;
-import com.igalia.wolvic.browser.components.BrowserIconsHelper;
+import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.BookmarkItemBinding;
 import com.igalia.wolvic.databinding.BookmarkItemFolderBinding;
 import com.igalia.wolvic.databinding.BookmarkSeparatorBinding;
@@ -202,7 +202,7 @@ public class BookmarkAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             binding.setIsNarrow(mIsNarrowLayout);
 
             // Load favicon
-            BrowserIconsHelper.loadIntoView(binding.favicon.getContext(), binding.favicon, item.getUrl(), IconRequest.Size.DEFAULT);
+            SessionStore.get().getBrowserIcons().loadIntoView(binding.favicon, item.getUrl(), IconRequest.Size.DEFAULT);
 
             binding.layout.setOnHoverListener((view, motionEvent) -> {
                 int ev = motionEvent.getActionMasked();


### PR DESCRIPTION
Link the `BrowserIcons` instance with its associated extension, so the list of known favicons can be updated as we browser the Web.

This change required adding the `Engine` interface to `WolvicWebExtensionRuntime` so we can call `BrowserIcons.install()`.

`Engine` inherits from `WebExtensionRuntime`, which is what ` WolvicWebExtensionRuntime` implements. Unfortunately, the component's API requires an instance of the child interface, even if it does not actually use any functionality that is specific to it.