### PR TITLE
Improve documentation about jdk requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For testing on a non-VR device:
 
 Building for Oculus Mobile, Huawei and WaveVR requires access to their respective SDKs which are not included in this repo.
 
-The command line version of `gradlew` requires [JDK 8 from Oracle](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html). If you see an error that Gradle doesn't understand your Java version, check which version of you're using by running `java -showversion` or `java -version`. You're probably using JDK 9 or 10, which won't work.
+The command line version of `gradlew` requires JDK 11. If you see an error that Gradle doesn't understand your Java version, check which version of you're using by running `java -showversion` or `java -version`. You're probably using and older JDK, which won't work.
 
 *Open the project with [Android Studio](https://developer.android.com/studio/index.html)* then build and run it. Depending on what you already have installed in Android Studio, the build may fail and then may prompt you to install dependencies. Just keep doing as it suggests. To select the device to build for, go to `Tool Windows > Build Variants` and select a build variant corresponding to your device.
 


### PR DESCRIPTION
The current README.md file suggests to use JDK 8 version from Oracle. It also mentioned that 
version 9 or 10 won't work. The reality is that the current dependencies require at least version 11.
 Also the Oracle implementation is not really required, we're using OpenJDK without any issue.

Fixes #409