### PR TITLE
Experiment: copy downloaded file to public folder and insert in MediaStore

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -2,23 +2,31 @@ package com.igalia.wolvic.downloads;
 
 import android.app.DownloadManager;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.MediaStore;
+import android.util.Log;
 import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.utils.UrlUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
@@ -96,6 +104,7 @@ public class DownloadsManager {
         }
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.Q)
     public void startDownload(@NonNull DownloadJob job) {
         if (!URLUtil.isHttpUrl(job.getUri()) && !URLUtil.isHttpsUrl(job.getUri())) {
             notifyDownloadError(mContext.getString(R.string.download_error_protocol), job.getFilename());
@@ -222,7 +231,13 @@ public class DownloadsManager {
                 if (c != null) {
                     if (c.moveToFirst()) {
                         notifyDownloadsUpdate();
-                        notifyDownloadCompleted(Download.from(c));
+                        Download download = Download.from(c);
+                        notifyDownloadCompleted(download);
+
+                        // Copy the downloaded file to the public Downloads folder.
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            copyToDownloadsFolder(download);
+                        }
                     }
                     c.close();
                 }
@@ -230,10 +245,64 @@ public class DownloadsManager {
         }
     };
 
+    @RequiresApi(api = Build.VERSION_CODES.Q)
+    private void copyToDownloadsFolder(Download download) {
+        Log.e(LOGTAG, "************************ copyToDownloadsFolder ************************");
+        Log.e(LOGTAG, "DISPLAY_NAME : " + download.getFilename());
+        Log.e(LOGTAG, "EXTERNAL_CONTENT_URI : " + MediaStore.Downloads.EXTERNAL_CONTENT_URI);
+        Log.e(LOGTAG, "MIME_TYPE : " + download.getMediaType());
+        Log.e(LOGTAG, "SIZE : " + download.getSizeBytes());
+        Log.e(LOGTAG, "OutputFilePath : " + download.getOutputFilePath());
+
+        // Create a new entry for the Downloads table in MediaStore.
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(MediaStore.Downloads.DISPLAY_NAME, download.getFilename());
+        contentValues.put(MediaStore.Downloads.SIZE, download.getSizeBytes());
+        contentValues.put(MediaStore.Downloads.MIME_TYPE, download.getMediaType());
+        contentValues.put(MediaStore.Downloads.DATE_MODIFIED, download.getLastModified());
+        String mime = mDownloadManager.getMimeTypeForDownloadedFile(download.getId());
+        contentValues.put(MediaStore.Downloads.MIME_TYPE, mime);
+        contentValues.put(MediaStore.Downloads.DOWNLOAD_URI, download.getUri());
+
+        // This flag indicates that the file is not yet ready.
+        contentValues.put(MediaStore.Downloads.IS_PENDING, 1);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            contentValues.put(MediaStore.Downloads.IS_DRM, 0);
+        }
+
+        Log.e(LOGTAG, "Inserting : " + contentValues);
+
+        ContentResolver contentResolver = mContext.getContentResolver();
+        Uri uri = contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues);
+
+        Log.e(LOGTAG, "Inserted URI : " + uri);
+
+        // This URI can be accessed from the console:
+        //     adb shell content query --uri content://media/external/downloads/362
+
+        try {
+            File file = new File(download.getOutputFilePath());
+            Log.e(LOGTAG, "Source file : " + file);
+
+            Log.e(LOGTAG, "Copying to : " + uri);
+            Files.copy(file.toPath(), contentResolver.openOutputStream(uri));
+
+            // The file is finally ready.
+            Log.e(LOGTAG, "Updating IS_PENDING");
+            contentValues.put(MediaStore.Downloads.IS_PENDING, 0);
+            contentResolver.update(uri, contentValues, null, null);
+
+            Log.e(LOGTAG, "************************ Done! ************************");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     private void notifyDownloadsUpdate() {
         List<Download> downloads = getDownloads();
         int filter = Download.RUNNING | Download.PAUSED | Download.PENDING;
-        boolean activeDownloads = downloads.stream().filter(d -> (d.getStatus() & filter) != 0).count()  > 0;
+        boolean activeDownloads = downloads.stream().filter(d -> (d.getStatus() & filter) != 0).count() > 0;
         mListeners.forEach(listener -> listener.onDownloadsUpdate(downloads));
         if (!activeDownloads) {
             stopUpdates();


### PR DESCRIPTION
This PR copies the downloaded file to the public `Downloads` folder and inserts a new entry in the `MediaStore`.

The remote file is saved in:

```
 /storage/emulated/0/Android/data/com.igalia.wolvic/files/Download/ 
```

Then, we insert a new entry in the Downloads table of the MediaStore (content URI: `content://media/external/downloads`) and open a new stream to that URI so we can copy the downloaded file.

The results of the above operation can be verified with `adb` by checking that a new file has been opened in the public folder:

```
    adb shell ls -lh /storage/emulated/0/Download
```

And a new entry has been added to `MediaStore` at the URI that we created:

```
    adb shell content query --uri content://media/external/downloads/361

```