### PR TITLE
Add support to skipping frames

### DIFF
--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -81,6 +81,7 @@ public:
   }
   virtual void StartFrame(const FramePrediction aPrediction = FramePrediction::NO_FRAME_AHEAD) = 0;
   virtual void BindEye(const device::Eye aWhich) = 0;
+  virtual bool ShouldRender() const { return mShouldRender; };
   virtual void EndFrame(const FrameEndMode aMode = FrameEndMode::APPLY) = 0;
   virtual bool IsInGazeMode() const { return false; };
   virtual int32_t GazeModeIndex() const { return -1; };
@@ -104,6 +105,7 @@ protected:
 
   virtual ~DeviceDelegate() {}
 
+  bool mShouldRender { false };
 private:
   VRB_NO_DEFAULTS(DeviceDelegate)
 };

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -904,6 +904,7 @@ DeviceDelegateOculusVR::SupportsFramePrediction(FramePrediction aPrediction) con
 
 void
 DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
+  mShouldRender = false;
   if (!m.ovr) {
     VRB_LOG("StartFrame called while not in VR mode");
     return;
@@ -972,6 +973,7 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
   }
 
   VRB_GL_CHECK(glClearColor(m.clearColor.Red(), m.clearColor.Green(), m.clearColor.Blue(), m.clearColor.Alpha()));
+  mShouldRender = true;
 }
 
 void

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -741,6 +741,7 @@ DeviceDelegateOpenXR::SupportsFramePrediction(FramePrediction aPrediction) const
 
 void
 DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
+  mShouldRender = false;
   if (!m.vrReady) {
     VRB_ERROR("OpenXR StartFrame called while not in VR mode");
     return;
@@ -764,8 +765,6 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
   XrFrameBeginInfo frameBeginInfo{XR_TYPE_FRAME_BEGIN_INFO};
   CHECK_XRCMD(xrBeginFrame(m.session, &frameBeginInfo));
 
-  CHECK_MSG(frameState.shouldRender, "shouldRender==false bailout not implemented yet");
-
   m.framePrediction = aPrediction;
   if (aPrediction == FramePrediction::ONE_FRAME_AHEAD) {
     m.prevPredictedDisplayTime = m.predictedDisplayTime;
@@ -775,6 +774,10 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
   } else {
     m.predictedDisplayTime = frameState.predictedDisplayTime;
   }
+
+  mShouldRender = frameState.shouldRender;
+  if (!frameState.shouldRender)
+    return;
 
   // Query head location
   XrSpaceLocation location {XR_TYPE_SPACE_LOCATION};
@@ -945,6 +948,11 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
   auto canAddLayers = [&layers, maxLayers = m.systemProperties.graphicsProperties.maxLayerCount]() {
       return layers.size() < maxLayers - 1;
   };
+
+  if (!mShouldRender) {
+      submitEndFrame();
+      return;
+  }
 
   // Add skybox layer
   if (m.cubeLayer && m.cubeLayer->IsLoaded() && m.cubeLayer->IsDrawRequested()) {

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -854,6 +854,7 @@ HandToString(ElbowModel::HandEnum hand) {
 
 void
 DeviceDelegateWaveVR::StartFrame(const FramePrediction aPrediction) {
+  mShouldRender = false;
   VRB_GL_CHECK(glClearColor(m.clearColor.Red(), m.clearColor.Green(), m.clearColor.Blue(), m.clearColor.Alpha()));
   if (!m.lastSubmitDiscarded) {
     m.leftFBOIndex = WVR_GetAvailableTextureIndex(m.leftTextureQueue);
@@ -948,6 +949,7 @@ DeviceDelegateWaveVR::StartFrame(const FramePrediction aPrediction) {
       }
     }
   }
+  mShouldRender = true;
 }
 
 void


### PR DESCRIPTION
The OpenXR backend might ask the caller not to render a given frame by setting 
XrFrameWaitInfo.shouldRender to false when calling xrWaitFrame(). The current 
code was not only ignoring that, furthermore it was actually asserting in those cases.

That's why we have added a mShouldRender attribute to DeviceDelegate which 
will be used by BrowserWorld to decide whether or not to draw content. For the 
non-OpenXR backends that attribute is generally true except when there is an 
error in StartFrame().