### PR TITLE
Fix a crash when entering private mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -588,6 +588,12 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         }
     }
 
+    private void closeLibraryPanelInFocusedWindowIfNeeded() {
+        if (!mFocusedWindow.isLibraryVisible())
+            return;
+        mFocusedWindow.switchPanel(NONE);
+    }
+
     public void enterPrivateMode() {
         if (mPrivateMode) {
             return;
@@ -596,7 +602,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         if (mFocusedWindow != null) {
             mRegularWindowPlacement = mFocusedWindow.getWindowPlacement();
-
+            // Make sure we close the library before entering private mode. Otherwise we would
+            // get a EGL crash in Gecko.
+            closeLibraryPanelInFocusedWindowIfNeeded();
         } else {
             mRegularWindowPlacement = WindowPlacement.FRONT;
         }
@@ -639,7 +647,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         if (mFocusedWindow != null) {
             mPrivateWindowPlacement = mFocusedWindow.getWindowPlacement();
-
+            // Make sure we close the library before exiting private mode. Otherwise we would
+            // get a EGL crash in Gecko.
+            closeLibraryPanelInFocusedWindowIfNeeded();
         } else {
             mPrivateWindowPlacement = WindowPlacement.FRONT;
         }


### PR DESCRIPTION
Gecko was crashing when calling eglCreateWindowSurface whenever private mode was started if the current window had the library panel opened.

E/libEGL: eglCreateWindowSurface: native_window_api_connect (win=0x74b4d72010) failed (0xffffffed) (already connected to another API?) E/libEGL: eglCreateWindowSurfaceTmpl:750 error 3003 (EGL_BAD_ALLOC) E/libEGL: call to OpenGL ES API with no current context (logged once per thread)

In order to circumvent that we're closing the library panel before opening the private window, and showing it again just after leaving the private session.

This fixes #315