### PR TITLE
Download blob:http:// URIs

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.ui.adapters.Language;
 import com.igalia.wolvic.utils.LocaleUtils;
+import com.igalia.wolvic.utils.StringUtils;
 
 import java.io.File;
 import java.net.URI;
@@ -152,16 +153,18 @@ public class Download {
     }
 
     public String getFilename() {
-        try {
-            File f = new File(new URL(mUri).getPath());
-            return f.getName();
-
-        } catch (Exception e) {
-            if (mOutputFile != null) {
-                return mOutputFile;
-                
-            } else {
-                return "";
+        if (!StringUtils.isEmpty(mTitle)) {
+            return mTitle;
+        } else {
+            try {
+                File f = new File(new URL(mUri).getPath());
+                return f.getName();
+            } catch (Exception e) {
+                if (mOutputFile != null) {
+                    return mOutputFile;
+                } else {
+                    return "";
+                }
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.browser.api.WSession;
 
+import java.io.InputStream;
 import java.util.Map;
 
 public class DownloadJob {
@@ -18,6 +19,7 @@ public class DownloadJob {
     private String mTitle;
     private String mDescription;
     private String mOutputPath;
+    private InputStream inputStream;
 
     public static DownloadJob create(@NonNull String uri) {
         DownloadJob job = new DownloadJob();
@@ -42,6 +44,12 @@ public class DownloadJob {
         }
         job.mTitle = job.mFilename;
         job.mDescription = job.mFilename;
+        return job;
+    }
+
+    public static DownloadJob fromUri(@NonNull String uri, Map<String, String> headers, InputStream inputStream) {
+        DownloadJob job = fromUri(uri, headers);
+        job.inputStream = inputStream;
         return job;
     }
 
@@ -131,5 +139,10 @@ public class DownloadJob {
     @Nullable
     public String getOutputPath() {
         return mOutputPath;
+    }
+
+    @Nullable
+    public InputStream getInputStream() {
+        return inputStream;
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -147,13 +147,13 @@ public class DownloadsManager {
     }
 
     public void downloadBlobUri(DownloadJob job) {
-        if (!UrlUtils.isBlobUri(job.getUri()) || job.getInputStream() == null) {
-            Log.w(LOGTAG, "Failed to download Blob URI: " + job.getUri());
+        if (job.getInputStream() == null) {
+            Log.w(LOGTAG, "Failed to download Blob URI, missing input stream: " + job.getUri());
             return;
         }
 
         final File dir = mContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
-        if (dir == null || (dir.exists() && !dir.isDirectory())) {
+        if (dir == null) {
             Log.e(LOGTAG, "Error when saving " + job.getUri() + " : failed to get the Downloads directory");
             return;
         }
@@ -166,16 +166,16 @@ public class DownloadsManager {
                 extension = '.' + extension;
             }
             String name = file.getName();
-            int lastDot = name.lastIndexOf('.');
-            if (lastDot >= 0) {
-                name = name.substring(0, name.lastIndexOf('.'));
+            int lastDotIndex = name.lastIndexOf('.');
+            if (lastDotIndex >= 0) {
+                name = name.substring(0, lastDotIndex);
             }
             int currentIndex = 0;
-            int lastDash = name.lastIndexOf('-');
-            if (lastDash >= 0) {
+            int lastDashIndex = name.lastIndexOf('-');
+            if (lastDashIndex >= 0) {
                 try {
-                    name = name.substring(0, lastDash - 1);
-                    String index = name.substring(lastDash + 1);
+                    name = name.substring(0, lastDashIndex - 1);
+                    String index = name.substring(lastDashIndex + 1);
                     currentIndex = Integer.parseInt(index);
                 } catch (Exception e) {
                 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1679,7 +1679,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         // We don't want to trigger downloads of already downloaded files that we can't open
         // so we let the system handle it.
         if (!UrlUtils.isFileUri(webResponseInfo.uri())) {
-            DownloadJob job = DownloadJob.fromUri(webResponseInfo.uri(), webResponseInfo.headers());
+            DownloadJob job;
+            if (UrlUtils.isBlobUri(webResponseInfo.uri())) {
+                job = DownloadJob.fromUri(webResponseInfo.uri(), webResponseInfo.headers(), webResponseInfo.body());
+            } else {
+                job = DownloadJob.fromUri(webResponseInfo.uri(), webResponseInfo.headers());
+            }
             // Don't show the confirmation dialog when we are in WebXR, because it will not be visible.
             boolean showConfirmDialog = !mWidgetManager.isWebXRPresenting();
             startDownload(job, showConfirmDialog);

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -127,7 +127,7 @@ public class UrlUtils {
     }
 
     public static Boolean isBlobUri(@Nullable String aUri) {
-        return aUri != null && aUri.startsWith("blob");
+        return aUri != null && aUri.startsWith("blob:");
     }
 
     public static Boolean isBlankUri(@Nullable Context context, @Nullable String aUri) {


### PR DESCRIPTION
Blob URIs have the form `blob:http://example.com/...` and can be used to represent data that has been generated locally and does not exist in the remote server.

This PR makes it possible to download a Blob URI as if it was a regular file. Fortunately, Gecko provides us with an InputStream pointing at the blob's data, so all that we have to do is save this data to a file and update the Downloads database.

Fixes https://github.com/Igalia/wolvic/issues/304