### PR TITLE
Fix a crash in addons view

### DIFF
--- a/app/src/main/res/layout/addons_section_item.xml
+++ b/app/src/main/res/layout/addons_section_item.xml
@@ -3,20 +3,37 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/title"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/library_item_row_height"
-    android:gravity="center_vertical"
-    android:duplicateParentState="true"
-    android:ellipsize="none"
-    android:paddingStart="10dp"
-    android:paddingEnd="10dp"
-    android:scrollHorizontally="true"
-    android:singleLine="true"
-    android:textAllCaps="true"
-    android:textColor="@color/rhino"
-    android:textSize="@dimen/library_item_title_text_size"
-    android:textStyle="bold"
-    tools:text="Item Title" />
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:visibility="gone"
+        android:layout_marginTop="7dp"
+        android:background="?android:attr/listDivider" />
+
+    <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/library_item_row_height"
+        android:gravity="center_vertical"
+        android:duplicateParentState="true"
+        android:ellipsize="none"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:scrollHorizontally="true"
+        android:singleLine="true"
+        android:textAllCaps="true"
+        android:textColor="@color/rhino"
+        android:textSize="@dimen/library_item_title_text_size"
+        android:textStyle="bold"
+        tools:text="Item Title" />
+</LinearLayout>


### PR DESCRIPTION
This is a regression caused by the upgrade to AC v75. The SectionViewHolder component now requires a divider.
We added the code to retrieve the divider in Kotlin. However we didn't add the divider in the resources file.

That's what we do now in order to provide a divider.

This fixes #341