### PR TITLE
Thumbnails in the Downloads tab

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
@@ -116,6 +116,7 @@ public class Download {
         return mDescription;
     }
 
+    @Status
     public int getStatus() {
         return mStatus;
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
@@ -156,13 +156,14 @@ public class DownloadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 binding.thumbnail.setImageResource(R.drawable.ic_error_circle);
                 break;
             case Download.SUCCESSFUL: {
-                if (downloadItem.getOutputFileUri() == null) {
-                    binding.thumbnail.setImageResource(R.drawable.ic_generic_file);
+                String fileUri = downloadItem.getOutputFileUri();
+                if (fileUri == null) {
+                    // If this ever happens, we mark the item as unavailable.
+                    binding.thumbnail.setImageResource(R.drawable.ic_error_circle);
                 } else {
-                    final String itemUri = downloadItem.getOutputFileUri();
-                    ThumbnailAsyncTask task = new ThumbnailAsyncTask(binding.layout.getContext(), Uri.parse(itemUri),
+                    ThumbnailAsyncTask task = new ThumbnailAsyncTask(binding.layout.getContext(), Uri.parse(fileUri),
                             bitmap -> {
-                                if (bitmap == null || binding.getItem() == null || !Objects.equals(itemUri, binding.getItem().getOutputFileUri()))
+                                if (bitmap == null || binding.getItem() == null || !Objects.equals(fileUri, binding.getItem().getOutputFileUri()))
                                     binding.thumbnail.setImageResource(R.drawable.ic_generic_file);
                                 else
                                     binding.thumbnail.setImageBitmap(bitmap);

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
@@ -2,6 +2,7 @@ package com.igalia.wolvic.ui.adapters;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -23,6 +24,7 @@ import com.igalia.wolvic.utils.AnimationHelper;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 public class DownloadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
@@ -135,8 +137,42 @@ public class DownloadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         DownloadItemViewHolder item = (DownloadItemViewHolder) holder;
         DownloadItemBinding binding = item.binding;
-        item.binding.setItem(mDownloadsList.get(position));
+        Download downloadItem = mDownloadsList.get(position);
+        item.binding.setItem(downloadItem);
         item.binding.setIsNarrow(mIsNarrowLayout);
+
+        switch (downloadItem.getStatus()) {
+            case Download.PENDING:
+                binding.thumbnail.setImageResource(R.drawable.ic_pending_circle);
+                break;
+            case Download.RUNNING:
+                binding.thumbnail.setImageResource(R.drawable.ic_downloading_circle);
+                break;
+            case Download.PAUSED:
+                binding.thumbnail.setImageResource(R.drawable.ic_pause_circle);
+                break;
+            case Download.FAILED:
+            case Download.UNAVAILABLE:
+                binding.thumbnail.setImageResource(R.drawable.ic_error_circle);
+                break;
+            case Download.SUCCESSFUL: {
+                if (downloadItem.getOutputFileUri() == null) {
+                    binding.thumbnail.setImageResource(R.drawable.ic_generic_file);
+                } else {
+                    final String itemUri = downloadItem.getOutputFileUri();
+                    ThumbnailAsyncTask task = new ThumbnailAsyncTask(binding.layout.getContext(), Uri.parse(itemUri),
+                            bitmap -> {
+                                if (bitmap == null || binding.getItem() == null || !Objects.equals(itemUri, binding.getItem().getOutputFileUri()))
+                                    binding.thumbnail.setImageResource(R.drawable.ic_generic_file);
+                                else
+                                    binding.thumbnail.setImageBitmap(bitmap);
+                            }
+                    );
+                    task.execute();
+                }
+                break;
+            }
+        }
         binding.layout.setOnHoverListener((view, motionEvent) -> {
             int ev = motionEvent.getActionMasked();
             switch (ev) {

--- a/app/src/main/res/drawable/ic_downloading_circle.xml
+++ b/app/src/main/res/drawable/ic_downloading_circle.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18.32,4.26C16.84,3.05 15.01,2.25 13,2.05v2.02c1.46,0.18 2.79,0.76 3.9,1.62L18.32,4.26zM19.93,11h2.02c-0.2,-2.01 -1,-3.84 -2.21,-5.32L18.31,7.1C19.17,8.21 19.75,9.54 19.93,11zM18.31,16.9l1.43,1.43c1.21,-1.48 2.01,-3.32 2.21,-5.32h-2.02C19.75,14.46 19.17,15.79 18.31,16.9zM13,19.93v2.02c2.01,-0.2 3.84,-1 5.32,-2.21l-1.43,-1.43C15.79,19.17 14.46,19.75 13,19.93zM13,12V7h-2v5H7l5,5l5,-5H13zM11,19.93v2.02c-5.05,-0.5 -9,-4.76 -9,-9.95s3.95,-9.45 9,-9.95v2.02C7.05,4.56 4,7.92 4,12S7.05,19.44 11,19.93z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_error_circle.xml
+++ b/app/src/main/res/drawable/ic_error_circle.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11,15h2v2h-2v-2zM11,7h2v6h-2L11,7zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_pause_circle.xml
+++ b/app/src/main/res/drawable/ic_pause_circle.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,16h2V8H9V16zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8s8,3.59 8,8S16.41,20 12,20zM13,16h2V8h-2V16z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_pending_circle.xml
+++ b/app/src/main/res/drawable/ic_pending_circle.xml
@@ -1,0 +1,8 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12c0,5.52 4.48,10 10,10s10,-4.48 10,-10C22,6.48 17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8c0,-4.42 3.58,-8 8,-8s8,3.58 8,8C20,16.42 16.42,20 12,20z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M7,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    <path android:fillColor="@android:color/white" android:pathData="M12,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    <path android:fillColor="@android:color/white" android:pathData="M17,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+</vector>

--- a/app/src/main/res/layout/download_item.xml
+++ b/app/src/main/res/layout/download_item.xml
@@ -26,8 +26,7 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="@dimen/library_item_row_height"
-        app:layout_height="@{isNarrow ? @dimen/library_item_row_height_narrow : @dimen/library_item_row_height}"
+        android:layout_height="wrap_content"
         android:layout_marginEnd="20dp"
         android:background="@color/void_color">
 
@@ -42,6 +41,8 @@
             android:onClick="@{(view) ->  callback.onClick(view, item)}"
             android:paddingStart="10dp"
             android:paddingEnd="10dp"
+            android:paddingTop="5dp"
+            android:paddingBottom="5dp"
             android:soundEffectsEnabled="false"
             android:addStatesFromChildren="true">
 
@@ -54,7 +55,16 @@
                 android:layout_toStartOf="@id/time_buttons"
                 android:gravity="center_vertical"
                 android:addStatesFromChildren="true"
-                android:orientation="@{isNarrow ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}">
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/thumbnail"
+                    android:layout_width="@dimen/thumbnailSize"
+                    android:layout_height="@dimen/thumbnailSize"
+                    android:layout_gravity="center"
+                    android:layout_marginEnd="10dp"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_generic_file" />
 
                 <TextView
                     android:id="@+id/url"
@@ -62,7 +72,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:ellipsize="middle"
-                    android:paddingEnd="20dp"
+                    android:layout_marginEnd="20dp"
                     android:scrollHorizontally="true"
                     android:singleLine="true"
                     android:text="@{item.filename}"
@@ -77,7 +87,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="2"
                     android:ellipsize="end"
-                    android:paddingEnd="20dp"
+                    android:layout_marginEnd="20dp"
                     android:scrollHorizontally="true"
                     android:singleLine="true"
                     android:gravity="@{isNarrow ? Gravity.START : Gravity.END}"


### PR DESCRIPTION
Display thumbnails in the Downloads tab in the Library. This reuses the same functionality that we implemented for the file uploading dialog.

Several new icons are added to illustrate the different states of a downloading file.

This PR depends on https://github.com/Igalia/wolvic/pull/361