### PR TITLE
OpenXR: Initial support for hand tracking

### DIFF
--- a/app/src/main/cpp/Controller.cpp
+++ b/app/src/main/cpp/Controller.cpp
@@ -47,6 +47,7 @@ Controller::operator=(const Controller& aController) {
   scrollDeltaY = aController.scrollDeltaY;
   transform = aController.transform;
   beamToggle = aController.beamToggle;
+  modelToggle = aController.modelToggle;
   beamParent = aController.beamParent;
   pointer = aController.pointer;
   transformMatrix = aController.transformMatrix;
@@ -93,6 +94,7 @@ Controller::Reset() {
   scrollDeltaX = scrollDeltaY = 0.0f;
   transform = nullptr;
   beamToggle = nullptr;
+  modelToggle = nullptr;
   beamParent = nullptr;
   pointer = nullptr;
   transformMatrix = Matrix::Identity();

--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -40,6 +40,7 @@ struct Controller {
   float scrollDeltaY;
   vrb::TransformPtr transform;
   vrb::TogglePtr beamToggle;
+  vrb::TogglePtr modelToggle;
   vrb::TransformPtr beamParent;
   PointerPtr pointer;
   vrb::Matrix transformMatrix;

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -238,7 +238,10 @@ ControllerContainer::CreateController(const int32_t aControllerIndex, const int3
 
   if (aControllerIndex != m.gazeIndex) {
     if ((m.models.size() >= aModelIndex) && m.models[aModelIndex]) {
-      controller.transform->AddNode(m.models[aModelIndex]);
+      controller.modelToggle = vrb::Toggle::Create(create);
+      controller.modelToggle->AddNode(m.models[aModelIndex]);
+      controller.transform->AddNode(controller.modelToggle);
+      controller.modelToggle->ToggleAll(true);
       controller.beamToggle = vrb::Toggle::Create(create);
       controller.beamToggle->ToggleAll(true);
       vrb::TransformPtr beamTransform = Transform::Create(create);
@@ -329,6 +332,14 @@ ControllerContainer::SetEnabled(const int32_t aControllerIndex, const bool aEnab
   m.SetVisible(m.list[aControllerIndex], aEnabled);
 }
 
+void
+ControllerContainer::SetModelVisible(const int32_t aControllerIndex, const bool aVisible) {
+    if (!m.Contains(aControllerIndex))
+        return;
+
+    assert(m.list[aControllerIndex].modelToggle != nullptr);
+    m.list[aControllerIndex].modelToggle->ToggleAll(aVisible);
+}
 
 void
 ControllerContainer::SetControllerType(const int32_t aControllerIndex, device::DeviceType aType) {

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -44,6 +44,7 @@ public:
   void DestroyController(const int32_t aControllerIndex) override;
   void SetCapabilityFlags(const int32_t aControllerIndex, const device::CapabilityFlags aFlags) override;
   void SetEnabled(const int32_t aControllerIndex, const bool aEnabled) override;
+  void SetModelVisible(const int32_t aControllerIndex, const bool aVisible) override;
   void SetControllerType(const int32_t aControllerIndex, device::DeviceType aType) override;
   void SetTargetRayMode(const int32_t aControllerIndex, device::TargetRayMode aMode) override;
   void SetTransform(const int32_t aControllerIndex, const vrb::Matrix& aTransform) override;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -42,6 +42,7 @@ public:
   virtual uint32_t GetControllerCount() = 0;
   virtual void SetCapabilityFlags(const int32_t aControllerIndex, const device::CapabilityFlags aFlags) = 0;
   virtual void SetEnabled(const int32_t aControllerIndex, const bool aEnabled) = 0;
+  virtual void SetModelVisible(const int32_t aControllerIndex, const bool aVisible) = 0;
   virtual void SetControllerType(const int32_t aControllerIndex, device::DeviceType aType) = 0;
   virtual void SetTargetRayMode(const int32_t aControllerIndex, device::TargetRayMode aMode) = 0;
   virtual void SetTransform(const int32_t aControllerIndex, const vrb::Matrix& aTransform) = 0;

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -140,6 +140,9 @@ struct DeviceDelegateOpenXR::State {
         if (OpenXRExtensions::IsExtensionSupported(XR_FB_HAND_TRACKING_AIM_EXTENSION_NAME)) {
             extensions.push_back(XR_FB_HAND_TRACKING_AIM_EXTENSION_NAME);
         }
+        if (OpenXRExtensions::IsExtensionSupported(XR_FB_HAND_TRACKING_MESH_EXTENSION_NAME)) {
+            extensions.push_back(XR_FB_HAND_TRACKING_MESH_EXTENSION_NAME);
+        }
     }
 #ifdef OCULUSVR
     if (OpenXRExtensions::IsExtensionSupported(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME)) {

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -96,6 +96,7 @@ struct DeviceDelegateOpenXR::State {
   std::vector<const XrCompositionLayerBaseHeader*> frameEndLayers;
   std::function<void()> controllersReadyCallback;
   std::optional<XrPosef> firstPose;
+  bool mHandTrackingSupported = false;
 
   void Initialize() {
     vrb::RenderContextPtr localContext = context.lock();
@@ -182,9 +183,20 @@ struct DeviceDelegateOpenXR::State {
     CHECK_XRCMD(xrGetSystem(instance, &systemInfo, &system));
     CHECK_MSG(system != XR_NULL_SYSTEM_ID, "Failed to initialize XRSystem");
 
+    // If hand tracking extension is present, query whether the runtime actually supports it
+    XrSystemHandTrackingPropertiesEXT handTrackingProperties{XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_EXT};
+    handTrackingProperties.supportsHandTracking = XR_FALSE;
+    if (OpenXRExtensions::IsExtensionSupported(XR_EXT_HAND_TRACKING_EXTENSION_NAME)) {
+        handTrackingProperties.next = systemProperties.next;
+        systemProperties.next = &handTrackingProperties;
+    }
+
     // Retrieve system info
     CHECK_XRCMD(xrGetSystemProperties(instance, system, &systemProperties))
     VRB_LOG("OpenXR system name: %s", systemProperties.systemName);
+
+    mHandTrackingSupported = handTrackingProperties.supportsHandTracking;
+    VRB_LOG("OpenXR runtime %s hand tracking", mHandTrackingSupported ? "does support" : "doesn't support");
   }
 
   // xrGet*GraphicsRequirementsKHR check must be called prior to xrCreateSession

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -9,6 +9,7 @@ PFN_xrCreateSwapchainAndroidSurfaceKHR OpenXRExtensions::sXrCreateSwapchainAndro
 PFN_xrCreateHandTrackerEXT OpenXRExtensions::sXrCreateHandTrackerEXT = nullptr;
 PFN_xrDestroyHandTrackerEXT OpenXRExtensions::sXrDestroyHandTrackerEXT = nullptr;
 PFN_xrLocateHandJointsEXT OpenXRExtensions::sXrLocateHandJointsEXT = nullptr;
+PFN_xrGetHandMeshFB OpenXRExtensions::sXrGetHandMeshFB = nullptr;
 
 void OpenXRExtensions::Initialize() {
     uint32_t extensionCount { 0 };
@@ -40,6 +41,10 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
                                         reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyHandTrackerEXT)));
         CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrLocateHandJointsEXT",
                                         reinterpret_cast<PFN_xrVoidFunction *>(&sXrLocateHandJointsEXT)));
+        if (IsExtensionSupported(XR_FB_HAND_TRACKING_MESH_EXTENSION_NAME)) {
+            CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrGetHandMeshFB",
+                                            reinterpret_cast<PFN_xrVoidFunction *>(&sXrGetHandMeshFB)));
+        }
     }
 }
 

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -22,6 +22,7 @@ namespace crow {
     static PFN_xrCreateHandTrackerEXT sXrCreateHandTrackerEXT;
     static PFN_xrDestroyHandTrackerEXT sXrDestroyHandTrackerEXT;
     static PFN_xrLocateHandJointsEXT sXrLocateHandJointsEXT;
+    static PFN_xrGetHandMeshFB sXrGetHandMeshFB;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
   };

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -107,6 +107,49 @@ XrResult OpenXRInputSource::Initialize()
 
         RETURN_IF_XR_FAILED(OpenXRExtensions::sXrCreateHandTrackerEXT(mSession, &handTrackerInfo,
                                                                       &mHandTracker));
+
+        if (OpenXRExtensions::IsExtensionSupported(XR_FB_HAND_TRACKING_MESH_EXTENSION_NAME) &&
+                OpenXRExtensions::sXrGetHandMeshFB != XR_NULL_HANDLE) {
+            XrHandTrackingMeshFB mesh = { XR_TYPE_HAND_TRACKING_MESH_FB };
+            // Figure out sizes first
+            mesh.jointCapacityInput = 0;
+            mesh.vertexCapacityInput = 0;
+            mesh.indexCapacityInput = 0;
+            CHECK_XRCMD(OpenXRExtensions::sXrGetHandMeshFB(mHandTracker, &mesh));
+            mesh.jointCapacityInput = mesh.jointCountOutput;
+            mesh.vertexCapacityInput = mesh.vertexCountOutput;
+            mesh.indexCapacityInput = mesh.indexCountOutput;
+
+            // Skeleton
+            mHandMesh.jointCount = mesh.jointCountOutput;
+            mHandMesh.jointPoses.resize(mesh.jointCountOutput);
+            mHandMesh.jointParents.resize(mesh.jointCountOutput);
+            mHandMesh.jointRadii.resize(mesh.jointCountOutput);
+            mesh.jointBindPoses = mHandMesh.jointPoses.data();
+            mesh.jointParents = mHandMesh.jointParents.data();
+            mesh.jointRadii = mHandMesh.jointRadii.data();
+            // Vertex
+            mHandMesh.vertexCount = mesh.vertexCountOutput;
+            mHandMesh.vertexPositions.resize(mesh.vertexCountOutput);
+            mHandMesh.vertexNormals.resize(mesh.vertexCountOutput);
+            mHandMesh.vertexUVs.resize(mesh.vertexCountOutput);
+            mHandMesh.vertexBlendIndices.resize(mesh.vertexCountOutput);
+            mHandMesh.vertexBlendWeights.resize(mesh.vertexCountOutput);
+            mesh.vertexPositions = mHandMesh.vertexPositions.data();
+            mesh.vertexNormals = mHandMesh.vertexNormals.data();
+            mesh.vertexUVs = mHandMesh.vertexUVs.data();
+            mesh.vertexBlendIndices = mHandMesh.vertexBlendIndices.data();
+            mesh.vertexBlendWeights = mHandMesh.vertexBlendWeights.data();
+            // Index
+            mHandMesh.indexCount = mesh.indexCountOutput;
+            mHandMesh.indices.resize(mesh.indexCountOutput);
+            mesh.indices = mHandMesh.indices.data();
+
+            // Now get the actual mesh
+            RETURN_IF_XR_FAILED(OpenXRExtensions::sXrGetHandMeshFB(mHandTracker, &mesh));
+            mHasHandMesh = true;
+            VRB_LOG("xrGetHandMeshFB: %u, %u, %u", mHandMesh.jointCount, mHandMesh.vertexCount, mHandMesh.indexCount);
+        }
     }
 
     return XR_SUCCESS;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -30,6 +30,24 @@ private:
       bool touched { false };
       float value { 0 };
     };
