### PR TITLE
[OpenXR] Properly initialize the DeviceType

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -19,11 +19,9 @@ public class DeviceType {
     public static final int PicoG2 = 7;
     public static final int PicoNeo3 = 8;
     public static final int OculusQuest2 = 9;
-    public static final int PicoXR = 12;
-
-    // These values are not present in Device.h yet but are needed for the WebXR UI
     public static final int HVR3DoF = 10;
     public static final int HVR6DoF = 11;
+    public static final int PicoXR = 12;
 
     private static @Type int mType = Unknown;
 

--- a/app/src/main/cpp/Device.h
+++ b/app/src/main/cpp/Device.h
@@ -40,6 +40,8 @@ const DeviceType PicoNeo2 = 6;
 const DeviceType PicoG2 = 7;
 const DeviceType PicoNeo3 = 8;
 const DeviceType OculusQuest2 = 9;
+const DeviceType HVR3DoF = 10;
+const DeviceType HVR6DoF = 11;
 const DeviceType PicoXR = 12;
 
 enum class TargetRayMode : uint8_t { Gaze, TrackedPointer, Screen };

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -98,6 +98,25 @@ struct DeviceDelegateOpenXR::State {
   std::optional<XrPosef> firstPose;
   bool mHandTrackingSupported = false;
 
+  bool IsPositionTrackingSupported() {
+      CHECK(system != XR_NULL_SYSTEM_ID);
+      CHECK(instance != XR_NULL_HANDLE);
+      return systemProperties.trackingProperties.positionTracking == XR_TRUE;
+  }
+
+  // This might require more sophisticated code to properly detect specific hardware. That was
+  // easy to do with propietary SDKs but it's a bit more difficult with OpenXR.
+  void InitializeDeviceType() {
+      VRB_LOG("Initializing device %s from vendor %d", systemProperties.systemName, systemProperties.vendorId);
+#if OCULUSVR
+      deviceType = device::OculusQuest2;
+#elif HVR
+      deviceType = IsPositionTrackingSupported() ? device::HVR6DoF : device::HVR3DoF;
+#elif PICOXR
+      deviceType = device::PicoXR;
+#endif
+  }
+
   void Initialize() {
     vrb::RenderContextPtr localContext = context.lock();
     elbow = ElbowModel::Create();
@@ -197,6 +216,8 @@ struct DeviceDelegateOpenXR::State {
 
     mHandTrackingSupported = handTrackingProperties.supportsHandTracking;
     VRB_LOG("OpenXR runtime %s hand tracking", mHandTrackingSupported ? "does support" : "doesn't support");
+
+    InitializeDeviceType();
   }
 
   // xrGet*GraphicsRequirementsKHR check must be called prior to xrCreateSession
@@ -639,7 +660,7 @@ DeviceDelegateOpenXR::GetControllerModelName(const int32_t aModelIndex) const {
 bool
 DeviceDelegateOpenXR::IsPositionTrackingSupported() const {
   // returns true for 6DoF controllers
-  return m.systemProperties.trackingProperties.positionTracking == XR_TRUE;
+  return m.IsPositionTrackingSupported();
 }
 
 void


### PR DESCRIPTION
DeviceType used to be properly initialized by each SDK backend on their respective DeviceDelegateXXX.cpp file. However that model does not work for OpenXR because it's a multidevice backend by itself.

This PR adds a very simple, build based, initialization code for the device type. More sophisticated platform code might be needed in the future to properly support more devices. OpenXR unfortunately does only provide the name of the system (pretty generic usually) and a vendor ID (not useful to differentiate among devices of the same vendor).