### PR TITLE
[OpenXR][XRLayers] Improve OpenXR Layers support

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1770,6 +1770,9 @@ BrowserWorld::CreateSkyBox(const std::string& aBasePath, const std::string& aExt
   if (extension == ".ktx") {
 #if defined(OPENXR) && defined(OCULUSVR)
     glFormat =  GL_COMPRESSED_SRGB8_ETC2;
+#elif defined(PICOXR)
+    // FIXME: Pico does not support compressed textures yet.
+    glFormat = GL_RGBA8;
 #else
     glFormat =  GL_COMPRESSED_RGB8_ETC2;
 #endif

--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -366,11 +366,13 @@ VRLayerQuad::~VRLayerQuad() {}
 struct VRLayerCylinder::State: public VRLayerSurface::State {
   float radius;
   vrb::Matrix uvTransform[2];
+  vrb::Matrix rotation;
   State():
       radius(1.0f)
   {
     uvTransform[0] = vrb::Matrix::Identity();
     uvTransform[1] = vrb::Matrix::Identity();
+    rotation = vrb::Matrix::Identity();
   }
 };
 
@@ -397,6 +399,16 @@ VRLayerCylinder::GetUVTransform(device::Eye aEye) const {
 void
 VRLayerCylinder::SetUVTransform(device::Eye aEye, const vrb::Matrix& aTransform) {
   m.uvTransform[device::EyeIndex(aEye)] = aTransform;
+}
+
+void
+VRLayerCylinder::SetRotation(const vrb::Matrix& aTransform) {
+  m.rotation = aTransform;
+}
+
+vrb::Matrix&
+VRLayerCylinder::GetRotation() {
+  return m.rotation;
 }
 
 void

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -142,6 +142,8 @@ public:
   const vrb::Matrix& GetUVTransform(device::Eye aEye) const;
   void SetRadius(const float aRadius);
   void SetUVTransform(device::Eye aEye, const vrb::Matrix& aTransform);
+  void SetRotation(const vrb::Matrix& aTransform);
+  vrb::Matrix& GetRotation();
 protected:
   struct State;
   VRLayerCylinder(State& aState);

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -38,7 +38,12 @@ OpenXRLayerQuad::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClear
 
   for (int i = 0; i < xrLayers.size(); ++i) {
     device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
+#if PICOXR
+    // Seems like Pico does not properly use the layerSpace.
+    xrLayers[i].pose =  MatrixToXrPose(layer->GetModelTransform(eye).Translate(-kAverageHeight));
+#else
     xrLayers[i].pose =  MatrixToXrPose(layer->GetModelTransform(eye));
+#endif
     xrLayers[i].size.width = layer->GetWorldWidth();
     xrLayers[i].size.height = layer->GetWorldHeight();
     device::EyeRect rect = layer->GetTextureRect(eye);
@@ -76,6 +81,10 @@ OpenXRLayerCylinder::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
 
     auto scale = layer->GetModelTransform(eye).GetScale();
     auto model = layer->GetModelTransform(eye).Scale({1/scale.x(), 1/scale.y(), 1/scale.z()});
+#if PICOXR
+    // Seems like Pico does not properly use the layerSpace.
+    model = model.Translate(-kAverageHeight);
+#endif
     xrLayers[i].pose.position = MatrixToXrPose(model).position;
     xrLayers[i].pose.orientation = MatrixToXrPose(layer->GetRotation()).orientation;
 

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -49,7 +49,7 @@ OpenXRLayerQuad::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClear
     device::EyeRect rect = layer->GetTextureRect(eye);
     xrLayers[i].subImage.swapchain = swapchain->SwapChain();
     xrLayers[i].subImage.imageArrayIndex = 0;
-    xrLayers[i].subImage.imageRect = GetRect(layer->GetWidth(), layer->GetHeight(), rect);
+    xrLayers[i].subImage.imageRect = GetRect(swapchain->Width(), swapchain->Height(), rect);
   }
 }
 
@@ -95,7 +95,7 @@ OpenXRLayerCylinder::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
     device::EyeRect rect = layer->GetTextureRect(device::Eye::Left);
     xrLayers[i].subImage.swapchain = swapchain->SwapChain();
     xrLayers[i].subImage.imageArrayIndex = 0;
-    xrLayers[i].subImage.imageRect = GetRect(layer->GetWidth(), layer->GetHeight(), rect);
+    xrLayers[i].subImage.imageRect = GetRect(swapchain->Width(), swapchain->Height(), rect);
   }
 }
 

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -73,12 +73,16 @@ OpenXRLayerCylinder::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
 
   for (int i = 0; i < xrLayers.size(); ++i) {
     device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
-    vrb::Matrix matrix = XrPoseToMatrix(aPose).PostMultiply(layer->GetModelTransform(eye));
-    xrLayers[i].pose = MatrixToXrPose(matrix);
+
+    auto scale = layer->GetModelTransform(eye).GetScale();
+    auto model = layer->GetModelTransform(eye).Scale({1/scale.x(), 1/scale.y(), 1/scale.z()});
+    xrLayers[i].pose.position = MatrixToXrPose(model).position;
+    xrLayers[i].pose.orientation = MatrixToXrPose(layer->GetRotation()).orientation;
+
     xrLayers[i].radius = layer->GetRadius();
     // See Cylinder.cpp: texScaleX = M_PI / theta;
     xrLayers[i].centralAngle = (float) M_PI / layer->GetUVTransform(eye).GetScale().x();
-    xrLayers[i].aspectRatio = layer->GetWorldWidth() / layer->GetWorldHeight();
+    xrLayers[i].aspectRatio = (float) layer->GetWidth() / layer->GetHeight();
     device::EyeRect rect = layer->GetTextureRect(device::Eye::Left);
     xrLayers[i].subImage.swapchain = swapchain->SwapChain();
     xrLayers[i].subImage.imageArrayIndex = 0;

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -174,7 +174,12 @@ protected:
     XrSwapchainCreateInfo info{XR_TYPE_SWAPCHAIN_CREATE_INFO};
     info.width = width;
     info.height = height;
-    if (aSurfaceType == VRLayerSurface::SurfaceType::AndroidSurface) {
+    bool shouldZeroInitialize = aSurfaceType == VRLayerSurface::SurfaceType::AndroidSurface;
+#if defined(PICOXR)
+    // Circumvent a bug in the pico OpenXR runtime.
+    shouldZeroInitialize = false;
+#endif
+    if (shouldZeroInitialize) {
       // These members must be zero
       // See https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/xrCreateSwapchainAndroidSurfaceKHR.html#XR_KHR_android_surface_swapchain
       info.format = 0;


### PR DESCRIPTION
This multi-commit PR does:
* Workarounds a bug in PicoXR when initializing swapchains for android surfaces
* Workarounds the unsupported compressed texture support in PicoXR
* Adds support for OpenXR cylinder layers