### PR TITLE
[Pico] Fix splash screen orientation

### DIFF
--- a/app/src/main/cpp/SplashAnimation.cpp
+++ b/app/src/main/cpp/SplashAnimation.cpp
@@ -65,7 +65,11 @@ struct SplashAnimation::State {
     layer->Bind(GL_DRAW_FRAMEBUFFER);
     read->Bind(GL_READ_FRAMEBUFFER);
     VRB_GL_CHECK(glBlitFramebuffer(0, 0, aTexture->GetWidth(), aTexture->GetHeight(),
+#if PICOXR
+                                   0, aTexture->GetHeight(), aTexture->GetWidth(), 0,
+#else
                                    0, 0, aTexture->GetWidth(), aTexture->GetHeight(),
+#endif
                                    GL_COLOR_BUFFER_BIT, GL_LINEAR));
     layer->Unbind();
     read->Unbind();


### PR DESCRIPTION
Splash screen was shown upside down for Pico devices when using layers. This PR properly
sets the origin and destination points for the logo texture so it's properly rendered.

Fixes #428