### PR TITLE
[OpenXR] Add plumbing to retrieve hand joint locations and aim state  

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -106,7 +106,7 @@ if(OPENXR)
                 )
     elseif (HVR)
         include_directories(
-                ${CMAKE_SOURCE_DIR}/../third_party/hvr/include
+                ${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK/include
                 ${CMAKE_SOURCE_DIR}/../app/src/openxr/cpp
         )
         add_custom_command(TARGET native-lib POST_BUILD

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -4,6 +4,10 @@
     <uses-feature android:name="android.hardware.vr.headtracking" android:version="1" android:required="${headtrackingRequired}" />
     <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
     <uses-permission android:name="${permissionToRemove}" tools:node="remove" />
+
+    <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+    <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
+
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -6,6 +6,9 @@ namespace crow {
 std::unordered_set<std::string> OpenXRExtensions::sSupportedExtensions { };
 PFN_xrGetOpenGLESGraphicsRequirementsKHR OpenXRExtensions::sXrGetOpenGLESGraphicsRequirementsKHR = nullptr;
 PFN_xrCreateSwapchainAndroidSurfaceKHR OpenXRExtensions::sXrCreateSwapchainAndroidSurfaceKHR = nullptr;
+PFN_xrCreateHandTrackerEXT OpenXRExtensions::sXrCreateHandTrackerEXT = nullptr;
+PFN_xrDestroyHandTrackerEXT OpenXRExtensions::sXrDestroyHandTrackerEXT = nullptr;
+PFN_xrLocateHandJointsEXT OpenXRExtensions::sXrLocateHandJointsEXT = nullptr;
 
 void OpenXRExtensions::Initialize() {
     uint32_t extensionCount { 0 };
@@ -30,6 +33,14 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
       CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreateSwapchainAndroidSurfaceKHR",
                                         reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreateSwapchainAndroidSurfaceKHR)));
   }
+    if (IsExtensionSupported(XR_EXT_HAND_TRACKING_EXTENSION_NAME)) {
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreateHandTrackerEXT",
+                                        reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreateHandTrackerEXT)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrDestroyHandTrackerEXT",
+                                        reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyHandTrackerEXT)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrLocateHandJointsEXT",
+                                        reinterpret_cast<PFN_xrVoidFunction *>(&sXrLocateHandJointsEXT)));
+    }
 }
 
 bool OpenXRExtensions::IsExtensionSupported(const char* name) {

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -17,6 +17,11 @@ namespace crow {
 
     static PFN_xrGetOpenGLESGraphicsRequirementsKHR sXrGetOpenGLESGraphicsRequirementsKHR;
     static PFN_xrCreateSwapchainAndroidSurfaceKHR sXrCreateSwapchainAndroidSurfaceKHR;
+
+    // hand tracking extension prototypes
+    static PFN_xrCreateHandTrackerEXT sXrCreateHandTrackerEXT;
+    static PFN_xrDestroyHandTrackerEXT sXrDestroyHandTrackerEXT;
+    static PFN_xrLocateHandJointsEXT sXrLocateHandJointsEXT;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
   };

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -40,6 +40,7 @@ private:
     XrResult applyHapticFeedback(XrAction, XrDuration, float = XR_FREQUENCY_UNSPECIFIED, float = 0.0) const;
     XrResult stopHapticFeedback(XrAction) const;
     void UpdateHaptics(ControllerDelegate&);
+    bool GetHandTrackingInfo(const XrFrameState&, XrSpace);
 
     XrInstance mInstance { XR_NULL_HANDLE };
     XrSession mSession { XR_NULL_HANDLE };
@@ -63,6 +64,11 @@ private:
     bool squeezeActionStarted { false };
     std::vector<float> axesContainer;
     crow::ElbowModelPtr elbow;
+    XrHandTrackerEXT mHandTracker { XR_NULL_HANDLE };
+    std::array<XrHandJointLocationEXT, XR_HAND_JOINT_COUNT_EXT> mHandJoints;
+    bool mHasHandJoints { false };
+    XrHandTrackingAimStateFB mAimState { XR_TYPE_HAND_TRACKING_AIM_STATE_FB };
+    bool mHasAimState { false };
 
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);


### PR DESCRIPTION
This mini-series sets the stage for hand tracking support on the OpenXR backend.

It detects support for the needed extensions, load pointers to the prototypes, and add a method to retrieve hand joints and aim state.

It also makes HVR backend use the newer, standalone OpenXR headers in the third_party repo, instead of those shipped along with the SDK. This is to avoid wrapping all hand tracking code with ifdefs, since the headers in HVR SDK are old enough to not include the symbols.

In the case of Oculus, a snipped is added to the Android Manifest to enable access to the hand tracking APIs. 