### PR TITLE
Remove duplicate initialization of deviceType in Pico

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -119,10 +119,6 @@ struct DeviceDelegateOpenXR::State {
   }
 
   void Initialize() {
-#ifdef PICOXR
-    deviceType = device::PicoXR;
-#endif
-
     vrb::RenderContextPtr localContext = context.lock();
     elbow = ElbowModel::Create();
     for (int i = 0; i < 2; ++i) {


### PR DESCRIPTION
Remove a duplicate initialization of deviceType for Pico. We added a InitializeDeviceType()
 method to do that, but we forgot to remove the previous initialization code for Pico.