### PR TITLE
[Extensions] Allow installation of locally downloaded extensions/addons

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/addons/adapters/AddonsListViewAdapter.kt
+++ b/app/src/common/shared/com/igalia/wolvic/addons/adapters/AddonsListViewAdapter.kt
@@ -256,6 +256,8 @@ class AddonsManagerAdapter(
         val installedAddons = ArrayList<Addon>()
         val recommendedAddons = ArrayList<Addon>()
         val disabledAddons = ArrayList<Addon>()
+        // TODO Create another section for locally installed addons
+        // addons.forEach { addon -> logger.debug("Addons list " + addon.id + " " + addon.installedState) }
 
         addons.forEach { addon ->
             when {
@@ -391,8 +393,9 @@ class AddonsManagerAdapter(
 }
 
 private fun Addon.inRecommendedSection() = !isInstalled()
-private fun Addon.inInstalledSection() = isInstalled() && isSupported() && isEnabled()
-private fun Addon.inDisabledSection() = isInstalled() && isSupported() && !isEnabled()
+//private fun Addon.inInstalledSection() = isInstalled() && isSupported() && isEnabled()
+private fun Addon.inInstalledSection() = isInstalled() && isEnabled()
+private fun Addon.inDisabledSection() = isInstalled() && !isEnabled()
 
 /**
  * Get the formatted number amount for the current default locale.

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -112,6 +112,7 @@ public class SettingsStore {
     public final static int DOWNLOADS_SORTING_ORDER_DEFAULT = SortingContextMenuWidget.SORT_DATE_DESC;
     public final static boolean AUTOCOMPLETE_ENABLED = true;
     public final static boolean WEBGL_OUT_OF_PROCESS = false;
+    public final static boolean ALLOW_LOCAL_ADDON = false;
     public final static int PREFS_LAST_RESET_VERSION_CODE = 0;
     public final static boolean PASSWORDS_ENCRYPTION_KEY_GENERATED = false;
     public final static boolean AUTOFILL_ENABLED = true;
@@ -810,6 +811,16 @@ public class SettingsStore {
 
     public boolean isWebGLOutOfProcess() {
         return mPrefs.getBoolean(mContext.getString(R.string.settings_key_webgl_out_of_process), WEBGL_OUT_OF_PROCESS);
+    }
+
+    public void setAllowLocalAddon(boolean isEnabled) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(mContext.getString(R.string.settings_key_allow_local_addon), isEnabled);
+        editor.commit();
+    }
+
+    public boolean isAllowLocalAddon() {
+        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_allow_local_addon), ALLOW_LOCAL_ADDON);
     }
 
     public int getPrefsLastResetVersionCode() {

--- a/app/src/common/shared/com/igalia/wolvic/browser/extensions/LocalExtension.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/extensions/LocalExtension.java
@@ -1,0 +1,40 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.igalia.wolvic.browser.extensions;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.igalia.wolvic.utils.SystemUtils;
+
+import mozilla.components.concept.engine.webextension.WebExtensionRuntime;
+
+/**
+ * Feature to install temporary extensions from local add-on files.
+ */
+public class LocalExtension {
+
+    private static final String LOGTAG = SystemUtils.createLogtag(LocalExtension.class);
+
+    /**
+     * Installs the web extension in the runtime through the WebExtensionRuntime install method
+     */
+    public static void install(@NonNull WebExtensionRuntime runtime, @NonNull String extensionId, @NonNull String extensionUrl) {
+        runtime.installWebExtension(extensionId, extensionUrl, webExtension -> {
+//            TODO Debug addon installedstate enabled false
+//            runtime.enableWebExtension(webExtension, EnableSource.APP_SUPPORT, addon1 -> null, throwable -> {
+//                Log.d(LOGTAG, String.valueOf(throwable.getMessage()));
+//                return null;
+//            });
+            Log.i(LOGTAG, extensionId + " from " + extensionUrl + " Web Extension successfully installed");
+            return null;
+        }, (s, throwable) -> {
+            Log.e(LOGTAG, "Error installing the " + extensionId + " from " + extensionUrl + " Web Extension: " + throwable.getLocalizedMessage());
+            return null;
+        });
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
@@ -139,7 +139,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         public void onClick(@NonNull View view, @NonNull Download item) {
             mBinding.downloadsList.requestFocusFromTouch();
 
-            if (item.getMediaType().equals(UrlUtils.EXTENSION_MIME_TYPE)) {
+            if (SettingsStore.getInstance(getContext()).isAllowLocalAddon() && item.getMediaType().equals(UrlUtils.EXTENSION_MIME_TYPE)) {
                 LocalExtension.install(
                         SessionStore.get().getWebExtensionRuntime(),
                         UUID.randomUUID().toString(),

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
@@ -40,10 +40,13 @@ import com.igalia.wolvic.ui.widgets.menus.library.DownloadsContextMenuWidget;
 import com.igalia.wolvic.ui.widgets.menus.library.LibraryContextMenuWidget;
 import com.igalia.wolvic.ui.widgets.menus.library.SortingContextMenuWidget;
 import com.igalia.wolvic.utils.SystemUtils;
+import com.igalia.wolvic.browser.extensions.LocalExtension;
+import com.igalia.wolvic.utils.UrlUtils;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.UUID;
 
 public class DownloadsView extends LibraryView implements DownloadsManager.DownloadsListener {
 
@@ -136,10 +139,18 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         public void onClick(@NonNull View view, @NonNull Download item) {
             mBinding.downloadsList.requestFocusFromTouch();
 
-            SessionStore.get().getActiveSession().loadUri(item.getOutputFileUri());
+            if (item.getMediaType().equals(UrlUtils.EXTENSION_MIME_TYPE)) {
+                LocalExtension.install(
+                        SessionStore.get().getWebExtensionRuntime(),
+                        UUID.randomUUID().toString(),
+                        item.getOutputFileUri()
+                );
+            } else {
+                SessionStore.get().getActiveSession().loadUri(item.getOutputFileUri());
 
-            WindowWidget window = mWidgetManager.getFocusedWindow();
-            window.hidePanel();
+                WindowWidget window = mWidgetManager.getFocusedWindow();
+                window.hidePanel();
+            }
         }
 
         @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
@@ -73,6 +73,9 @@ class DeveloperOptionsView extends SettingsView {
         } else {
             mBinding.webglOutOfProcessSwitch.setVisibility(View.GONE);
         }
+
+        mBinding.allowLocalAddonSwitch.setOnCheckedChangeListener(mAllowLocalAddonListener);
+        setAllowLocalAddon(SettingsStore.getInstance(getContext()).isAllowLocalAddon(), false);
     }
 
     private SwitchSetting.OnCheckedChangeListener mRemoteDebuggingListener = (compoundButton, value, doApply) -> {
@@ -97,6 +100,10 @@ class DeveloperOptionsView extends SettingsView {
 
     private SwitchSetting.OnCheckedChangeListener mWebGLOutOfProcessListener = (compundButton, value, doApply) -> {
         setWebGLOutOfProcess(value, doApply);
+    };
+
+    private SwitchSetting.OnCheckedChangeListener mAllowLocalAddonListener = (compoundButton, value, doApply) -> {
+        setAllowLocalAddon(value, doApply);
     };
 
     private OnClickListener mResetListener = (view) -> {
@@ -126,6 +133,10 @@ class DeveloperOptionsView extends SettingsView {
         if (BuildConfig.DEBUG && mBinding.webglOutOfProcessSwitch.isChecked() != SettingsStore.WEBGL_OUT_OF_PROCESS) {
             setWebGLOutOfProcess(SettingsStore.WEBGL_OUT_OF_PROCESS, true);
             restart = true;
+        }
+
+        if (mBinding.allowLocalAddonSwitch.isChecked() != SettingsStore.ALLOW_LOCAL_ADDON) {
+            setAllowLocalAddon(SettingsStore.ALLOW_LOCAL_ADDON, true);
         }
 
         if (restart) {
@@ -195,6 +206,16 @@ class DeveloperOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setWebGLOutOfProcess(value);
             showRestartDialog();
+        }
+    }
+
+    private void setAllowLocalAddon(boolean value, boolean doApply) {
+        mBinding.allowLocalAddonSwitch.setOnCheckedChangeListener(null);
+        mBinding.allowLocalAddonSwitch.setValue(value, false);
+        mBinding.allowLocalAddonSwitch.setOnCheckedChangeListener(mAllowLocalAddonListener);
+
+        if (doApply) {
+            SettingsStore.getInstance(getContext()).setAllowLocalAddon(value);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -135,12 +135,15 @@ public class UrlUtils {
     }
 
     public static String getMimeTypeFromUrl(String url) {
+        String mimeType = UNKNOWN_MIME_TYPE;
         String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension == null) {
-            return UNKNOWN_MIME_TYPE;
-        } else {
-            return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+        if (extension != null) {
+            mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+            if (mimeType == null) {
+                return UNKNOWN_MIME_TYPE;
+            }
         }
+        return mimeType;
     }
 
     public static String titleBarUrl(@Nullable String aUri) {

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -34,6 +34,7 @@ public class UrlUtils {
     private static List<String> ENGINE_SUPPORTED_SCHEMES = Arrays.asList(null, "about", "data", "file", "ftp", "http", "https", "moz-extension", "moz-safe-about", "resource", "view-source", "ws", "wss", "blob");
 
     public static String UNKNOWN_MIME_TYPE = "application/octet-stream";
+    public static String EXTENSION_MIME_TYPE = "application/x-xpinstall";
 
     public static String stripCommonSubdomains(@Nullable String host) {
         if (host == null) {

--- a/app/src/main/res/layout/options_developer.xml
+++ b/app/src/main/res/layout/options_developer.xml
@@ -73,6 +73,12 @@
                     android:layout_height="wrap_content"
                     app:description="@string/enable_webgl_out_of_process_switch" />
 
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/allow_local_addon_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/allow_local_addon_switch" />
+
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -61,6 +61,8 @@
     <string name="settings_key_webgl_out_of_process" translatable="false">settings_key_webgl_out_of_processe</string>
     <string name="settings_key_prefs_last_reset_version_code" translatable="false">settings_key_prefs_last_reset_version_code</string>
     <string name="enable_webgl_out_of_process_switch" translatable="false">Out of Process WebGL</string>
+    <string name="settings_key_allow_local_addon" translatable="false">settings_key_allow_local_addon</string>
+    <string name="allow_local_addon_switch" translatable="false">Allow Installation of Local Addons</string>
     <string name="settings_key_passwords_encryption_key_generated" translatable="false">settings_key_passwords_encryption_key_generated</string>
     <string name="settings_key_autofill_enabled" translatable="false">settings_key_autofill_enabled</string>
     <string name="settings_key_login_autocomplete_enabled" translatable="false">settings_key_login_autocomplete_enabled</string>


### PR DESCRIPTION
Related to #22 
This PR adds a Developer Setting to Allow installation of locally downloaded extensions.
## Flow:
1. User enables Developer Option to Allow local addon installation (Settings > Developer Options >  "Allow Installation of Local Addons")
2. User downloads .xpi file from the extension's website
3. User clicks on the corresponding entry in the Download Manager
4. The addon is installed and enabled

## TODO
[ ] Dialog to show success/failure of addon installation
[ ] Update Addons List as soon as addon installation complete (currently have to reopen the app to refresh the list)
[ ] Fix addon showing up in the Disabled section even though Enabled. This is probably because of [AddonManager code in AC 75.0.22](https://github.com/mozilla-mobile/android-components/blob/5204f4025ce8b60c64f92eb3f60ee644cafd4fc8/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt#L105), which provides list of addons, ignores `installedstate` and forces `enabled = false`
[ ] Tests for the feature?

![com igalia wolvic-20221225-191408](https://user-images.githubusercontent.com/19701790/209495394-aa166607-1723-421c-bf4b-f71823b46207.jpg)
![com igalia wolvic-20221225-191339](https://user-images.githubusercontent.com/19701790/209495401-5b9888b4-8184-4bd0-8f57-a8701128252f.jpg)
