### PR TITLE
OpenXR: Draw hands by using a sphere for each hand joint

### DIFF
--- a/app/src/main/cpp/Controller.cpp
+++ b/app/src/main/cpp/Controller.cpp
@@ -75,6 +75,8 @@ Controller::operator=(const Controller& aController) {
   squeezeActionStartFrameId = aController.squeezeActionStartFrameId;
   squeezeActionStopFrameId = aController.squeezeActionStopFrameId;
   batteryLevel = aController.batteryLevel;
+  handMeshToggle = aController.handMeshToggle;
+  handJointTransforms = aController.handJointTransforms;
   return *this;
 }
 
@@ -121,6 +123,8 @@ Controller::Reset() {
   squeezeActionStartFrameId = 0;
   squeezeActionStopFrameId = 0;
   batteryLevel = -1;
+  handJointTransforms.clear();
+  handMeshToggle = nullptr;
 }
 
 vrb::Vector Controller::StartPoint() const {

--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -10,6 +10,7 @@
 #include "Device.h"
 #include "vrb/Forward.h"
 #include "vrb/Matrix.h"
+#include "vrb/Transform.h"
 
 namespace crow {
 
@@ -41,6 +42,8 @@ struct Controller {
   vrb::TransformPtr transform;
   vrb::TogglePtr beamToggle;
   vrb::TogglePtr modelToggle;
+  vrb::TogglePtr handMeshToggle;
+  std::vector<vrb::TransformPtr> handJointTransforms;
   vrb::TransformPtr beamParent;
   PointerPtr pointer;
   vrb::Matrix transformMatrix;

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -68,6 +68,8 @@ public:
   bool IsVisible() const override;
   void SetVisible(const bool aVisible) override;
   void SetGazeModeIndex(const int32_t aControllerIndex) override;
+  void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix>& jointTransforms) override;
+  void SetHandVisible(const int32_t aControllerIndex, bool aVisible = true) override;
   void SetFrameId(const uint64_t aFrameId);
 protected:
   struct State;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -65,6 +65,8 @@ public:
   virtual bool IsVisible() const = 0;
   virtual void SetVisible(const bool aVisible) = 0;
   virtual void SetGazeModeIndex(const int32_t aControllerIndex) = 0;
+  virtual void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix>& jointTransforms) = 0;
+  virtual void SetHandVisible(const int32_t aControllerIndex, bool aVisible = true) = 0;
 protected:
   ControllerDelegate() {}
 private:

--- a/app/src/main/cpp/DeviceUtils.h
+++ b/app/src/main/cpp/DeviceUtils.h
@@ -8,6 +8,7 @@
 
 #include "vrb/MacroUtils.h"
 #include "vrb/Forward.h"
+#include "vrb/Geometry.h"
 
 namespace crow {
 
@@ -24,6 +25,7 @@ public:
                                      const uint32_t aRecommendedWidth, const uint32_t aRecommendedHeight,
                                      const uint32_t aMaxWidth, const uint32_t aMaxHeight,
                                      uint32_t& aTargetWidth, uint32_t& aTargetHeight);
+  static vrb::GeometryPtr GetSphereGeometry(vrb::CreationContextPtr& context, uint32_t resolution, float radius);
 private:
   VRB_NO_DEFAULTS(DeviceUtils)
 };


### PR DESCRIPTION
This is a stop-gap version of hand rendering that paints a ball (sphere) for each hand joint detected.

While we aim at painting actual hand models in the future, (e.g, hand mesh as provided by XR_FB_hand_tracking_mesh), this is an initial default/fallback version for devices that support XR_EXT_hand_tracking, but not necessarily support other extensions that facilitate hand mesh rendering. 