### PR TITLE
Add option to adjust render resolution (for all OpenXR variants)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,13 @@ def getUseDebugSigningOnRelease = { ->
     return false
 }
 
+def getOpenXRBool = { ->
+    if (gradle.hasProperty("userProperties.openxr")) {
+        return gradle."userProperties.openxr" == "true" ? "true" : "false"
+    }
+    return "false"
+}
+
 def getOpenXRFlags = { ->
     if (gradle.hasProperty("userProperties.openxr")) {
         return gradle."userProperties.openxr" == "true" ? " -DOPENXR" : ""
@@ -115,6 +122,8 @@ android {
         buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "false"
         buildConfigField "Boolean", "KIOSK_MODE_ALWAYS", "false"
+        buildConfigField "float", "RENDER_RESOLUTION_FACTOR_DEFAULT", "1.0f"
+        buildConfigField "boolean", "SUPPORTS_RENDER_RESOLUTION_FACTOR", "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
@@ -190,6 +199,7 @@ android {
                 }
             }
             manifestPlaceholders = [ headtrackingRequired:"false", permissionToRemove:"android.permission.RECEIVE_BOOT_COMPLETED" ]
+            buildConfigField "boolean", "SUPPORTS_RENDER_RESOLUTION_FACTOR", getOpenXRBool()
         }
 
         oculusvrStore {
@@ -201,6 +211,7 @@ android {
                 }
             }
             manifestPlaceholders = [ headtrackingRequired:"false", permissionToRemove:"android.permission.RECEIVE_BOOT_COMPLETED" ]
+            buildConfigField "boolean", "SUPPORTS_RENDER_RESOLUTION_FACTOR", getOpenXRBool()
         }
 
         oculusvr3dofStore {
@@ -212,6 +223,7 @@ android {
                 }
             }
             manifestPlaceholders = [ headtrackingRequired:"false", permissionToRemove:"android.permission.CAMERA" ]
+            buildConfigField "boolean", "SUPPORTS_RENDER_RESOLUTION_FACTOR", getOpenXRBool()
         }
 
         wavevr {
@@ -270,6 +282,8 @@ android {
                     arguments "-DVR_SDK_LIB=picoxr-lib", "-DPICOXR=ON", "-DOPENXR=ON"
                 }
             }
