### PR TITLE
Fixes a crash generating download thumnails

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -134,12 +134,12 @@ public class UrlUtils {
         return context != null && aUri != null && aUri.equals(context.getString(R.string.about_blank));
     }
 
-    public static String getMimeTypeFromUrl(String url) {
+    public static @NonNull String getMimeTypeFromUrl(String url) {
         String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension.isEmpty())
+        if (StringUtils.isEmpty(extension))
             return UNKNOWN_MIME_TYPE;
         String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-        return mimeType == null ? UNKNOWN_MIME_TYPE : mimeType;
+        return StringUtils.isEmpty(mimeType) ? UNKNOWN_MIME_TYPE : mimeType;
     }
 
     public static String titleBarUrl(@Nullable String aUri) {

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -136,7 +136,7 @@ public class UrlUtils {
 
     public static String getMimeTypeFromUrl(String url) {
         String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension == null)
+        if (extension.isEmpty())
             return UNKNOWN_MIME_TYPE;
         String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
         return mimeType == null ? UNKNOWN_MIME_TYPE : mimeType;


### PR DESCRIPTION
Due to some other bug, some downloads are stored using names without any extension. That was making getMimeTypeFromUrl() return null in those cases.

The problem is that we were incorrectly doing a null check in the value returned by MimeTypeMap.getFileExtensionFromUrl(). As the docs mention, that method returns the empty string in case of not finding an extension. As the empty string is not null we were never early returning UNKNOWN_FILE_TYPE, and instead we returned null because MimeTypeMap.getSingleton().getMimeTypeFromExtension() does indeed return null if the extension is not recognized.