### PR TITLE
Bring back the logins crash hack

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.launch
+import mozilla.appservices.logins.InvalidKeyException
 import mozilla.components.concept.storage.Login
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.sync.GlobalSyncableStoreProvider
@@ -22,7 +23,17 @@ class LoginStorage(
     init {
         EngineProvider.getOrCreateRuntime(context).setUpLoginPersistence(places.logins)
         GlobalScope.launch(Dispatchers.IO) {
-            storage.value.warmUp();
+            try {
+                storage.value.warmUp()
+            } catch (e: InvalidKeyException) {
+                // Login database sometimes gets corrupted for unknown reasons. This has been reported
+                // to mozilla components in the past (https://github.com/mozilla-mobile/android-components/issues/6681
+                // or https://github.com/mozilla-mobile/fenix/issues/15597) but it was never really
+                // fixed so clients have to deal with that. The only thing we could do is to delete
+                // the database file. We cannot just use wipe()/wipeLocal() because those calls also
+                // try to use the connection to the DB and thus they'll crash as well.
+                places.clearLoginsDatabaseUglyHack()
+            }
         }
 
         GlobalSyncableStoreProvider.configureStore(SyncEngine.Passwords to storage)

--- a/app/src/common/shared/com/igalia/wolvic/browser/Places.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/Places.kt
@@ -92,4 +92,15 @@ class Places(var context: Context) {
             logins.value.wipeLocal()
         }
     }
+
+    fun clearLoginsDatabaseUglyHack() {
+        // This is the ugliest part of this hack. We're using the name extracted from the sources of the
+        // mozilla-components. That database file should be totally opaque to us, but that's what it is as
+        // long as mozilla-components don't provide a better solution for clients.
+        var loginsDatabase = context.getDatabasePath("logins.sqlite")
+        if (loginsDatabase != null) {
+            if (loginsDatabase.delete())
+                Logger.warn("Force-deleted logins database ${loginsDatabase.absolutePath}")
+        }
+    }
 }


### PR DESCRIPTION
We were told in https://github.com/mozilla-mobile/android-components/issues/6681 that there were no more crashes reported starting on Mozilla AC v75. That's why after the migration to that version we decided to remove the ugly hack that prevented those crashes inside Wolvic. From our testing we were indeed unable to reproduce the crash.

However some users have recently reported again the same crash in pre-release builds of Wolvic which were shipped with v75 and without the ugly fix. That's why we have to add it again to avoid having those crashes in next releases.