### PR TITLE
Parse and store Web apps

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -917,4 +917,13 @@ public class SettingsStore {
         return mPrefs.getBoolean(mContext.getString(R.string.settings_key_privacy_policy_accepted), false);
     }
 
+    public void setWebAppsData(String aWebAppsData) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putString(mContext.getString(R.string.settings_key_web_apps_data), aWebAppsData);
+        editor.commit();
+    }
+
+    public String getWebAppsData() {
+        return mPrefs.getString(mContext.getString(R.string.settings_key_web_apps_data), "");
+    }
 }

--- a/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
@@ -1,0 +1,131 @@
+package com.igalia.wolvic.browser;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.gson.Gson;
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.ui.adapters.WebApp;
+import com.igalia.wolvic.utils.StringUtils;
+import com.igalia.wolvic.utils.SystemUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class WebAppsStore implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    protected final String LOGTAG = SystemUtils.createLogtag(this.getClass());
+
+    private Context mContext;
+    private List<WebApp> mWebApps;
+    private Set<WebAppsListener> mListeners;
+    private SharedPreferences mPrefs;
+
+    public WebAppsStore(Context context) {
+        mContext = context.getApplicationContext();
+        mWebApps = new ArrayList<>();
+        mListeners = new LinkedHashSet<>();
+
+        mPrefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        mPrefs.registerOnSharedPreferenceChangeListener(this);
+
+        mWebApps = new ArrayList<>();
+        updateWebAppsListFromStorage();
+    }
+
+    private void updateWebAppsListFromStorage() {
+        String json = SettingsStore.getInstance(mContext).getWebAppsData();
+
+        if (StringUtils.isEmpty(json)) {
+            mWebApps.clear();
+            notifyListeners();
+        } else {
+            try {
+                Gson gson = new Gson();
+                WebApp[] webAppsArray = gson.fromJson(json, WebApp[].class);
+                mWebApps.clear();
+                mWebApps.addAll(Arrays.asList(webAppsArray));
+                notifyListeners();
+            } catch (RuntimeException e) {
+                Log.w(LOGTAG, "retrieveListFromStorage: error parsing stored data: " + e.getMessage());
+
+                // the stored data is invalid, so we need to clear it
+                SettingsStore.getInstance(mContext).setWebAppsData("");
+                mWebApps.clear();
+                notifyListeners();
+            }
+        }
+    }
+
+    private void saveWebAppsListToStorage() {
+        Gson gson = new Gson();
+        WebApp[] webAppsArray = mWebApps.toArray(new WebApp[]{});
+        String json = gson.toJson(webAppsArray, WebApp[].class);
+        SettingsStore.getInstance(mContext).setWebAppsData(json);
+    }
+
+    /**
+     * @return {@code true} if the list did not already contain the specified Web app,
+     * {@code false} if the Web app was already in the list (in which case, it was updated).
+     */
+    public boolean addWebApp(@NonNull WebApp webAppToAdd) {
+        for (WebApp webApp : mWebApps) {
+            if (webApp.getId().equals(webAppToAdd.getId())) {
+                // the Web app is already in the list, we update it
+                webApp.copyFrom(webAppToAdd);
+                notifyListeners();
+                return false;
+            }
+        }
+        mWebApps.add(webAppToAdd);
+        notifyListeners();
+        return true;
+    }
+
+    /**
+     * @return {@code true} if any elements were removed
+     */
+    public void removeWebApp(@NonNull WebApp webAppToDelete) {
+        mWebApps.removeIf(webApp -> webApp.getId().equals(webAppToDelete.getId()));
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (key.equals(mContext.getString(R.string.settings_key_web_apps_data))) {
+            updateWebAppsListFromStorage();
+        }
+    }
+
+    public interface WebAppsListener {
+        void onWebAppsUpdated(List<WebApp> webApps);
+    }
+
+    public void addListener(@NonNull WebAppsListener listener) {
+        mListeners.add(listener);
+    }
+
+    public void removeListener(@NonNull WebAppsListener listener) {
+        mListeners.remove(listener);
+    }
+
+    private void notifyListeners() {
+        List<WebAppsListener> listenersCopy = new ArrayList(mListeners);
+        List<WebApp> webAppsCopy = Collections.unmodifiableList(mWebApps);
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(() -> {
+            for (WebAppsListener listener : listenersCopy) {
+                listener.onWebAppsUpdated(webAppsCopy);
+            }
+        });
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
@@ -44,27 +44,22 @@ public class WebAppsStore implements SharedPreferences.OnSharedPreferenceChangeL
     }
 
     private void updateWebAppsListFromStorage() {
-        String json = SettingsStore.getInstance(mContext).getWebAppsData();
+        mWebApps.clear();
 
-        if (StringUtils.isEmpty(json)) {
-            mWebApps.clear();
-            notifyListeners();
-        } else {
+        String json = SettingsStore.getInstance(mContext).getWebAppsData();
+        if (!StringUtils.isEmpty(json)) {
             try {
                 Gson gson = new Gson();
                 WebApp[] webAppsArray = gson.fromJson(json, WebApp[].class);
-                mWebApps.clear();
                 mWebApps.addAll(Arrays.asList(webAppsArray));
-                notifyListeners();
             } catch (RuntimeException e) {
                 Log.w(LOGTAG, "retrieveListFromStorage: error parsing stored data: " + e.getMessage());
 
                 // the stored data is invalid, so we need to clear it
                 SettingsStore.getInstance(mContext).setWebAppsData("");
-                mWebApps.clear();
-                notifyListeners();
             }
         }
+        notifyListeners();
     }
 
     private void saveWebAppsListToStorage() {

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1079,7 +1079,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         }
 
         // TODO Check that this is the correct place to clear the stored manifest. Update the UI if needed.
-        Log.d(LOGTAG, "OnLocationChange: clear stored Web app manifest");
+        Log.d(LOGTAG, "onLocationChange: clear stored Web app manifest");
         mState.mWebAppManifest = null;
 
         // The homepage finishes loading after the region has been updated

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -46,11 +46,15 @@ import com.igalia.wolvic.browser.content.TrackingProtectionPolicy;
 import com.igalia.wolvic.browser.content.TrackingProtectionStore;
 import com.igalia.wolvic.geolocation.GeolocationData;
 import com.igalia.wolvic.telemetry.TelemetryService;
+import com.igalia.wolvic.ui.adapters.WebApp;
 import com.igalia.wolvic.utils.BitmapCache;
 import com.igalia.wolvic.utils.InternalPages;
 import com.igalia.wolvic.utils.SystemUtils;
 import com.igalia.wolvic.utils.UrlUtils;
 
+import org.json.JSONObject;
+
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -953,6 +957,10 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         return mState.mDrmState;
     }
 
