### PR TITLE
[OpenXR][Pico] Enable hand tracking in the manifest

### DIFF
--- a/app/src/picoxr/AndroidManifest.xml
+++ b/app/src/picoxr/AndroidManifest.xml
@@ -12,5 +12,6 @@
             </intent-filter>
         </activity>
         <meta-data android:name="pvr.app.type" android:value="vr" />
+        <meta-data android:name="handtracking" android:value="1" />
     </application>
 </manifest>


### PR DESCRIPTION
In order to launch Wolvic when the user is using hand tracking instead of the controllers, we have to declare in the 
manifest that the application supports hand tracking.

Note that the hand tracking support is still WIP, so don't expect it to work on Pico just because we allow it in the manifest.