### PR TITLE
[OVR] Move OVR user entitlement out of DeviceDelegateOculusVR

### DIFF
--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -93,6 +93,9 @@ protected:
   void CreateSkyBox(const std::string& aBasePath, const std::string& aExtension);
   void CreateEnvironment();
 private:
+#if defined(OCULUSVR) && STORE_BUILD == 1
+  void ProcessOVRPlatformEvents();
+#endif
   State& m;
   BrowserWorld() = delete;
   VRB_NO_DEFAULTS(BrowserWorld)


### PR DESCRIPTION
It was previously located in the OVR device delegate, however that is not the optimal location for that code because the 
OVR platform initialization has to be done as well in the case of having a OpenXR based store build. That is not the case at 
the moment, but we'll eventually release an OpenXR based Meta version of Wolvic.

That's why we're moving that code to BrowserWorld, guarded by a couple of flags so that we could later build OpenXR 
based store versions with user entitlement. Also from now on, we are only doing the entitlement for store builds as there 
is no point in doing it for non-store builds.