### PR TITLE
Support Pico 4 (and probably Pico Neo 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This repo is only available to Igalia members. If you have access to the relevan
  - `third_party/OVRPlatformSDK/` for Oculus (should contain a `Android` and `include` folders)
  - `third_party/hvr/` for Huawei (should contain  `arm64-v8a`, `armeabi-v7a` and `include` folders)
  - `third_party/wavesdk/` for Vive (should contain a `build` folder, among other things)
+ - `third_party/picoxr` [Pico OpenXR Mobile SDK](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11) (should contain `Include` and `Libs` folders, among other things that are not necessary for Wolvic)
+ - `third_party/OpenXR-SDK/` [OpenXR-SDK](https://github.com/KhronosGroup/OpenXR-SDK) (should contain an `include` folder)
 
 The [repo in `third_party`](https://github.com/Igalia/wolvic-third-parties) can be updated like so:
 
@@ -60,6 +62,7 @@ You can build for different devices:
 - **`hvr`**: Huawei VR Glasses
 - **`wavevr`**: VIVE Focus
 - **`picovr`**: Pico Neo
+- **`picoxr`**: Pico 4 and (untested) Pico Neo 3
 
 For testing on a non-VR device:
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -115,6 +115,17 @@ if(OPENXR)
                 ${CMAKE_SOURCE_DIR}/../third_party/hvr/${ANDROID_ABI}/libxr_loader.so
                 ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libxr_loader.so
                 )
+    elseif (PICOXR)
+        include_directories(
+            ${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK/include
+            ${CMAKE_SOURCE_DIR}/../third_party/picoxr/Include
+            ${CMAKE_SOURCE_DIR}/../app/src/openxr/cpp
+        )
+        add_custom_command(TARGET native-lib POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_SOURCE_DIR}/../third_party/picoxr/Libs/Android/${ANDROID_ABI}/libopenxr_loader.so
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopenxr_loader.so
+        )
     endif ()
     target_sources(
             native-lib
@@ -191,6 +202,10 @@ set_target_properties(wavevr-lib PROPERTIES IMPORTED_LOCATION
 add_library(hvr-lib SHARED IMPORTED)
 set_target_properties(hvr-lib PROPERTIES IMPORTED_LOCATION
         ${CMAKE_SOURCE_DIR}/../third_party/hvr/${ANDROID_ABI}/libxr_loader.so)
+
+add_library(picoxr-lib SHARED IMPORTED)
+set_target_properties(picoxr-lib PROPERTIES IMPORTED_LOCATION
+        ${CMAKE_SOURCE_DIR}/../third_party/picoxr/Libs/Android/${ANDROID_ABI}/libopenxr_loader.so)
 
 # Specifies libraries CMake should link to your target library. You
 # can link multiple libraries, such as libraries you define in this

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -262,6 +262,16 @@ android {
             }
         }
 
+        picoxr {
+            dimension "platform"
+            externalNativeBuild {
+                cmake {
+                    cppFlags " -DPICOXR -DOPENXR -I" + file("src/openxr/cpp").absolutePath
+                    arguments "-DVR_SDK_LIB=picoxr-lib", "-DPICOXR=ON", "-DOPENXR=ON"
+                }
+            }
+        }
+
         hvr {
             dimension "platform"
             externalNativeBuild {

--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -19,6 +19,7 @@ public class DeviceType {
     public static final int PicoG2 = 7;
     public static final int PicoNeo3 = 8;
     public static final int OculusQuest2 = 9;
+    public static final int PicoXR = 12;
 
     // These values are not present in Device.h yet but are needed for the WebXR UI
     public static final int HVR3DoF = 10;
@@ -53,6 +54,9 @@ public class DeviceType {
             case PicoG2:
                 name = "Pico G2";
                 break;
+            case PicoXR:
+                name = "Pico XR";
+                break;
             default:
                 name = "Unknown Type";
         }
@@ -83,12 +87,18 @@ public class DeviceType {
         return BuildConfig.FLAVOR_platform.toLowerCase().contains("picovr");
     }
 
+    public static boolean isPicoXR() {
+        return BuildConfig.FLAVOR_platform.toLowerCase().contains("picoxr");
+    }
+
     public static String getDeviceTypeId() {
         String type = BuildConfig.FLAVOR_platform;
         if (DeviceType.isOculusBuild()) {
             type = "oculusvr";
         } else if (DeviceType.isPicoVR()) {
             type = "picovr";
+        } else if (DeviceType.isPicoXR()) {
+            type = "picoxr";
         } else if (DeviceType.isWaveBuild()) {
             type = "wavevrStore";
         }

--- a/app/src/main/cpp/Device.h
+++ b/app/src/main/cpp/Device.h
@@ -40,6 +40,7 @@ const DeviceType PicoNeo2 = 6;
 const DeviceType PicoG2 = 7;
 const DeviceType PicoNeo3 = 8;
 const DeviceType OculusQuest2 = 9;
+const DeviceType PicoXR = 12;
 
 enum class TargetRayMode : uint8_t { Gaze, TrackedPointer, Screen };
 

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -188,6 +188,15 @@ android_main(android_app *aAppState) {
   aAppState->userData = sAppContext.get();
   aAppState->onAppCmd = CommandCallback;
 
+#ifdef PICOXR
+  if (!sAppContext->mEgl && aAppState->window) {
+    // Work around APP_CMD_INIT_WINDOW and APP_CMD_RESUME callback not
+    // firing on Pico 4 when starting the app
+    CommandCallback(aAppState, APP_CMD_INIT_WINDOW);
+    CommandCallback(aAppState, APP_CMD_RESUME);
+  }
+#endif
+
   // Main render loop
   while (true) {
     int events;

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -33,6 +33,7 @@ namespace crow {
     constexpr const char* kPathTrackpad { "input/trackpad" };
     constexpr const char* kPathSelect { "/input/select" };
     constexpr const char* kPathMenu { "input/menu" };
+    constexpr const char* kPathBack { "input/back" };
     constexpr const char* kPathHaptic { "output/haptic" };
     constexpr const char* kPathButtonA { "input/a" };
     constexpr const char* kPathButtonB { "input/b" };
@@ -189,6 +190,33 @@ namespace crow {
                     { kPathHaptic, OpenXRHandFlags::Both },
             },
     };
+
+    // Pico controller: this definition was created for the Pico 4, but the Neo 3 will likely also be compatible
+    const OpenXRInputMapping Pico4 {
+            "/interaction_profiles/pico/neo3_controller",
+            "Pico: PICO HMD",
+            IS_6DOF,
+            "vr_controller_pico4_left.obj",
+            "vr_controller_pico4_right.obj",
+            device::PicoXR,
+            std::vector<OpenXRInputProfile> { "oculus-touch-v3", "oculus-touch-v2", "oculus-touch", "generic-trigger-squeeze-thumbstick" },
+            std::vector<OpenXRButton> {
+                    { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
+                    { OpenXRButtonType::Squeeze, kPathSqueeze, OpenXRButtonFlags::Value, OpenXRHandFlags::Both },
+                    { OpenXRButtonType::Thumbstick, kPathThumbstick, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Both },
+                    { OpenXRButtonType::ButtonX, kPathButtonX, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left },
+                    { OpenXRButtonType::ButtonY, kPathButtonY, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left,  },
+                    { OpenXRButtonType::ButtonA, kPathButtonA, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
+                    { OpenXRButtonType::ButtonB, kPathButtonB, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
+                    { OpenXRButtonType::Back, kPathBack, OpenXRButtonFlags::Click, OpenXRHandFlags::Both, ControllerDelegate::Button::BUTTON_APP, true }
+            },
+            std::vector<OpenXRAxis> {
+                    { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
+            },
+            std::vector<OpenXRHaptic> {
+                    { kPathHaptic, OpenXRHandFlags::Both },
+            },
+    };
     
     // HVR 3DOF: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-trigger-touchpad.json
     const OpenXRInputMapping Hvr3DOF {
@@ -202,7 +230,7 @@ namespace crow {
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
                     { OpenXRButtonType::Trackpad, kPathTrackpad, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Both },
-                    { OpenXRButtonType::Back, "input/back", OpenXRButtonFlags::All, OpenXRHandFlags::Both, ControllerDelegate::Button::BUTTON_APP, true },
+                    { OpenXRButtonType::Back, kPathBack, OpenXRButtonFlags::All, OpenXRHandFlags::Both, ControllerDelegate::Button::BUTTON_APP, true },
             },
             std::vector<OpenXRAxis> {
                 { OpenXRAxisType::Trackpad, "input/trackpad/value",  OpenXRHandFlags::Both },
@@ -262,8 +290,8 @@ namespace crow {
             },
     };
 
-    const std::array<OpenXRInputMapping, 5> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, Hvr6DOF, Hvr3DOF, KHRSimple
+    const std::array<OpenXRInputMapping, 6> OpenXRInputMappings {
+        OculusTouch, OculusTouch2, Pico4, Hvr6DOF, Hvr3DOF, KHRSimple
     };
 
 } // namespace crow

--- a/app/src/picoxr/AndroidManifest.xml
+++ b/app/src/picoxr/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.igalia.wolvic" xmlns:tools="http://schemas.android.com/tools">
+    <uses-feature android:glEsVersion="0x00030001"/>
+    <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" />
+
+    <application>
+        <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
+            <meta-data android:name="android.app.lib_name" android:value="native-lib" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <meta-data android:name="pvr.app.type" android:value="vr" />
+    </application>
+</manifest>

--- a/app/src/picoxr/assets/vr_controller_pico4_left.obj
+++ b/app/src/picoxr/assets/vr_controller_pico4_left.obj
@@ -1,0 +1,1 @@
+# Empty obj file to not render a controller

--- a/app/src/picoxr/assets/vr_controller_pico4_right.obj
+++ b/app/src/picoxr/assets/vr_controller_pico4_right.obj
@@ -1,0 +1,1 @@
+# Empty obj file to not render a controller

--- a/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
@@ -1,0 +1,43 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.igalia.wolvic;
+
+import android.app.NativeActivity;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.WindowManager;
+
+import com.igalia.wolvic.utils.SystemUtils;
+
+public class PlatformActivity extends NativeActivity {
+
+    public static boolean filterPermission(final String aPermission) {
+        // Dummy implementation.
+        return false;
+    }
+
+    public static boolean isNotSpecialKey(KeyEvent event) {
+        // Dummy implementation.
+        return true;
+    }
+
+    public static boolean isPositionTrackingSupported() {
+        // Dummy implementation.
+        return true;
+    }
+
+    @Override
+    public void onBackPressed() {
+        queueRunnable(new Runnable() {
+            @Override
+            public void run() {
+                platformExit();
+            }
+        });
+    }    
+    protected native void queueRunnable(Runnable aRunnable);
+    protected native boolean platformExit();
+}

--- a/app/src/picoxr/res/layout/webxr_interstitial_controller.xml
+++ b/app/src/picoxr/res/layout/webxr_interstitial_controller.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="com.igalia.wolvic.utils.DeviceType"/>
+        <import type="com.igalia.wolvic.ui.widgets.WebXRInterstitialController"/>
+        <variable
+            name="model"
+            type="int" />
+        <variable
+            name="hand"
+            type="int" />
+    </data>
+
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="#00000000"
+        android:padding="5dp">
+
+        <!-- Left Controller -->
+        <RelativeLayout
+            app:visibleGone="@{hand == WebXRInterstitialController.HAND_LEFT}"
+            tools:visibility="gone"
+            android:layout_width="200dp"
+            android:layout_height="130dp"
+            >
+            <ImageView
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                android:layout_alignParentRight="true"
+                android:layout_centerVertical="true"
+                android:scaleType="fitCenter"
+                android:src="@drawable/empty_drawable"
+                tools:ignore="RtlHardcoded" />
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_marginRight="60dp"
+                android:layout_marginTop="52dp"
+                android:paddingBottom="16dp"
+                android:rotation="-30"
+                android:layout_alignParentTop="true"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_webxr_controller_arrow"
+                tools:ignore="RtlHardcoded,RtlSymmetry"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAlignment="textEnd"
+                android:layout_alignParentRight="true"
+                android:layout_marginRight="100dp"
+                android:layout_marginTop="23dp"
+                android:layout_alignParentTop="true"
+                android:textSize="18sp"
+                tools:ignore="RtlHardcoded,RtlSymmetry"
+                android:text="@string/webxr_interstitial_exit_webxr"/>
+        </RelativeLayout>
+
+        <!-- Right Controller -->
+        <RelativeLayout
+            app:visibleGone="@{hand == WebXRInterstitialController.HAND_RIGHT}"
+            tools:visibility="gone"
+            android:layout_width="200dp"
+            android:layout_height="130dp"
+            >
+            <ImageView
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                android:layout_alignParentLeft="true"
+                android:layout_centerVertical="true"
+                android:scaleType="fitCenter"
+                android:src="@drawable/empty_drawable"
+                tools:ignore="RtlHardcoded" />
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_marginLeft="60dp"
+                android:layout_marginTop="52dp"
+                android:paddingBottom="16dp"
+                android:scaleX="-1"
+                android:rotation="30"
+                android:layout_alignParentTop="true"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_webxr_controller_arrow"
+                tools:ignore="RtlHardcoded,RtlSymmetry"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAlignment="textStart"
+                android:layout_alignParentLeft="true"
+                android:layout_marginLeft="100dp"
+                android:layout_marginTop="26dp"
+                android:layout_alignParentTop="true"
+                android:textSize="18sp"
+                tools:ignore="RtlHardcoded,RtlSymmetry"
+                android:text="@string/webxr_interstitial_exit_webxr"/>
+        </RelativeLayout>
+
+    </FrameLayout>
+
+</layout>


### PR DESCRIPTION
This PR introduces a new build variant "picoxr" using Pico's OpenXR SDK, and makes necessary changes to get Wolvic to run on the Pico 4. It is likely that the variant also works with at least some versions of the Pico Neo 3, but that was not tested.

Official 3D models of the Pico 4 controllers are available as part of the Pico SDKs, but it is unclear if they are license-compatible with this repository. They are thus not included in this PR.

Fixes #306
Fixes #24 (untested, but Pico Neo 3 is documented to use the same SDK than the Pico 4)