### PR TITLE
Copy download to content URI

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -763,7 +763,7 @@ public class SettingsStore {
         editor.commit();
     }
 
-    public @Storage int getDownloadsSortingOrder() {
+    public @SortingContextMenuWidget.Order int getDownloadsSortingOrder() {
         return mPrefs.getInt(mContext.getString(R.string.settings_key_downloads_sorting_order), DOWNLOADS_SORTING_ORDER_DEFAULT);
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/downloads/CopyToContentUriCallback.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/CopyToContentUriCallback.java
@@ -1,0 +1,9 @@
+package com.igalia.wolvic.downloads;
+
+import android.net.Uri;
+
+public interface CopyToContentUriCallback {
+    void onSuccess(Uri uri, boolean isNewUri);
+
+    void onFailure(Download download);
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/callbacks/DownloadsContextMenuCallback.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/callbacks/DownloadsContextMenuCallback.java
@@ -3,5 +3,7 @@ package com.igalia.wolvic.ui.callbacks;
 import com.igalia.wolvic.ui.widgets.menus.library.DownloadsContextMenuWidget;
 
 public interface DownloadsContextMenuCallback extends LibraryContextMenuCallback {
+    void onCopyToContentUri(DownloadsContextMenuWidget.DownloadsContextMenuItem item);
+
     void onDelete(DownloadsContextMenuWidget.DownloadsContextMenuItem item);
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/BookmarksContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/BookmarksContextMenuWidget.java
@@ -2,10 +2,19 @@ package com.igalia.wolvic.ui.widgets.menus.library;
 
 import android.content.Context;
 
+import java.util.EnumSet;
+
 public class BookmarksContextMenuWidget extends LibraryContextMenuWidget {
 
     public BookmarksContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows) {
-        super(aContext, item, canOpenWindows, true, false);
+        super(aContext, item, getAdditionalActions(canOpenWindows));
+    }
+
+    private static EnumSet<LibraryContextMenuWidget.Action> getAdditionalActions(boolean canOpenWindows) {
+        EnumSet<Action> additionalActions = EnumSet.of(Action.IS_BOOKMARKED);
+        if (canOpenWindows)
+            additionalActions.add(Action.OPEN_WINDOW);
+        return additionalActions;
     }
 
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/BookmarksContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/BookmarksContextMenuWidget.java
@@ -5,7 +5,7 @@ import android.content.Context;
 public class BookmarksContextMenuWidget extends LibraryContextMenuWidget {
 
     public BookmarksContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows) {
-        super(aContext, item, canOpenWindows, true);
+        super(aContext, item, canOpenWindows, true, false);
     }
 
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/DownloadsContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/DownloadsContextMenuWidget.java
@@ -7,11 +7,22 @@ import androidx.annotation.NonNull;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.ui.callbacks.DownloadsContextMenuCallback;
 
+import java.util.EnumSet;
+
 public class DownloadsContextMenuWidget extends LibraryContextMenuWidget {
 
     public DownloadsContextMenuWidget(Context aContext, LibraryContextMenuItem item,
                                       boolean canOpenWindows, boolean canCopyToContentUri) {
-        super(aContext, item, canOpenWindows, false, canCopyToContentUri);
+        super(aContext, item, getAdditionalActions(canOpenWindows, canCopyToContentUri));
+    }
+
+    private static EnumSet<Action> getAdditionalActions(boolean canOpenWindows, boolean canCopyToContentUri) {
+        EnumSet<Action> additionalActions = EnumSet.noneOf(Action.class);
+        if (canOpenWindows)
+            additionalActions.add(Action.OPEN_WINDOW);
+        if (canCopyToContentUri)
+            additionalActions.add(Action.CAN_COPY);
+        return additionalActions;
     }
 
     public static class DownloadsContextMenuItem extends LibraryContextMenuItem {
@@ -30,8 +41,9 @@ public class DownloadsContextMenuWidget extends LibraryContextMenuWidget {
 
     }
 
-    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
-        if (canCopyToContentUri) {
+    @Override
+    protected void setupCustomMenuItems(EnumSet<Action> additionalActions) {
+        if (additionalActions.contains(Action.CAN_COPY)) {
             mItems.add(new MenuItem(getContext().getString(
                     R.string.download_context_copy_to_content_uri),
                     R.drawable.ic_icon_file_copy,

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/DownloadsContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/DownloadsContextMenuWidget.java
@@ -9,8 +9,9 @@ import com.igalia.wolvic.ui.callbacks.DownloadsContextMenuCallback;
 
 public class DownloadsContextMenuWidget extends LibraryContextMenuWidget {
 
-    public DownloadsContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows) {
-        super(aContext, item, canOpenWindows, false);
+    public DownloadsContextMenuWidget(Context aContext, LibraryContextMenuItem item,
+                                      boolean canOpenWindows, boolean canCopyToContentUri) {
+        super(aContext, item, canOpenWindows, false, canCopyToContentUri);
     }
 
     public static class DownloadsContextMenuItem extends LibraryContextMenuItem {
@@ -29,12 +30,19 @@ public class DownloadsContextMenuWidget extends LibraryContextMenuWidget {
 
     }
 
-    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked) {
+    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
+        if (canCopyToContentUri) {
+            mItems.add(new MenuItem(getContext().getString(
+                    R.string.download_context_copy_to_content_uri),
+                    R.drawable.ic_icon_file_copy,
+                    () -> mItemDelegate.ifPresent((present ->
+                            ((DownloadsContextMenuCallback) mItemDelegate.get()).onCopyToContentUri((DownloadsContextMenuItem) mItem)))));
+        }
         mItems.add(new MenuItem(getContext().getString(
                 R.string.download_context_delete),
                 R.drawable.ic_icon_library_clearfromlist,
                 () -> mItemDelegate.ifPresent((present ->
-                        ((DownloadsContextMenuCallback)mItemDelegate.get()).onDelete((DownloadsContextMenuItem)mItem)))));
+                        ((DownloadsContextMenuCallback) mItemDelegate.get()).onDelete((DownloadsContextMenuItem) mItem)))));
     }
 
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/HistoryContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/HistoryContextMenuWidget.java
@@ -5,13 +5,26 @@ import android.content.Context;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.ui.callbacks.HistoryContextMenuCallback;
 
+import java.util.EnumSet;
+
 public class HistoryContextMenuWidget extends LibraryContextMenuWidget {
 
     public HistoryContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows, boolean isBookmarked) {
-        super(aContext, item, canOpenWindows, isBookmarked, false);
+        super(aContext, item, getAdditionalActions(canOpenWindows, isBookmarked));
     }
 
-    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
+    private static EnumSet<Action> getAdditionalActions(boolean canOpenWindows, boolean isBookmarked) {
+        EnumSet<Action> additionalActions = EnumSet.noneOf(Action.class);
+        if (canOpenWindows)
+            additionalActions.add(Action.OPEN_WINDOW);
+        if (isBookmarked)
+            additionalActions.add(Action.IS_BOOKMARKED);
+        return additionalActions;
+    }
+
+    @Override
+    protected void setupCustomMenuItems(EnumSet<Action> additionalActions) {
+        boolean isBookmarked = additionalActions.contains(Action.IS_BOOKMARKED);
         mItems.add(new MenuItem(getContext().getString(
                 isBookmarked ? R.string.history_context_remove_bookmarks : R.string.history_context_add_bookmarks),
                 isBookmarked ? R.drawable.ic_icon_bookmarked_active : R.drawable.ic_icon_bookmarked,

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/HistoryContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/HistoryContextMenuWidget.java
@@ -8,19 +8,19 @@ import com.igalia.wolvic.ui.callbacks.HistoryContextMenuCallback;
 public class HistoryContextMenuWidget extends LibraryContextMenuWidget {
 
     public HistoryContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows, boolean isBookmarked) {
-        super(aContext, item, canOpenWindows, isBookmarked);
+        super(aContext, item, canOpenWindows, isBookmarked, false);
     }
 
-    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked) {
+    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
         mItems.add(new MenuItem(getContext().getString(
                 isBookmarked ? R.string.history_context_remove_bookmarks : R.string.history_context_add_bookmarks),
                 isBookmarked ? R.drawable.ic_icon_bookmarked_active : R.drawable.ic_icon_bookmarked,
                 () -> mItemDelegate.ifPresent((present -> {
                     if (isBookmarked) {
-                        ((HistoryContextMenuCallback)mItemDelegate.get()).onRemoveFromBookmarks(mItem);
+                        ((HistoryContextMenuCallback) mItemDelegate.get()).onRemoveFromBookmarks(mItem);
 
                     } else {
-                        ((HistoryContextMenuCallback)mItemDelegate.get()).onAddToBookmarks(mItem);
+                        ((HistoryContextMenuCallback) mItemDelegate.get()).onAddToBookmarks(mItem);
                     }
                 }))));
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/LibraryContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/LibraryContextMenuWidget.java
@@ -41,12 +41,13 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
     Optional<LibraryContextMenuCallback> mItemDelegate;
     LibraryContextMenuItem mItem;
 
-    public LibraryContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows, boolean isBookmarked) {
+    public LibraryContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows,
+                                    boolean isBookmarked, boolean canCopyToContentUri) {
         super(aContext, R.layout.library_menu);
         initialize();
 
         mItem = item;
-        createMenuItems(canOpenWindows, isBookmarked);
+        createMenuItems(canOpenWindows, isBookmarked, canCopyToContentUri);
     }
 
     private void initialize() {
@@ -100,7 +101,7 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
         mItemDelegate = Optional.ofNullable(delegate);;
     }
 
-    private void createMenuItems(boolean canOpenWindows, boolean isBookmarked) {
+    private void createMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
         mItems = new ArrayList<>();
 
         if (canOpenWindows) {
@@ -115,7 +116,7 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
                 R.drawable.ic_icon_newtab,
                 () -> mItemDelegate.ifPresent((present -> mItemDelegate.get().onOpenInNewTabClick(mItem)))));
 
-        setupCustomMenuItems(canOpenWindows, isBookmarked);
+        setupCustomMenuItems(canOpenWindows, isBookmarked, canCopyToContentUri);
 
         super.updateMenuItems(mItems);
 
@@ -123,6 +124,7 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
         mWidgetPlacement.height += mBorderWidth * 2;
     }
 
-    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked) {}
+    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
+    }
 
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/LibraryContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/LibraryContextMenuWidget.java
@@ -12,9 +12,13 @@ import com.igalia.wolvic.ui.widgets.menus.MenuWidget;
 import com.igalia.wolvic.utils.AnimationHelper;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Optional;
 
 public abstract class LibraryContextMenuWidget extends MenuWidget {
+
+    // Additional actions that may appear in the menu, depending on different conditions.
+    protected enum Action {OPEN_WINDOW, IS_BOOKMARKED, CAN_COPY}
 
     public static class LibraryContextMenuItem {
 
@@ -41,13 +45,12 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
     Optional<LibraryContextMenuCallback> mItemDelegate;
     LibraryContextMenuItem mItem;
 
-    public LibraryContextMenuWidget(Context aContext, LibraryContextMenuItem item, boolean canOpenWindows,
-                                    boolean isBookmarked, boolean canCopyToContentUri) {
+    protected LibraryContextMenuWidget(Context aContext, LibraryContextMenuItem item, EnumSet<Action> additionalActions) {
         super(aContext, R.layout.library_menu);
         initialize();
 
         mItem = item;
-        createMenuItems(canOpenWindows, isBookmarked, canCopyToContentUri);
+        createMenuItems(additionalActions);
     }
 
     private void initialize() {
@@ -101,10 +104,10 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
         mItemDelegate = Optional.ofNullable(delegate);;
     }
 
-    private void createMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
+    private void createMenuItems(@NonNull EnumSet<Action> additionalActions) {
         mItems = new ArrayList<>();
 
-        if (canOpenWindows) {
+        if (additionalActions.contains(Action.OPEN_WINDOW)) {
             mItems.add(new MenuItem(getContext().getString(
                     R.string.history_context_menu_new_window),
                     R.drawable.ic_icon_library_new_window,
@@ -116,7 +119,7 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
                 R.drawable.ic_icon_newtab,
                 () -> mItemDelegate.ifPresent((present -> mItemDelegate.get().onOpenInNewTabClick(mItem)))));
 
-        setupCustomMenuItems(canOpenWindows, isBookmarked, canCopyToContentUri);
+        setupCustomMenuItems(additionalActions);
 
         super.updateMenuItems(mItems);
 
@@ -124,7 +127,7 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
         mWidgetPlacement.height += mBorderWidth * 2;
     }
 
-    protected void setupCustomMenuItems(boolean canOpenWindows, boolean isBookmarked, boolean canCopyToContentUri) {
+    protected void setupCustomMenuItems(EnumSet<Action> additionalActions) {
     }
 
 }

--- a/app/src/main/res/drawable/ic_icon_file_copy.xml
+++ b/app/src/main/res/drawable/ic_icon_file_copy.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/rhino"
+        android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM15,5l6,6v10c0,1.1 -0.9,2 -2,2L7.99,23C6.89,23 6,22.1 6,21l0.01,-14c0,-1.1 0.89,-2 1.99,-2h7zM14,12h5.5L14,6.5L14,12z" />
+</vector>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -986,6 +986,10 @@
          the more button is pressed in a downloads item. It deletes the selected item from the downloads list
          and also from disk. -->
     <string name="download_context_delete">Eliminar</string>
+    <!-- This string is displayed is the downloads context menu that is displayed when
+     the more button is pressed in a downloads item. It creates a copy of the selected item
+     in the public Downloads folder so it may be used by other apps. -->
+    <string name="download_context_copy_to_content_uri">Compartir con otras aplicaciones</string>
     <!-- This string labels the Reset button that restores the default display settings values. -->
     <string name="display_options_reset">Restablecer los ajustes de visualización</string>
     <!-- This string labels the Reset button that restores the default privacy and security settings values. -->
@@ -1546,6 +1550,21 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_status_unavailable">No disponible</string>
     <!-- This string is displayed in the downloads panel, in the download status when an unknown error happened. -->
     <string name="download_status_unknown_error">Error desconocido</string>
+    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
+    <string name="download_copy_to_content_uri_confirm_title">¿Copiar archivo?</string>
+    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
+    <string name="download_copy_to_content_uri_confirm_body">Se creará una copia del archivo en la carpeta de Descarga del sistema, donde podrá ser utilizada por otras aplicaciones.\n\n¿Deseas continuar?</string>
+    <!-- This string is displayed in the title of the download error dialog. -->
+    <string name="download_copy_to_content_uri_success_title">Fichero copiado</string>
+    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
+    <string name="download_copy_to_content_uri_success_body">El fichero se copió con éxito y está disponible en las Descargas del sistema.</string>
+    <!-- This string is displayed in the title of the copy downloaded file error dialog. -->
+    <string name="download_copy_to_content_uri_error_title">Error durante la copia</string>
+    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
+    <string name="download_copy_to_content_uri_error_body">Se ha producido un error mientras se copiaba el archivo.</string>
+    <!-- This string is displayed in the body of the copy downloaded file error dialog.
+     '%1$s' will be replaced at runtime with the name of the downloaded file. -->
+    <string name="download_copy_to_content_uri_error_body_v1">An error occurred while copying %1$s</string>
     <!-- This string is shown in the body of the error dialog displayed when the user is trying to download an environment in the external storage
     but hasn't granted the permission. -->
     <string name="environment_download_permission_error_body">Para descargar el entorno es necesario tener permiso de escritura en el almacenamiento externo.</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -327,6 +327,7 @@
     <string name="history_context_add_bookmarks">Engadir aos marcadores</string>
     <string name="history_context_remove_bookmarks">Eliminar dos marcadores</string>
     <string name="download_context_delete">Borrar</string>
+    <string name="download_context_copy_to_content_uri">Compartir con outras aplicacións</string>
     <string name="display_options_reset">Restablecer configuración de display</string>
     <string name="privacy_options_reset">Restablecer configuración de privacidade e seguridade</string>
     <string name="privacy_options_saved_logins_list_header">Inicios de sesión gardados:</string>
@@ -471,6 +472,13 @@
     <string name="download_status_paused">Pausada</string>
     <string name="download_status_unavailable">Non dispoñible</string>
     <string name="download_status_unknown_error">Erro descoñecido</string>
+    <string name="download_copy_to_content_uri_confirm_title">¿Copiar arquivo?</string>
+    <string name="download_copy_to_content_uri_confirm_body">Crearase unha copia do arquivo na carpeta de Descargas del sistema, onde poderá ser utilizada por outras aplicacións.\n\nDesexas continuar?</string>
+    <string name="download_copy_to_content_uri_success_title">Ficheiro copiado</string>
+    <string name="download_copy_to_content_uri_success_body">O ficheiro copiouse con éxito e está dispoñible nas Descargas do sistema.</string>
+    <string name="download_copy_to_content_uri_error_title">Erro durante a copia</string>
+    <string name="download_copy_to_content_uri_error_body">Produciuse un erro mentras se copiaba o arquivo.</string>
+    <string name="download_copy_to_content_uri_error_body_v1">Produciuse un erro mentras se copiaba %1$s</string>
     <string name="environment_download_permission_error_body">É necesario ter permiso de escritura no almacenamento externo para descargar a contorna.</string>
     <string name="environment_error_title">Erro na contorna</string>
     <string name="autofill_dialog_save_title">Gardar este inicio de sesión\?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1361,6 +1361,11 @@
          and also from disk. -->
     <string name="download_context_delete">Delete</string>
 
+    <!-- This string is displayed is the downloads context menu that is displayed when
+         the more button is pressed in a downloads item. It creates a copy of the selected item
+         in the public Downloads folder so it may be used by other apps. -->
+    <string name="download_context_copy_to_content_uri">Share with other apps</string>
+
     <!-- This string is displayed as the title of the System Notifications List, which contains
          the notifications received by the system (similar to Android's Notification Center). -->
     <string name="notifications_title">Notifications</string>
@@ -2195,6 +2200,28 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the error dialog shown when downloaded addon installation is blocked. -->
     <string name="download_addon_install_blocked_body">Allow local addon installation in Developer Options to proceed.</string>
+
+    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
+    <string name="download_copy_to_content_uri_confirm_title">Copy file?</string>
+
+    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
+    <string name="download_copy_to_content_uri_confirm_body">This will create a copy of this file on the system\'s Downloads folder, where it can be accessed by other apps.\n\nDo you want to continue?</string>
+
+    <!-- This string is displayed in the title of the download error dialog. -->
+    <string name="download_copy_to_content_uri_success_title">Successfully copied</string>
+
+    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
+    <string name="download_copy_to_content_uri_success_body">The file was copied successfully and is available in the system\'s Downloads.</string>
+
+    <!-- This string is displayed in the title of the copy downloaded file error dialog. -->
+    <string name="download_copy_to_content_uri_error_title">Copy error</string>
+
+    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
+    <string name="download_copy_to_content_uri_error_body">An error occurred while copying the downloaded file.</string>
+
+    <!-- This string is displayed in the body of the copy downloaded file error dialog.
+         '%1$s' will be replaced at runtime with the name of the downloaded file. -->
+    <string name="download_copy_to_content_uri_error_body_v1">An error occurred while copying %1$s</string>
 
     <!-- This string is shown in the body of the error dialog displayed when the user is trying to download an environment in the external storage
     but hasn't granted the permission. -->


### PR DESCRIPTION
Add a new context menu item for downloaded files with the label _"Share with other applications"_.

This functionality creates a new entry in Android's media database and copies the file to the public Downloads folder, where it may be viewed by other apps.

This is a suboptimal way to share downloaded content between Wolvic and other apps. It would be ideal to be able to store files in Android's content database by default and then open them in Wolvic, but the problem is that at the moment GeckoView is unable to handle Android's content URIs (which are all that the current Android APIs provide).

Fixes https://github.com/Igalia/wolvic/issues/207