+            buildConfigField "boolean", "SUPPORTS_RENDER_RESOLUTION_FACTOR", "true"
+            buildConfigField "float", "RENDER_RESOLUTION_FACTOR_DEFAULT", "1.4f"
         }
 
         hvr {
@@ -285,6 +299,7 @@ android {
             buildConfigField "String", "MK_API_KEY", "\"\""
             buildConfigField "String[]", "SPEECH_SERVICES", "${getHVRMLSpeechServices()}"
             buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "true"
+            buildConfigField "boolean", "SUPPORTS_RENDER_RESOLUTION_FACTOR", "true"
         }
 
         cn {

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1299,6 +1299,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Keep
     @SuppressWarnings("unused")
+    public float getRenderResolutionFactor() {
+        return SettingsStore.getInstance(this).getRenderResolutionFactor();
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
     private void setDeviceType(int aType) {
         runOnUiThread(() -> DeviceType.setType(aType));
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -375,6 +375,17 @@ public class SettingsStore {
         editor.commit();
     }
 
+    public float getRenderResolutionFactor() {
+        return mPrefs.getFloat(mContext.getString(R.string.settings_key_render_resolution_factor),
+                BuildConfig.RENDER_RESOLUTION_FACTOR_DEFAULT);
+    }
+
+    public void setRenderResolutionFactor(float aFactor) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putFloat(mContext.getString(R.string.settings_key_render_resolution_factor), aFactor);
+        editor.commit();
+    }
+
     public int getWindowWidth() {
         return WINDOW_WIDTH_DEFAULT;
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -13,6 +13,7 @@ import android.view.View;
 import androidx.databinding.DataBindingUtil;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsDisplayBinding;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
@@ -85,6 +86,12 @@ class DisplayOptionsView extends SettingsView {
         mBinding.dpiEdit.setFirstText(Integer.toString(SettingsStore.getInstance(getContext()).getDisplayDpi()));
         mBinding.dpiEdit.setOnClickListener(mDpiListener);
         setDisplayDpi(SettingsStore.getInstance(getContext()).getDisplayDpi());
+
+        mBinding.resolutionEdit.setHint1(String.valueOf(BuildConfig.RENDER_RESOLUTION_FACTOR_DEFAULT));
+        mBinding.resolutionEdit.setDefaultFirstValue(String.valueOf(BuildConfig.RENDER_RESOLUTION_FACTOR_DEFAULT));
+        mBinding.resolutionEdit.setFirstText(Float.toString(SettingsStore.getInstance(getContext()).getRenderResolutionFactor()));
+        mBinding.resolutionEdit.setOnClickListener(mResolutionListener);
+        setRenderResolutionFactor(SettingsStore.getInstance(getContext()).getRenderResolutionFactor());
     }
 
     @Override
@@ -172,6 +179,20 @@ class DisplayOptionsView extends SettingsView {
         }
     };
 
+    private OnClickListener mResolutionListener = (view) -> {
+        try {
+            float newFactor = Float.parseFloat(mBinding.resolutionEdit.getFirstText());
+            if (setRenderResolutionFactor(newFactor)) {
+                showRestartDialog();
+            }
+
+        } catch (NumberFormatException e) {
+            if (setRenderResolutionFactor(BuildConfig.RENDER_RESOLUTION_FACTOR_DEFAULT)) {
+                showRestartDialog();
+            }
+        }
+    };
+
     private SwitchSetting.OnCheckedChangeListener mCurvedDisplayListener = (compoundButton, enabled, apply) ->
             setCurvedDisplay(enabled, true);
 
@@ -187,6 +208,7 @@ class DisplayOptionsView extends SettingsView {
 
         restart = restart | setDisplayDensity(SettingsStore.DISPLAY_DENSITY_DEFAULT);
         restart = restart | setDisplayDpi(SettingsStore.DISPLAY_DPI_DEFAULT);
+        restart = restart | setRenderResolutionFactor(BuildConfig.RENDER_RESOLUTION_FACTOR_DEFAULT);
 
 
         setHomepage(mDefaultHomepageUrl);
@@ -276,6 +298,23 @@ class DisplayOptionsView extends SettingsView {
         }
         mBinding.dpiEdit.setFirstText(Integer.toString(newDpi));
         mBinding.dpiEdit.setOnClickListener(mDpiListener);
+
+        return restart;
+    }
+
+    private boolean setRenderResolutionFactor(float newFactor) {
+        mBinding.resolutionEdit.setOnClickListener(null);
+        boolean restart = false;
+        float prevFactor = SettingsStore.getInstance(getContext()).getRenderResolutionFactor();
+        if (newFactor <= 0) {
+            newFactor = prevFactor;
+
+        } else if (prevFactor != newFactor) {
+            SettingsStore.getInstance(getContext()).setRenderResolutionFactor(newFactor);
+            restart = true;
+        }
+        mBinding.resolutionEdit.setFirstText(Float.toString(newFactor));
+        mBinding.resolutionEdit.setOnClickListener(mResolutionListener);
 
         return restart;
     }

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -48,6 +48,8 @@ const char* const kGetActiveEnvironment = "getActiveEnvironment";
 const char* const kGetActiveEnvironmentSignature = "()Ljava/lang/String;";
 const char* const kGetPointerColor = "getPointerColor";
 const char* const kGetPointerColorSignature = "()I";
+const char* const kGetRenderResolutionFactor = "getRenderResolutionFactor";
+const char* const kGetRenderResolutionFactorSignature = "()F";
 const char* const kAreLayersEnabled = "areLayersEnabled";
 const char* const kAreLayersEnabledSignature = "()Z";
 const char* const kSetDeviceType = "setDeviceType";
@@ -87,6 +89,7 @@ jmethodID sGetStorageAbsolutePath = nullptr;
 jmethodID sIsOverrideEnvPathEnabled = nullptr;
 jmethodID sGetActiveEnvironment = nullptr;
 jmethodID sGetPointerColor = nullptr;
+jmethodID sGetRenderResolutionFactor = nullptr;
 jmethodID sAreLayersEnabled = nullptr;
 jmethodID sSetDeviceType = nullptr;
 jmethodID sHaltActivity = nullptr;
@@ -133,6 +136,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sIsOverrideEnvPathEnabled = FindJNIMethodID(sEnv, sBrowserClass, kIsOverrideEnvPathEnabledName, kIsOverrideEnvPathEnabledSignature);
   sGetActiveEnvironment = FindJNIMethodID(sEnv, sBrowserClass, kGetActiveEnvironment, kGetActiveEnvironmentSignature);
   sGetPointerColor = FindJNIMethodID(sEnv, sBrowserClass, kGetPointerColor, kGetPointerColorSignature);
+  sGetRenderResolutionFactor = FindJNIMethodID(sEnv, sBrowserClass, kGetRenderResolutionFactor, kGetRenderResolutionFactorSignature);
   sAreLayersEnabled = FindJNIMethodID(sEnv, sBrowserClass, kAreLayersEnabled, kAreLayersEnabledSignature);
   sSetDeviceType = FindJNIMethodID(sEnv, sBrowserClass, kSetDeviceType, kSetDeviceTypeSignature);
   sHaltActivity = FindJNIMethodID(sEnv, sBrowserClass, kHaltActivity, kHaltActivitySignature);
@@ -179,6 +183,7 @@ VRBrowser::ShutdownJava() {
   sIsOverrideEnvPathEnabled = nullptr;
   sGetActiveEnvironment = nullptr;
   sGetPointerColor = nullptr;
+  sGetRenderResolutionFactor = nullptr;
   sAreLayersEnabled = nullptr;
   sSetDeviceType = nullptr;
   sHaltActivity = nullptr;
@@ -357,6 +362,15 @@ VRBrowser::GetPointerColor() {
   CheckJNIException(sEnv, __FUNCTION__);
 
   return (int32_t )jHexColor;
+}
+
+float
+VRBrowser::GetRenderResolutionFactor() {
+  if (!ValidateMethodID(sEnv, sActivity, sGetRenderResolutionFactor, __FUNCTION__)) { return 1.0f; }
+  jfloat jFactor = (jfloat) sEnv->CallFloatMethod(sActivity, sGetRenderResolutionFactor);
+  CheckJNIException(sEnv, __FUNCTION__);
+
+  return (float )jFactor;
 }
 
 bool

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -38,6 +38,7 @@ std::string GetStorageAbsolutePath(const std::string& aRelativePath);
 bool isOverrideEnvPathEnabled();
 std::string GetActiveEnvironment();
 int32_t GetPointerColor();
+float GetRenderResolutionFactor();
 bool AreLayersEnabled();
 void SetDeviceType(const jint aType);
 void HaltActivity(const jint aReason);

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -2,6 +2,10 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+        <import type="com.igalia.wolvic.BuildConfig" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -94,6 +98,17 @@
                     android:maxLength="4"
                     app:description="@string/developer_options_display_dpi"
                     app:highlightedTextColor="@color/fog" />
+
+                <com.igalia.wolvic.ui.views.settings.SingleEditSetting
+                    android:id="@+id/resolution_edit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:width="75dp"
+                    android:inputType="numberDecimal"
+                    android:maxLength="4"
+                    app:description="@string/developer_options_render_resolution_factor"
+                    app:highlightedTextColor="@color/fog"
+                    app:visibleGone="@{BuildConfig.SUPPORTS_RENDER_RESOLUTION_FACTOR}"/>
 
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -21,6 +21,7 @@
     <string name="settings_key_input_mode" translatable="false">settings_touch_mode</string>
     <string name="settings_key_display_density" translatable="false">settings_display_density</string>
     <string name="settings_key_display_dpi" translatable="false">settings_display_dpi</string>>
+    <string name="settings_key_render_resolution_factor" translatable="false">settings_render_resolution_factor</string>
     <string name="settings_key_env" translatable="false">settings_env</string>
     <string name="settings_key_pointer_color" translatable="false">settings_pointer_color</string>
     <string name="settings_key_scroll_direction" translatable="false">settings_scroll_direction</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,6 +516,10 @@
          use for the display density. -->
     <string name="developer_options_display_density">Display Density:</string>
 
+    <!-- This string is used to label a numerical-entry field where the user may set a new factor to
+         use when determining the render resolution (on supported devices). -->
+    <string name="developer_options_render_resolution_factor">Render Resolution:</string>
+
     <!-- This string is used to label buttons to enable editing of text fields in the
          'Developer Options' dialog. Pressing this button switches the text to
          editable-text fields so their values may be changed. -->

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -228,18 +228,15 @@ struct DeviceDelegateOpenXR::State {
     viewConfig.resize(viewCount, {XR_TYPE_VIEW_CONFIGURATION_VIEW});
     CHECK_XRCMD(xrEnumerateViewConfigurationViews(instance, system, viewConfigType, viewCount, &viewCount, viewConfig.data()));
 
-#ifdef PICOXR
-    // The Pico 4 is much more capable than it advertises via OpenXR, and the primary device used
-    // with Pico XR builds. We thus bump resulutions by 1.4 for a drastic improvement in image clarity.
     if (viewCount > 0) {
+      float factor = VRBrowser::GetRenderResolutionFactor();
       viewConfig.front().recommendedImageRectWidth = std::min<unsigned int>(
           viewConfig.front().maxImageRectWidth,
-          viewConfig.front().recommendedImageRectWidth * 1.4f);
+          viewConfig.front().recommendedImageRectWidth * factor);
       viewConfig.front().recommendedImageRectHeight = std::min<unsigned int>(
           viewConfig.front().maxImageRectHeight,
-          viewConfig.front().recommendedImageRectHeight * 1.4f);
+          viewConfig.front().recommendedImageRectHeight * factor);
     }
-#endif
 
     // Cache view buffer (used in xrLocateViews)
     views.resize(viewCount, {XR_TYPE_VIEW});


### PR DESCRIPTION
This PR introduces a new option to permit end-users to set a factor scaling the render resolution used in OpenXR-based builds. Users that primarily consume text content might want to increase this factor for more clarity, while users that primarily run complex WebXR experiences may want to lower it for better performance.

For now, this commit does not change the default values: Pico XR remains at a factor of 1.4, while other builds default to 1.0. We might want to discuss and define more balanced default values (here, or in a later PR / issue).

*Note that I only tested the `picoxr` build variant, as I don't have other headsets.*