### PR TITLE
[OpenXR] Vertically flip OpenXR layers in Meta

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1087,13 +1087,7 @@ DeviceDelegateOpenXR::CreateLayerEquirect(const VRLayerPtr &aSource) {
   if (m.equirectLayer) {
     m.equirectLayer->Destroy();
   }
-  bool verticalFlip = false;
-#ifdef OCULUSVR
-    if (OpenXRExtensions::IsExtensionSupported(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME)) {
-        verticalFlip = true;
-    }
-#endif
-  m.equirectLayer = OpenXRLayerEquirect::Create(result, source, verticalFlip);
+  m.equirectLayer = OpenXRLayerEquirect::Create(result, source);
   if (m.session != XR_NULL_HANDLE) {
     vrb::RenderContextPtr context = m.context.lock();
     m.equirectLayer->Init(m.javaContext->env, m.session, context);

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -221,8 +221,7 @@ OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
 #if OCULUSVR
 const void*
 OpenXRLayerEquirect::GetNextStructureInChain() const {
-    // Oculus OpenXR backend flips layers vertically.
-    return OpenXRExtensions::IsExtensionSupported(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME) ? &this->mLayerImageLayout : XR_NULL_HANDLE;
+    return this->nextStructureInChain;
 }
 #endif
 

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -14,6 +14,7 @@
 #include <openxr/openxr_platform.h>
 #include "OpenXRSwapChain.h"
 #include "OpenXRHelpers.h"
+#include "OpenXRExtensions.h"
 #include <array>
 
 
@@ -78,12 +79,15 @@ public:
     });
   }
 
+  virtual const void* GetNextStructureInChain() const { return XR_NULL_HANDLE; };
+
   virtual void
   Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override {
     for (int i = 0; i < xrLayers.size(); ++i) {
       xrLayers[i].layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
       xrLayers[i].eyeVisibility = XR_EYE_VISIBILITY_BOTH;
       xrLayers[i].space = aSpace;
+      xrLayers[i].next = GetNextStructureInChain();
     }
   }
 
@@ -190,6 +194,11 @@ protected:
 
     return info;
   }
+
+protected:
+#if OCULUSVR
+    XrCompositionLayerImageLayoutFB mLayerImageLayout { .type = XR_TYPE_COMPOSITION_LAYER_IMAGE_LAYOUT_FB, .next = XR_NULL_HANDLE, .flags = XR_COMPOSITION_LAYER_IMAGE_LAYOUT_VERTICAL_FLIP_BIT_FB };
+#endif
 };
 
 
@@ -211,6 +220,13 @@ public:
     });
     OpenXRLayerBase<T, U>::Init(aEnv, session, aContext);
   }
+
+#if OCULUSVR
+  const void* GetNextStructureInChain() const override {
+    // Oculus OpenXR backend flips layers vertically.
+    return OpenXRExtensions::IsExtensionSupported(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME) ? &this->mLayerImageLayout : XR_NULL_HANDLE;
+  }
+#endif
 
   void Resize() {
     if (!this->IsSwapChainReady()) {
@@ -336,15 +352,14 @@ public:
   std::weak_ptr<OpenXRLayer> sourceLayer;
 
   static OpenXRLayerEquirectPtr
-  Create(const VRLayerEquirectPtr &aLayer, const OpenXRLayerPtr &aSourceLayer, bool aVerticalFlip);
+  Create(const VRLayerEquirectPtr &aLayer, const OpenXRLayerPtr &aSourceLayer);
   void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
   void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
   void Destroy() override;
   bool IsDrawRequested() const override;
-
-protected:
-  XrCompositionLayerImageLayoutFB mLayerImageLayout;
-  bool mVerticalFlip;
+#if OCULUSVR
+  const void* GetNextStructureInChain() const override;
+#endif
 };
 
 }

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -196,8 +196,14 @@ protected:
   }
 
 protected:
-#if OCULUSVR
-    XrCompositionLayerImageLayoutFB mLayerImageLayout { .type = XR_TYPE_COMPOSITION_LAYER_IMAGE_LAYOUT_FB, .next = XR_NULL_HANDLE, .flags = XR_COMPOSITION_LAYER_IMAGE_LAYOUT_VERTICAL_FLIP_BIT_FB };
+#if OCULUSVR \
+  // Oculus OpenXR backend flips layers vertically.
+  XrCompositionLayerImageLayoutFB mLayerImageLayout {
+    .type = XR_TYPE_COMPOSITION_LAYER_IMAGE_LAYOUT_FB,
+    .next = XR_NULL_HANDLE,
+    .flags = XR_COMPOSITION_LAYER_IMAGE_LAYOUT_VERTICAL_FLIP_BIT_FB
+  };
+  void* nextStructureInChain { OpenXRExtensions::IsExtensionSupported(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME) ? &mLayerImageLayout : XR_NULL_HANDLE };
 #endif
 };
 
@@ -223,8 +229,7 @@ public:
 
 #if OCULUSVR
   const void* GetNextStructureInChain() const override {
-    // Oculus OpenXR backend flips layers vertically.
-    return OpenXRExtensions::IsExtensionSupported(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME) ? &this->mLayerImageLayout : XR_NULL_HANDLE;
+    return this->nextStructureInChain;
   }
 #endif
 


### PR DESCRIPTION
Most OpenXR layers in Meta appear upside down, i.e., flipped in the y direction. In particular we're talking about Quad,
Cylinder and Equirect layers (cubemaps are not affected).

This does not happen in other devices using XRLayers (like Pico) so it must be definitely a Meta implementation issue.
In order to fix that we use the XR_FB_composition_layer_image_layout extension developed precisely by Meta.

We were using this only for equirect layers but it turns out that quad and cylinder are also affected, so we've generalized
the same fix for the other layer types.