### PR TITLE
[OpenXR][Pico] Remove scaling factor

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -268,19 +268,6 @@ struct DeviceDelegateOpenXR::State {
     viewConfig.resize(viewCount, {XR_TYPE_VIEW_CONFIGURATION_VIEW});
     CHECK_XRCMD(xrEnumerateViewConfigurationViews(instance, system, viewConfigType, viewCount, &viewCount, viewConfig.data()));
 
-#ifdef PICOXR
-    // The Pico 4 is much more capable than it advertises via OpenXR, and the primary device used
-    // with Pico XR builds. We thus bump resulutions by 1.4 for a drastic improvement in image clarity.
-    if (viewCount > 0) {
-      viewConfig.front().recommendedImageRectWidth = std::min<unsigned int>(
-          viewConfig.front().maxImageRectWidth,
-          viewConfig.front().recommendedImageRectWidth * 1.4f);
-      viewConfig.front().recommendedImageRectHeight = std::min<unsigned int>(
-          viewConfig.front().maxImageRectHeight,
-          viewConfig.front().recommendedImageRectHeight * 1.4f);
-    }
-#endif
-
     // Cache view buffer (used in xrLocateViews)
     views.resize(viewCount, {XR_TYPE_VIEW});
 


### PR DESCRIPTION
When the PicoXR flavour was added it came with some upscaling code that increases the resolution used to render
the Wolvic widgets.

However that's a mistake. We should not ignore the limits provided by OpenXR as we might compromise stability. 
In fact this code causes a lot of crashes (OOM issues) when using XRLayers as the code will create swapchains 
bigger than expected.