### PR TITLE
[Pico] Limit the amount of layers created by widgets

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TitleBarWidget.java
@@ -21,6 +21,7 @@ import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.databinding.TitleBarBinding;
 import com.igalia.wolvic.ui.viewmodel.WindowViewModel;
+import com.igalia.wolvic.utils.DeviceType;
 
 public class TitleBarWidget extends UIWidget {
 
@@ -107,6 +108,10 @@ public class TitleBarWidget extends UIWidget {
         aPlacement.translationY = -35;
         aPlacement.cylinder = true;
         aPlacement.visible = true;
+        // FIXME: we temporarily disable the creation of a layer for this widget in order to
+        // limit the amount of layers we create, as Pico's runtime only allows 16 at a given time.
+        if (DeviceType.isPicoXR())
+            aPlacement.layer = false;
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TopBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TopBarWidget.java
@@ -22,6 +22,7 @@ import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.audio.AudioEngine;
 import com.igalia.wolvic.databinding.TopBarBinding;
 import com.igalia.wolvic.ui.viewmodel.WindowViewModel;
+import com.igalia.wolvic.utils.DeviceType;
 
 public class TopBarWidget extends UIWidget {
 
@@ -70,6 +71,10 @@ public class TopBarWidget extends UIWidget {
         aPlacement.anchorY = 0.0f;
         aPlacement.parentAnchorX = 0.5f;
         aPlacement.parentAnchorY = 1.0f;
+        // FIXME: we temporarily disable the creation of a layer for this widget in order to
+        // limit the amount of layers we create, as Pico's runtime only allows 16 at a given time.
+        if (DeviceType.isPicoXR())
+            aPlacement.layer = false;
     }
 
     private void updateUI() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WebXRInterstitialWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WebXRInterstitialWidget.java
@@ -40,6 +40,10 @@ public class WebXRInterstitialWidget extends UIWidget implements WidgetManagerDe
         aPlacement.anchorY = 0.5f;
         aPlacement.cylinder = false;
         aPlacement.visible = false;
+        // FIXME: we temporarily disable the creation of a layer for this widget in order to
+        // limit the amount of layers we create, as Pico's runtime only allows 16 at a given time.
+        if (DeviceType.isPicoXR())
+            aPlacement.layer = false;
     }
 
     private void initialize() {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -773,7 +773,7 @@ BrowserWorld::State::UpdateWidgetCylinder(const WidgetPtr& aWidget, const float 
     aWidget->SetCylinderDensity(aDensity);
   } else if (useCylinder && !aWidget->GetCylinder()) {
     VRLayerSurfacePtr moveLayer = aWidget->GetLayer();
-    VRLayerCylinderPtr layer = device->CreateLayerCylinder(moveLayer);
+    VRLayerCylinderPtr layer = aWidget->GetPlacement()->layer ? device->CreateLayerCylinder(moveLayer) : nullptr;
     CylinderPtr cylinder = Cylinder::Create(create, layer);
     aWidget->SetCylinder(cylinder);
     aWidget->SetCylinderDensity(aDensity);
@@ -781,7 +781,7 @@ BrowserWorld::State::UpdateWidgetCylinder(const WidgetPtr& aWidget, const float 
     float w = 0, h = 0;
     aWidget->GetWorldSize(w, h);
     VRLayerSurfacePtr moveLayer = aWidget->GetLayer();
-    VRLayerQuadPtr layer = device->CreateLayerQuad(moveLayer);
+    VRLayerQuadPtr layer = aWidget->GetPlacement()->layer ? device->CreateLayerQuad(moveLayer) : nullptr;
     QuadPtr quad = Quad::Create(create, w, h, layer);
     aWidget->SetQuad(quad);
   }
@@ -1178,17 +1178,13 @@ BrowserWorld::AddWidget(int32_t aHandle, const WidgetPlacementPtr& aPlacement) {
 
   WidgetPtr widget;
   if (aPlacement->cylinder && m.cylinderDensity > 0) {
-    VRLayerCylinderPtr layer = m.device->CreateLayerCylinder(textureWidth, textureHeight, VRLayerQuad::SurfaceType::AndroidSurface);
+    VRLayerCylinderPtr layer = aPlacement->layer ? m.device->CreateLayerCylinder(textureWidth, textureHeight, VRLayerQuad::SurfaceType::AndroidSurface) : nullptr;
     CylinderPtr cylinder = Cylinder::Create(m.create, layer);
     widget = Widget::Create(m.context, aHandle, aPlacement, textureWidth, textureHeight, (int32_t)worldWidth, (int32_t)worldHeight, cylinder);
   }
 
   if (!widget) {
-    VRLayerQuadPtr layer;
-    if (aPlacement->layer) {
-      layer = m.device->CreateLayerQuad(textureWidth, textureHeight, VRLayerQuad::SurfaceType::AndroidSurface);
-    }
-
+    VRLayerQuadPtr layer = aPlacement->layer ? m.device->CreateLayerQuad(textureWidth, textureHeight, VRLayerQuad::SurfaceType::AndroidSurface) : nullptr;
     QuadPtr quad = Quad::Create(m.create, worldWidth, worldHeight, layer);
     widget = Widget::Create(m.context, aHandle, aPlacement, textureWidth, textureHeight, quad);
   }


### PR DESCRIPTION
Pico runtime only allows 16 simultaneous layers due to restrictions in the compositor. That's a problem for us because each widget uses a different layer. It starts becoming a real issue when having more than 1 window as it's easy to surpass the limit.

In order to fix that we must do
1. Ensure that we respect the `layer` attribute of `WidgetPlacement` and not create layers when the value is false
2. Prevent specific small, non critical, widgets to create layers

The most important and large widgets will keep using layers so the overall look&feel remains great.