### PR TITLE
Fix the upper bound limit for layers

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -942,8 +942,9 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
       frameEndInfo.layers = layers.data();
       CHECK_XRCMD(xrEndFrame(session, &frameEndInfo));
   };
+
   auto canAddLayers = [&layers, maxLayers = m.systemProperties.graphicsProperties.maxLayerCount]() {
-      return layers.size() < maxLayers - 1;
+      return layers.size() < maxLayers;
   };
 
   // Add skybox layer


### PR DESCRIPTION
In 9c80164e we added some code to limit the amount of layers to be sent to the compositor
 for a given frame. It had a nasty bug, the upper limit was set to `maxLayerCount - 1` instead 
of `maxLayerCount`. For a device supporting a large number of layers that was not a real issue, 
but for those only supporting 1 layer (like HVR) that meant that nothing was sent to the 
compositor, because we were considering that 1-1=0 was the maximum number of layers, 
i.e., we were not even allowing the projection layer to be sent.