### PR TITLE
Add the include path for OVR platform on Meta OpenXR builds

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -96,6 +96,7 @@ if(OPENXR)
     if (OCULUSVR)
         include_directories(
             ${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK/include
+            ${CMAKE_SOURCE_DIR}/../third_party/OVRPlatformSDK/Include
             ${CMAKE_SOURCE_DIR}/../third_party/ovr_openxr_mobile_sdk/OpenXR/Include
             ${CMAKE_SOURCE_DIR}/../app/src/openxr/cpp
         )


### PR DESCRIPTION
This is a leftover from b198a4c322a1291da7091660a4798acb0ce9c89a. I forgot
to add the CMake changes to that commit which add the Meta VR platform 
includes to the Meta OpenXR build. That broke the Meta OpenXR store builds.

We require them to perform the user entitlement.