### PR TITLE
Do not make blob: URIs visible to DownloadManager

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -215,7 +215,7 @@ public class DownloadsManager {
 
         mDownloadManager.addCompletedDownload(file.getName(), file.getName(),
                 true, UrlUtils.getMimeTypeFromUrl(file.getPath()), file.getPath(), readBytes, true,
-                Uri.parse(job.getUri()), null);
+                Uri.parse(job.getUri().replaceFirst("^blob:","")), null);
     }
 
     public void removeDownload(long downloadId, boolean deleteFiles) {


### PR DESCRIPTION
The Mozilla's DownloadManager does not really support blob: URIs, it does only support
 HTTP/HTTPS. That's why after downloading a blob URI we should remove the blob: prefix 
when reporting.

Fixes #430