### PR TITLE
Add com.oculus.intent.category to Meta's manifests

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -14,6 +14,9 @@
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
             <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
+            <intent-filter>
+                <category android:name="com.oculus.intent.category.VR" android:value="vr_only"/>
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -45,6 +45,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.INFO" />
+                <category android:name="com.oculus.intent.category.VR" android:value="vr_only"/>
             </intent-filter>
             <!--
             <intent-filter>


### PR DESCRIPTION
The Meta store hasn't complained about that so far, however it is preventing us now from
uploading OpenXR based packages to the store due to the lack of that definition in the manifest.