### PR TITLE
Migrate from old set-output to github environment files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,12 @@ jobs:
 
       # Inspired by https://stackoverflow.com/questions/60679609/github-action-to-simply-cat-a-file-to-an-output
       - name: Read wolvic third parties SHA
-        id: getsha
-        run: echo "::set-output name=sha::$(cat third_party_hash)"
+        run: echo "third_party_sha=$(cat third_party_hash)" >> $GITHUB_ENV
 
       - name: Checkout third parties
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.getsha.outputs.sha }}
+          ref: ${{ env.third_party_sha }}
           repository: Igalia/wolvic-third-parties
           token: ${{ secrets.THIRD_PARTY_PAT }}
           path: 'third_party'


### PR DESCRIPTION
The checkout third_party step in our CI was issuing this warning

> Warning: The `set-output` command is deprecated and will be disabled soon.
> Please upgrade to using Environment Files. For more information see:
> https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

So that's basically what we're doing here.