### PR TITLE
Hide navigation bar after VR video if needed

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -806,7 +806,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         }
         AnimationHelper.fadeOut(mBinding.navigationBarMenu.resizeModeContainer, 0, () -> onWidgetUpdate(mAttachedWindow));
         mWidgetManager.popBackHandler(mResizeBackHandler);
-        mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isFullScreen());
+        mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isFullScreen() || !mAttachedWindow.isKioskMode());
         closeFloatingMenus();
 
         if (aResizeAction == ResizeAction.KEEP_SIZE) {
@@ -888,10 +888,11 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         closeFloatingMenus();
         mWidgetManager.setControllersVisible(true);
 
-        this.setVisible(true);
+        this.setVisible(!mAttachedWindow.isKioskMode());
         mAttachedWindow.disableVRVideoMode();
         mAttachedWindow.setVisible(true);
         mMediaControlsWidget.setVisible(false);
+        mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isFullScreen() || !mAttachedWindow.isKioskMode());
 
         // Reposition UI in front of the user when exiting a VR video.
         mWidgetManager.recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL);


### PR DESCRIPTION
Ensure that the navigation bar remains hidden after exiting a VR video in kiosk mode.

This fixes a bug where the navigation bar was becoming visible in kiosk mode, after leaving an immersive VR video.