### PR TITLE
OpenXR: Emulate Oculus Touch interaction profile if hand tracking is enabled

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -449,7 +449,7 @@ struct DeviceDelegateOpenXR::State {
   const char* GetDefaultInteractionProfilePath() {
 #if OCULUSVR
       return OculusTouch.path;
-#elif PICO4
+#elif PICOXR
       return Pico4.path;
 #else
       return nullptr;
@@ -468,8 +468,7 @@ struct DeviceDelegateOpenXR::State {
       // This is a temporary situation while we don't implement WebXR hand tracking
       // APIs.
       if (mHandTrackingSupported) {
-          const char* defaultProfilePath = GetDefaultInteractionProfilePath();
-          if (defaultProfilePath)
+          if (const char* defaultProfilePath = GetDefaultInteractionProfilePath())
               UpdateInteractionProfile(defaultProfilePath);
       }
   }
@@ -571,8 +570,7 @@ struct DeviceDelegateOpenXR::State {
     // TODO: Check if activity globarRef needs to be released
   }
 
-  void UpdateInteractionProfile(const char* emulateProfile = nullptr)
-  {
+  void UpdateInteractionProfile(const char* emulateProfile = nullptr) {
       if (!input || !controller)
           return;
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -38,6 +38,7 @@
 #include "OpenXRHelpers.h"
 #include "OpenXRSwapChain.h"
 #include "OpenXRInput.h"
+#include "OpenXRInputMappings.h"
 #include "OpenXRExtensions.h"
 #include "OpenXRLayers.h"
 
@@ -445,12 +446,33 @@ struct DeviceDelegateOpenXR::State {
     return nullptr;
   }
 
+  const char* GetDefaultInteractionProfilePath() {
+#if OCULUSVR
+      return OculusTouch.path;
+#elif PICO4
+      return Pico4.path;
+#else
+      return nullptr;
+#endif
+  }
+
   void BeginXRSession() {
       XrSessionBeginInfo sessionBeginInfo{XR_TYPE_SESSION_BEGIN_INFO};
       sessionBeginInfo.primaryViewConfigurationType = viewConfigType;
       CHECK_XRCMD(xrBeginSession(session, &sessionBeginInfo));
       vrReady = true;
-    }
+
+      // If hand tracking is supported, we want to emulate a default interaction
+      // profile, so that if Wolvic is launched without controllers active, we can
+      // still use hand tracking for emulating the controllers.
+      // This is a temporary situation while we don't implement WebXR hand tracking
+      // APIs.
+      if (mHandTrackingSupported) {
+          const char* defaultProfilePath = GetDefaultInteractionProfilePath();
+          if (defaultProfilePath)
+              UpdateInteractionProfile(defaultProfilePath);
+      }
+  }
 
   void HandleSessionEvent(const XrEventDataSessionStateChanged& event) {
     VRB_LOG("OpenXR XrEventDataSessionStateChanged: state %s->%s session=%p time=%ld",
@@ -547,6 +569,18 @@ struct DeviceDelegateOpenXR::State {
     }
 
     // TODO: Check if activity globarRef needs to be released
+  }
+
+  void UpdateInteractionProfile(const char* emulateProfile = nullptr)
+  {
+      if (!input || !controller)
+          return;
+
+      input->UpdateInteractionProfile(*controller, emulateProfile);
+      if (controllersReadyCallback && input->AreControllersReady()) {
+          controllersReadyCallback();
+          controllersReadyCallback = nullptr;
+      }
   }
 };
 
@@ -692,13 +726,7 @@ DeviceDelegateOpenXR::ProcessEvents() {
         return;
       }
       case XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED: {
-        if (m.input) {
-          m.input->UpdateInteractionProfile(*m.controller);
-          if (m.controllersReadyCallback && m.input->AreControllersReady()) {
-            m.controllersReadyCallback();
-            m.controllersReadyCallback = nullptr;
-          }
-        }
+        m.UpdateInteractionProfile();
         break;
       }
       case XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING:

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -107,10 +107,10 @@ std::string OpenXRInput::GetControllerModelName(const int32_t aModelIndex) const
   return mInputSources.at(aModelIndex)->ControllerModelName();
 }
 
-void OpenXRInput::UpdateInteractionProfile(ControllerDelegate& delegate)
+void OpenXRInput::UpdateInteractionProfile(ControllerDelegate& delegate, const char* emulateProfile)
 {
   for (auto& input : mInputSources) {
-    input->UpdateInteractionProfile(delegate);
+    input->UpdateInteractionProfile(delegate, emulateProfile);
   }
 }
 

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -36,7 +36,7 @@ public:
   XrResult Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, float offsetY, device::RenderMode renderMode, ControllerDelegate& delegate);
   int32_t GetControllerModelCount() const;
   std::string GetControllerModelName(const int32_t aModelIndex) const;
-  void UpdateInteractionProfile(ControllerDelegate&);
+  void UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);
   bool AreControllersReady() const;
 
   ~OpenXRInput();

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -790,14 +790,27 @@ XrResult OpenXRInputSource::UpdateInteractionProfile(ControllerDelegate& delegat
         }
     }
 
-    // Add haptic devices to controller, if any
     if (mActiveMapping != nullptr) {
+        // Add haptic devices to controller, if any
         uint32_t numHaptics = 0;
         for (auto& haptic: mActiveMapping->haptics) {
             if (haptic.hand == OpenXRHandFlags::Both || haptic.hand == mHandeness)
                 numHaptics++;
         }
         delegate.SetHapticCount(mIndex, numHaptics);
+
+        // On emulated profiles we need to set the button count here because it
+        // may never be set during Update() (e.g, when hand tracking is active).
+        if (emulateProfile) {
+            int buttonCount { 0 };
+            for (auto &button: mActiveMapping->buttons) {
+                if ((button.hand & mHandeness) == 0) {
+                    continue;
+                }
+                buttonCount++;
+            }
+            delegate.SetButtonCount(mIndex, buttonCount);
+        }
     }
 
     return XR_SUCCESS;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -97,7 +97,7 @@ public:
     XrResult SuggestBindings(SuggestedBindings&) const;
     void EmulateControllerFromHand(device::RenderMode renderMode, ControllerDelegate& delegate);
     void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, float offsetY, device::RenderMode, ControllerDelegate& delegate);
-    XrResult UpdateInteractionProfile(ControllerDelegate&);
+    XrResult UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }
 };


### PR DESCRIPTION
Since we are emulating controller functionality for hand tracking, we need to always have an active interaction profile, even if Wolvic is launched without any controllers active.

This patch emulates the activation of OculusTouch controllers at the beginnig of the OpenXR session, if hand tracking support is detected at runtime.

However, there is a caveat: in immersive mode, hand tracking will not work if the actual controllers have not been used at least once since Wolvic was launched. This is because we are implementing hand-tracking in Wolvic side, and Gecko engine is unaware of the emulation of controllers. So if gecko hasn't populated any controllers to the web app through WebXR APIs, the web app will not detect any controller during an immersive experience. 