### PR TITLE
Prevent crashes when opening unsupported dialogs

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/PromptDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/PromptDelegate.java
@@ -287,6 +287,24 @@ public class PromptDelegate implements
         return result;
     }
 
+    @Nullable
+    @Override
+    public WResult<PromptResponse> onColorPrompt(@NonNull WSession session, @NonNull ColorPrompt prompt) {
+        // TODO implement color picker
+        final WResult<PromptResponse> result = WResult.create();
+        result.cancel();
+        return result;
+    }
+
+    @Nullable
+    @Override
+    public WResult<PromptResponse> onDateTimePrompt(@NonNull WSession session, @NonNull DateTimePrompt prompt) {
+        // TODO implement date/time picker
+        final WResult<PromptResponse> result = WResult.create();
+        result.cancel();
+        return result;
+    }
+
     private Observer<List<SitePermission>> mPopUpSiteObserver = sites -> {
         mAllowedPopUpSites = sites;
     };
@@ -321,6 +339,15 @@ public class PromptDelegate implements
             }
         }
 
+        return result;
+    }
+
+    @Nullable
+    @Override
+    public WResult<PromptResponse> onSharePrompt(@NonNull WSession session, @NonNull SharePrompt prompt) {
+        // TODO implement share request
+        final WResult<PromptResponse> result = WResult.create();
+        result.cancel();
         return result;
     }
 
@@ -472,6 +499,15 @@ public class PromptDelegate implements
         });
         mPrompt.show(UIWidget.REQUEST_FOCUS, true);
 
+        return result;
+    }
+
+    @Nullable
+    @Override
+    public WResult<PromptResponse> onRepostConfirmPrompt(@NonNull WSession session, @NonNull RepostConfirmPrompt prompt) {
+        // TODO implement POST resubmission confirmation
+        final WResult<PromptResponse> result = WResult.create();
+        result.cancel();
         return result;
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1607,7 +1607,25 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         }
         return WResult.fromValue(autocompleteRequest.dismiss());
     }
-    
+
+    @Nullable
+    @Override
+    public WResult<PromptResponse> onSharePrompt(@NonNull WSession aSession, @NonNull SharePrompt prompt) {
+        if (mPromptDelegate != null) {
+            return mPromptDelegate.onSharePrompt(aSession, prompt);
+        }
+        return WResult.fromValue(prompt.dismiss());
+    }
+
+    @Nullable
+    @Override
+    public WResult<PromptResponse> onRepostConfirmPrompt(@NonNull WSession aSession, @NonNull RepostConfirmPrompt prompt) {
+        if (mPromptDelegate != null) {
+            return mPromptDelegate.onRepostConfirmPrompt(aSession, prompt);
+        }
+        return WResult.fromValue(prompt.dismiss());
+    }
+
     // HistoryDelegate
     @Override
     public void onHistoryStateChange(@NonNull WSession aSession, @NonNull WSession.HistoryDelegate.HistoryList historyList) {


### PR DESCRIPTION
Some Web dialogs are not supported by Wolvic yet. These include the color picker, date/time picker, "share", etc. This PR prevents a crash when a website tries to open one of these dialogs.

This is a quick fix to ensure the stability of the app, we still need to implement these dialogs in the future.

Fixes #408