### PR TITLE
[OpenXR][Pico] Fix brightness issues

### DIFF
--- a/app/src/main/cpp/SplashAnimation.cpp
+++ b/app/src/main/cpp/SplashAnimation.cpp
@@ -79,7 +79,7 @@ SplashAnimation::Load(vrb::RenderContextPtr& aContext, const DeviceDelegatePtr& 
     return;
   }
   vrb::CreationContextPtr create = m.context.lock();
-#ifdef OCULUSVR
+#if OCULUSVR || PICOXR
   VRB_GL_CHECK(glDisable(GL_FRAMEBUFFER_SRGB_EXT));
 #endif
   vrb::TextureGLPtr texture = create->LoadTexture("logo.png");

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -716,7 +716,7 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
     return;
   }
 
-#if OCULUSVR
+#if OCULUSVR || PICOXR
   // Fix brigthness issue.
   glDisable(GL_FRAMEBUFFER_SRGB_EXT);
 #endif


### PR DESCRIPTION
We're basically applying the same trick as we did in the Oculus case, i.e, we disable GL_FRAMEBUFFER_SRGB_EXT so that we show the images with the correct color space.