### PR TITLE
Import assert.h in OpenXRInputSource.cpp

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -1,5 +1,6 @@
 #include "OpenXRInputSource.h"
 #include "OpenXRExtensions.h"
+#include <assert.h>
 #include <unordered_set>
 
 namespace crow {


### PR DESCRIPTION
This fixed a build issue in Mac systems.