+    public WebApp getWebAppManifest() {
+        return mState.mWebAppManifest;
+    }
+
     // Session Settings
 
     public int getUaMode() {
@@ -1069,6 +1077,10 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         for (WSession.NavigationDelegate listener : mNavigationListeners) {
             listener.onLocationChange(aSession, aUri);
         }
+
+        // TODO Check that this is the correct place to clear the stored manifest. Update the UI if needed.
+        Log.d(LOGTAG, "OnLocationChange: clear stored Web app manifest");
+        mState.mWebAppManifest = null;
 
         // The homepage finishes loading after the region has been updated
         if (mState.mRegion != null && aUri.equalsIgnoreCase(SettingsStore.getInstance(mContext).getHomepage())) {
@@ -1331,6 +1343,23 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         if (mState.mSession == aSession) {
             for (WSession.ContentDelegate listener : mContentListeners) {
                 listener.onFirstContentfulPaint(aSession);
+            }
+        }
+    }
+
+    @Override
+    public void onWebAppManifest(@NonNull WSession aSession, @NonNull JSONObject manifest) {
+        if (mState.mSession == aSession) {
+            try {
+                mState.mWebAppManifest = new WebApp(manifest);
+                Log.d(LOGTAG, "onWebAppManifest: received Web app manifest");
+            } catch (IOException e) {
+                Log.w(LOGTAG, "onWebAppManifest: malformed Web app manifest: " + e.getMessage());
+                mState.mWebAppManifest = null;
+            }
+
+            for (WSession.ContentDelegate listener : mContentListeners) {
+                listener.onWebAppManifest(aSession, manifest);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionState.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionState.java
@@ -14,6 +14,7 @@ import com.igalia.wolvic.browser.Media;
 import com.igalia.wolvic.browser.api.WDisplay;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.api.WSessionState;
+import com.igalia.wolvic.ui.adapters.WebApp;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,6 +49,7 @@ public class SessionState {
     public String mUri = "";
     public String mPreviousUri;
     public String mTitle = "";
+    public transient WebApp mWebAppManifest;
     public transient boolean mFullScreen;
     public transient boolean mInKioskMode;
     public transient WSession mSession;

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -17,6 +17,7 @@ import com.igalia.wolvic.browser.HistoryStore;
 import com.igalia.wolvic.browser.PermissionDelegate;
 import com.igalia.wolvic.browser.Services;
 import com.igalia.wolvic.browser.SessionChangeListener;
+import com.igalia.wolvic.browser.WebAppsStore;
 import com.igalia.wolvic.browser.adapter.ComponentsAdapter;
 import com.igalia.wolvic.browser.api.WResult;
 import com.igalia.wolvic.browser.api.WRuntime;
@@ -74,6 +75,7 @@ public class SessionStore implements
     private PermissionDelegate mPermissionDelegate;
     private BookmarksStore mBookmarksStore;
     private HistoryStore mHistoryStore;
+    private WebAppsStore mWebAppStore;
     private Services mServices;
     private boolean mSuspendPending;
     private TrackingProtectionStore mTrackingProtectionStore;
@@ -123,6 +125,7 @@ public class SessionStore implements
 
         mBookmarksStore = new BookmarksStore(context);
         mHistoryStore = new HistoryStore(context);
+        mWebAppStore = new WebAppsStore(context);
 
         // Web Extensions initialization
         BUILTIN_WEB_EXTENSIONS.forEach(extension -> BuiltinExtension.install(mWebExtensionRuntime, extension.first, extension.second));
@@ -370,6 +373,10 @@ public class SessionStore implements
 
     public HistoryStore getHistoryStore() {
         return mHistoryStore;
+    }
+
+    public WebAppsStore getWebAppsStore() {
+        return mWebAppStore;
     }
 
     public TrackingProtectionStore getTrackingProtectionStore() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
@@ -42,7 +42,7 @@ public class WebApp {
     // TODO icons, shortcuts, languages
 
     /**
-     * Will throw {@link java.io.IOException} if there is an error parsing the manifest.
+     * @throws java.io.IOException if there is an error parsing the manifest.
      */
     public WebApp(JSONObject manifest) throws IOException {
         mStartUrl = manifest.optString("start_url");

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
@@ -1,0 +1,163 @@
+package com.igalia.wolvic.ui.adapters;
+
+import android.graphics.Color;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.igalia.wolvic.utils.StringUtils;
+import com.igalia.wolvic.utils.SystemUtils;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+/**
+ * Parses and encapsulates (a subset of) the fields in a Web App manifest.
+ * See https://www.w3.org/TR/appmanifest/ for reference.
+ */
+public class WebApp {
+
+    protected final String LOGTAG = SystemUtils.createLogtag(this.getClass());
+
+    @NonNull
+    private String mIdentity;
+    @NonNull
+    private String mName;
+    @NonNull
+    private String mShortName;
+    @NonNull
+    private String mScope;
+    @NonNull
+    private String mStartUrl;
+
+    private int mThemeColor;
+    private int mBackgroundColor;
+
+    private OptionalInt mHashCode = OptionalInt.empty();
+
+    // TODO icons, shortcuts, languages
+
+    /**
+     * Will throw {@link java.io.IOException} if there is an error parsing the manifest.
+     */
+    public WebApp(JSONObject manifest) throws IOException {
+        mStartUrl = manifest.optString("start_url");
+        mName = manifest.optString("name");
+        mShortName = manifest.optString("short_name");
+        mScope = manifest.optString("scope");
+
+        int themeColor = Color.TRANSPARENT;
+        try {
+            String themeColorString = manifest.optString("theme_color");
+            themeColor = Color.parseColor(themeColorString);
+        } catch (IllegalArgumentException e) {
+            Log.w(LOGTAG, "Invalid theme_color value");
+        }
+        mThemeColor = themeColor;
+
+        int backgroundColor = Color.TRANSPARENT;
+        try {
+            String backgroundColorString = manifest.optString("background_color");
+            backgroundColor = Color.parseColor(backgroundColorString);
+        } catch (IllegalArgumentException e) {
+            Log.w(LOGTAG, "Invalid background_color value");
+        }
+        mBackgroundColor = backgroundColor;
+
+        // Algorithm for calculating Identity at https://www.w3.org/TR/appmanifest/#id-member
+        if (!StringUtils.isEmpty(mStartUrl)) {
+            URL startUrl = new URL(mStartUrl);
+            String id = manifest.optString("id");
+            URL identityUrl = new URL(startUrl.getProtocol(), startUrl.getHost(), startUrl.getPort(), id);
+            mIdentity = identityUrl.toString();
+        } else {
+            // Since Identity is used to uniquely identify the Web application,
+            // we treat its absence as an error.
+            throw new IOException("Unable to assign an identity to the Web App manifest");
+        }
+    }
+
+    @NonNull
+    public String getId() {
+        return mIdentity;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public String getShortName() {
+        return mShortName;
+    }
+
+    public String getScope() {
+        return mScope;
+    }
+
+    public String getStartUrl() {
+        return mStartUrl;
+    }
+
+    public int getThemeColor() {
+        return mThemeColor;
+    }
+
+    public int getBackgroundColor() {
+        return mBackgroundColor;
+    }
+
+    public void copyFrom(WebApp webApp) {
+        mIdentity = webApp.mIdentity;
+        mName = webApp.mName;
+        mShortName = webApp.mShortName;
+        mScope = webApp.mScope;
+        mStartUrl = webApp.mStartUrl;
+        mThemeColor = webApp.mThemeColor;
+        mBackgroundColor = webApp.mBackgroundColor;
+
+        mHashCode = OptionalInt.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        WebApp webApp = (WebApp) o;
+        return mIdentity.equals(webApp.mIdentity) &&
+                mName.equals(webApp.mName) &&
+                mShortName.equals(webApp.mShortName) &&
+                mScope.equals(webApp.mScope) &&
+                mStartUrl.equals(webApp.mStartUrl) &&
+                mThemeColor == webApp.mThemeColor &&
+                mBackgroundColor == webApp.mBackgroundColor;
+    }
+
+    @Override
+    public int hashCode() {
+        if (!mHashCode.isPresent()) {
+            mHashCode = OptionalInt.of(
+                    Objects.hash(mIdentity, mName, mShortName, mScope, mStartUrl, mThemeColor, mBackgroundColor));
+        }
+        return mHashCode.getAsInt();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "WebApp{" +
+                "mIdentity='" + mIdentity + '\'' +
+                ", mName='" + mName + '\'' +
+                ", mShortName='" + mShortName + '\'' +
+                ", mScope='" + mScope + '\'' +
+                ", mStartUrl='" + mStartUrl + '\'' +
+                ", mThemeColor='" + mThemeColor + '\'' +
+                ", mBackgroundColor='" + mBackgroundColor + '\'' +
+                '}';
+    }
+}

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -216,4 +216,7 @@
     <string name="hvr_learn_more_url" translatable="false">https://consumer.huawei.com/cn/wearables/vr-glass/</string>
     <string name="landing_page_url" translatable="false">https://wolvic.com/en/welcome/</string>
 
+    <!-- Shared preferences key to store the list of installed Web apps (JSON string) -->
+    <string name="settings_key_web_apps_data" translatable="false">settings_key_web_apps_data</string>
+
 </resources>


### PR DESCRIPTION
When the current website contains a link to a Web app manifest, we will receive this manifest (in JSON format) at Session.onWebAppManifest().

The manifest describing a Web app for the current website is encapsulated in a WebApp object and stored in SessionState.

The user can keep a list of installed Web apps. This list is saved in the shared preferences in JSON format. The WebAppsStore class can be used to access and modify this list.

An instance of WebAppsStore is kept in SessionStore.