### PR TITLE
Fix WebXR controller profiles on Pico XR

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -239,6 +239,9 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
     case device::PicoNeo3:
       result = mozilla::gfx::VRControllerType::PicoNeo2;
       break;
+    case device::PicoXR:
+      result = mozilla::gfx::VRControllerType::PicoNeo2;
+      break;
     case device::UnknownType:
     default:
       result = mozilla::gfx::VRControllerType::_empty;

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -199,7 +199,7 @@ namespace crow {
             "vr_controller_pico4_left.obj",
             "vr_controller_pico4_right.obj",
             device::PicoXR,
-            std::vector<OpenXRInputProfile> { "oculus-touch-v3", "oculus-touch-v2", "oculus-touch", "generic-trigger-squeeze-thumbstick" },
+            std::vector<OpenXRInputProfile> { "generic-trigger-squeeze-thumbstick" },
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
                     { OpenXRButtonType::Squeeze, kPathSqueeze, OpenXRButtonFlags::Value, OpenXRHandFlags::Both },


### PR DESCRIPTION
This PR sets the controller type for Gecko for Pico XR controllers to pico-neo2, causing them to get a suitable profile. It also adapts the input mappings to match the profiles exposed through Gecko for consistency.

If Gecko should get updated to support more recently added types, we might want to upgrade to pico-neo3 or, if available until then, a suitable controller type for Pico 4.