### PR TITLE
Fix issues in the Library tabs

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
@@ -183,6 +183,7 @@ public class LibraryPanel extends FrameLayout {
         mBinding.tabcontent.removeAllViews();
 
         mBinding.bookmarks.setActiveMode(false);
+        mBinding.webApps.setActiveMode(false);
         mBinding.history.setActiveMode(false);
         mBinding.downloads.setActiveMode(false);
         mBinding.addons.setActiveMode(false);

--- a/app/src/main/res/layout/library.xml
+++ b/app/src/main/res/layout/library.xml
@@ -33,7 +33,7 @@
                         android:id="@+id/bookmarks"
                         android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
-                        style="@style/libraryButtonStartTheme"
+                        style="@style/libraryButtonMiddleTheme"
                         android:src="@drawable/ic_icon_webapps"
                         android:id="@+id/web_apps"
                         android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>


### PR DESCRIPTION
This PR fixes two small bugs in the Library UI:

- the Web Apps tab does not use the correct style
- the Web Apps tab remains active after another tab is activated