### PR TITLE
Trigger CI only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
We used to trigger it also on push but they actually overlap in some cases and pull_request
is enough even when receiving them from other forks.