### PR TITLE
[Pico] Destroy swapchain ASAP on resize

### DIFF
--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -240,7 +240,14 @@ public:
     // Delay the destruction of the current swapChain until the new one is composited.
     // This is required to prevent a black flicker when resizing.
     OpenXRSwapChainPtr newSwapChain;
-    InitSwapChain(this->swapchain->Env(), this->swapchain->Session(), newSwapChain);
+    auto env = this->swapchain->Env();
+    auto session = this->swapchain->Session();
+#if PICOXR
+    // We cannot delay the destruction for Pico otherwise he'll easily hit the 16 android layer limit
+    // of Pico platform (it'll trigger an XR_OUT_OF_MEMORY_ERROR).
+    this->swapchain = nullptr;
+#endif
+    InitSwapChain(env, session, newSwapChain);
     this->layer->SetSurface(newSwapChain->AndroidSurface());
 
     SurfaceChangedTargetWeakPtr weakTarget = this->surfaceChangedTarget;


### PR DESCRIPTION
This prevents an OOM crash when exiting a WebXR session or an immersive video.
We delay the destruction of the previous swapchain on purpouse to avoid flickering
but this means that we'd easily hit the 16 android surface layer limit on Pico.