### PR TITLE
Do not leak swapchains on resize

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/FinalizerRunnable.java
+++ b/app/src/common/shared/com/igalia/wolvic/FinalizerRunnable.java
@@ -1,0 +1,32 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.igalia.wolvic;
+
+import android.view.Surface;
+
+import com.igalia.wolvic.ui.widgets.Widget;
+
+public class FinalizerRunnable implements Runnable {
+    public FinalizerRunnable(Runnable callback, Runnable destroyCallback) {
+        mCallback = callback;
+        mDestroyCallback = destroyCallback;
+    }
+    @Override
+    public void run() {
+        mExecuted = true;
+        mCallback.run();
+    }
+    protected void finalize()
+    {
+        if (mExecuted)
+            return;
+        mDestroyCallback.run();
+    }
+
+    private Runnable mCallback;
+    private Runnable mDestroyCallback;
+    private boolean mExecuted = false;
+}

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -993,7 +993,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 return;
             }
 
-            Runnable aFirstDrawCallback = () -> {
+            FinalizerRunnable firstDrawCallback = new FinalizerRunnable(() -> {
                 if (aNativeCallback != 0) {
                     queueRunnable(() -> runCallbackNative(aNativeCallback));
                 }
@@ -1001,9 +1001,14 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                     widget.setFirstPaintReady(true);
                     updateWidget(widget);
                 }
-            };
+            },
+            () -> {
+                if (aNativeCallback != 0) {
+                    queueRunnable(() -> deleteCallbackNative(aNativeCallback));
+                }
+            });
 
-            widget.setSurface(aSurface, aWidth, aHeight, aFirstDrawCallback);
+            widget.setSurface(aSurface, aWidth, aHeight, firstDrawCallback);
 
             UIWidget view = (UIWidget) widget;
             // Add widget to a virtual display for invalidation
@@ -1869,6 +1874,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void recenterUIYawNative(@YawTarget int aTarget);
     private native void setControllersVisibleNative(boolean aVisible);
     private native void runCallbackNative(long aCallback);
+    private native void deleteCallbackNative(long aCallback);
     private native void setCylinderDensityNative(float aDensity);
     private native void setCPULevelNative(@CPULevelFlags int aCPULevel);
     private native void setWebXRIntersitialStateNative(@WebXRInterstitialState int aState);

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1938,6 +1938,14 @@ JNI_METHOD(void, runCallbackNative)
   }
 }
 
+JNI_METHOD(void, deleteCallbackNative)
+(JNIEnv*, jobject, jlong aCallback) {
+  if (aCallback) {
+    auto func = reinterpret_cast<std::function<void()> *>((uintptr_t)aCallback);
+    delete func;
+  }
+}
+
 JNI_METHOD(void, setCPULevelNative)
 (JNIEnv*, jobject, jint aCPULevel) {
   crow::BrowserWorld::Instance().SetCPULevel(static_cast<crow::device::CPULevel>(aCPULevel));


### PR DESCRIPTION
Swapchains cannot be resized. That's why when we resize widgets (like for example window widgets when entering/leaving fullscreen) what we really do is:
1. Create a new swapchain with the new size
2. Once the new swapchain is ready replace the previous one and destroy it

That behaviour is sane in theory, however it does leak swapchains each time we leave fullscreen mode (i.e. when resize is triggered). This is why. The current code creates a new swapchain each time VRLayer::Resize is called. The layer notifies the SurfaceChangedDelegate (in this case a Widget) about that. The Widget then calls
VRBrowser::DispatchCreateWidgetLayer() in UpdateSurface(). Among other things, we pass a callback to the Java world. That callback is executed by Java code (actually is executed by native code, Java code just enqueues the execution of a Runnable) during the first draw. That callback is precisely the one that replaces the old swapchain with the new one.

The problem arises when Resize is called multiple times before the first draw call. In that case, only the last callback is called, meaning that for the other ones, the created swapchain will be leaked.

In order to fix that we keep a list of swapchains in OculusVRLayers and OpenXRLayers, and when the callback is called we simply use the last one and destroy the others.

This not only fixes a huge leak, but it's also critical for systems with a small limit of available android surface swapchains (like Pico).

Fixes #405