### PR TITLE
Enable layers in Pico builds

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -458,7 +458,7 @@ public class SettingsStore {
     }
 
     public boolean getLayersEnabled() {
-        if (DeviceType.isOculusBuild() && !mDisableLayers) {
+        if ((DeviceType.isOculusBuild() || DeviceType.isPicoXR()) && !mDisableLayers) {
             Log.i(LOGTAG, "Layers are enabled");
             return true;
         }


### PR DESCRIPTION
After landing the patches enabling OpenXR cylinder layers, and the ones limitting the amount of layers 
that can be created by widgets, we're now ready to turn OpenXR layers support on Pico devices by default.

There are still some issues (like skybox not rendered due to the lack of ktx texture support) but they'll 
get eventually fixed, and we don't consider a blocker to enable this.