### PR TITLE
Correct JVM target for Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,7 +148,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = '1.8'
     }
 
     buildTypes {


### PR DESCRIPTION
We were using `JavaVersion.VERSION_1_8.toString()`, which was wrong because it simply returns the position of that element in the enumeration (in this case, "7").