### PR TITLE
[OpenXR][XRLayers] Use reorient transform to position cylinders

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1440,6 +1440,8 @@ BrowserWorld::LayoutWidget(int32_t aHandle) {
 
   if (!widget->GetCylinder()) {
     widget->LayoutQuadWithCylinderParent(parent);
+  } else if (widget->GetLayer()) {
+    widget->RecenterYawInCylinderLayer(m.device->GetReorientTransform());
   }
 }
 
@@ -1510,6 +1512,8 @@ BrowserWorld::RecenterUIYaw(const YawTarget aTarget) {
     const float yaw = atan2(vector.z(), vector.x());
     m.widgetsYaw = vrb::Matrix::Rotation(vrb::Vector(0.0f, 1.0f, 0.0f), -yaw);
   }
+  // Force relayout of widgets so that cylinder layers are properly placed.
+  UpdateVisibleWidgets();
 }
 
 void

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -174,13 +174,13 @@ struct Widget::State {
     UpdateResizerTransform();
   }
 
-  void AdjustCylinderRotation(const float radius) {
+  void AdjustCylinderRotation(const float radius, const vrb::Matrix* uiYaw = nullptr) {
     const float x = transform->GetTransform().GetTranslation().x();
     const bool hasCylinderLayer = cylinder && cylinder->GetLayer();
     auto setCylinderLayerTransformIfNeeded = [&](const vrb::Matrix& rotation) {
         if (!hasCylinderLayer)
           return;
-        cylinder->GetLayer()->SetRotation(rotation);
+        cylinder->GetLayer()->SetRotation(uiYaw ? rotation.PostMultiply(*uiYaw) : rotation);
     };
 
     if (x != 0.0f && placement->cylinderMapRadius > 0) {
@@ -680,6 +680,11 @@ void Widget::LayoutQuadWithCylinderParent(const WidgetPtr& aParent) {
     m.transformContainer->SetTransform(aParent->m.transformContainer->GetTransform());
   }
   m.UpdateResizerTransform();
+}
+
+void Widget::RecenterYawInCylinderLayer(const vrb::Matrix& reorientMatrix) {
+  const float radius = GetCylinder()->GetTransformNode()->GetTransform().GetScale().x();
+  m.AdjustCylinderRotation(radius, &reorientMatrix);
 }
 
 Widget::Widget(State& aState, vrb::RenderContextPtr& aContext) : m(aState) {

--- a/app/src/main/cpp/Widget.h
+++ b/app/src/main/cpp/Widget.h
@@ -81,6 +81,7 @@ public:
   void SetBorderColor(const vrb::Color& aColor);
   void SetProxifyLayer(const bool aValue);
   void LayoutQuadWithCylinderParent(const WidgetPtr& aParent);
+  void RecenterYawInCylinderLayer(const vrb::Matrix& reorientMatrix);
 protected:
   struct State;
   Widget(State& aState, vrb::RenderContextPtr& aContext);


### PR DESCRIPTION
Whenever we enter/leave WebXR experiences (and immersive videos) we recenter the UI yaw
so the 2D window is properly placed in front of the user no matter where it was before entering 
the experience.

We use something called a reorient transform to properly rotate the whole scene graph. However 
for the case of cylinder layers they were not aware of that transform because we are not currently
using the transform coming from the widget to position them.

With this PR we basically take that reorient transform into account when creating the rotation
matrix that is passed to the cylinder layers.

Fixes #414