+
+    struct OpenXRHandMesh {
+        // Skeleton
+        uint32_t jointCount;
+        std::vector<XrPosef> jointPoses;
+        std::vector<XrHandJointEXT> jointParents;
+        std::vector<float> jointRadii;
+        // Vertex
+        uint32_t vertexCount;
+        std::vector<XrVector3f> vertexPositions;
+        std::vector<XrVector3f> vertexNormals;
+        std::vector<XrVector2f> vertexUVs;
+        std::vector<XrVector4sFB> vertexBlendIndices;
+        std::vector<XrVector4f> vertexBlendWeights;
+        // Index
+        uint32_t indexCount;
+        std::vector<int16_t> indices;
+    };
     std::optional<OpenXRButtonState> GetButtonState(const OpenXRButton&) const;
     std::optional<XrVector2f> GetAxis(OpenXRAxisType) const;
     XrResult GetActionState(XrAction, bool*) const;
@@ -69,6 +87,8 @@ private:
     bool mHasHandJoints { false };
     XrHandTrackingAimStateFB mAimState { XR_TYPE_HAND_TRACKING_AIM_STATE_FB };
     bool mHasAimState { false };
+    OpenXRHandMesh mHandMesh;
+    bool mHasHandMesh { false };
 
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -75,6 +75,7 @@ public:
     ~OpenXRInputSource();
 
     XrResult SuggestBindings(SuggestedBindings&) const;
+    void EmulateControllerFromHand(device::RenderMode renderMode, ControllerDelegate& delegate);
     void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, float offsetY, device::RenderMode, ControllerDelegate& delegate);
     XrResult UpdateInteractionProfile(ControllerDelegate&);
     std::string ControllerModelName() const;


### PR DESCRIPTION
This series adds the first functional support for hand tracking. There are two caveats:

- Hands are not rendered yet, just the beam and pointer target, but that's enough to use the feature.
- For hand tracking to work properly in immersive mode, Wolvic has to be launched with the controllers active, or the controllers should be activated at some point prior to entering immersive mode.

Note that there is one patch that loads hand mesh information at input source initialization time, however that information is not yet used because rendering the hands is still WIP.     