### PR TITLE
OpenXR: Add vertical flip to equirect layers on Oculus

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -144,6 +144,9 @@ struct DeviceDelegateOpenXR::State {
     if (OpenXRExtensions::IsExtensionSupported(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME)) {
       extensions.push_back(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME);
     }
+    if (OpenXRExtensions::IsExtensionSupported(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME)) {
+      extensions.push_back(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME);
+    }
 #endif
 
 
@@ -1043,7 +1046,13 @@ DeviceDelegateOpenXR::CreateLayerEquirect(const VRLayerPtr &aSource) {
   if (m.equirectLayer) {
     m.equirectLayer->Destroy();
   }
-  m.equirectLayer = OpenXRLayerEquirect::Create(result, source);
+  bool verticalFlip = false;
+#ifdef OCULUSVR
+    if (OpenXRExtensions::IsExtensionSupported(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME)) {
+        verticalFlip = true;
+    }
+#endif
+  m.equirectLayer = OpenXRLayerEquirect::Create(result, source, verticalFlip);
   if (m.session != XR_NULL_HANDLE) {
     vrb::RenderContextPtr context = m.context.lock();
     m.equirectLayer->Init(m.javaContext->env, m.session, context);

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -152,10 +152,11 @@ OpenXRLayerCube::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClear
 // OpenXRLayerEquirect;
 
 OpenXRLayerEquirectPtr
-OpenXRLayerEquirect::Create(const VRLayerEquirectPtr& aLayer, const OpenXRLayerPtr& aSourceLayer) {
+OpenXRLayerEquirect::Create(const VRLayerEquirectPtr& aLayer, const OpenXRLayerPtr& aSourceLayer, bool aVerticalFlip) {
   auto result = std::make_shared<OpenXRLayerEquirect>();
   result->layer = aLayer;
   result->sourceLayer = aSourceLayer;
+  result->mVerticalFlip = aVerticalFlip;
   return result;
 }
 
@@ -166,8 +167,14 @@ OpenXRLayerEquirect::Init(JNIEnv * aEnv, XrSession session, vrb::RenderContextPt
     return;
   }
   swapchain = source->GetSwapChain();
+  if (mVerticalFlip) {
+      mLayerImageLayout.type = XR_TYPE_COMPOSITION_LAYER_IMAGE_LAYOUT_FB;
+      mLayerImageLayout.flags = XR_COMPOSITION_LAYER_IMAGE_LAYOUT_VERTICAL_FLIP_BIT_FB;
+      mLayerImageLayout.next = XR_NULL_HANDLE;
+  }
   for (auto& xrLayer: xrLayers) {
     xrLayer = {XR_TYPE_COMPOSITION_LAYER_EQUIRECT_KHR};
+    xrLayer.next = mVerticalFlip ? &mLayerImageLayout : XR_NULL_HANDLE;
   }
   OpenXRLayerBase<VRLayerEquirectPtr, XrCompositionLayerEquirectKHR>::Init(aEnv, session, aContext);
 }

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -336,11 +336,15 @@ public:
   std::weak_ptr<OpenXRLayer> sourceLayer;
 
   static OpenXRLayerEquirectPtr
-  Create(const VRLayerEquirectPtr &aLayer, const OpenXRLayerPtr &aSourceLayer);
+  Create(const VRLayerEquirectPtr &aLayer, const OpenXRLayerPtr &aSourceLayer, bool aVerticalFlip);
   void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
   void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
   void Destroy() override;
   bool IsDrawRequested() const override;
+
+protected:
+  XrCompositionLayerImageLayoutFB mLayerImageLayout;
+  bool mVerticalFlip;
 };
 
 }


### PR DESCRIPTION
Immersive videos are currently shown upside down on Oculus with OpenXR backend.

This patch uses XR_FB_composition_layer_image_layout extension to flip the videos vertically.

Fixes https://github.com/Igalia/wolvic/issues/67