### PR TITLE
[OpenXR] Extend hand-tracking support to Pico4

### DIFF
--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -209,14 +209,18 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
         ProgramPtr program = create->GetProgramFactory()->CreateProgram(create, 0);
         RenderStatePtr state = RenderState::Create(create);
         state->SetProgram(program);
-        vrb::Color handColor = vrb::Color(0.0f, 0.50f, 0.0f);
+        vrb::Color handColor = vrb::Color(0.5f, 0.5f, 0.5f);
         handColor.SetAlpha(1.0);
         state->SetMaterial(handColor, handColor,
                            Color(0.0f, 0.0f, 0.0f),
                            0.0f);
         state->SetLightsEnabled(false);
 
-        GeometryPtr sphere = DeviceUtils::GetSphereGeometry(create, 36, 1.0);
+        float radius = 0.75;
+#if defined(PICOXR)
+        radius = 0.65;
+#endif
+        GeometryPtr sphere = DeviceUtils::GetSphereGeometry(create, 36, radius);
         sphere->SetRenderState(state);
 
         for (uint32_t i = 0; i < jointTransforms.size(); i++) {

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -195,7 +195,7 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
         return;
 
     Controller &controller = m.list[aControllerIndex];
-    if (!controller.beamParent)
+    if (!m.root)
         return;
 
     // Initialize hand joints if needed
@@ -204,7 +204,7 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
 
         CreationContextPtr create = m.context.lock();
         controller.handMeshToggle = Toggle::Create(create);
-        controller.beamParent->AddNode(controller.handMeshToggle);
+        m.root->AddNode(controller.handMeshToggle);
 
         ProgramPtr program = create->GetProgramFactory()->CreateProgram(create, 0);
         RenderStatePtr state = RenderState::Create(create);
@@ -651,6 +651,7 @@ ControllerContainer::SetVisible(const bool aVisible) {
     for (int i = 0; i < m.list.size(); ++i) {
       if (m.list[i].enabled) {
         m.root->ToggleChild(*m.list[i].transform, true);
+        m.root->ToggleChild(*m.list[i].handMeshToggle, true);
       }
     }
   } else {

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -59,6 +59,7 @@ private:
     XrResult stopHapticFeedback(XrAction) const;
     void UpdateHaptics(ControllerDelegate&);
     bool GetHandTrackingInfo(const XrFrameState&, XrSpace);
+    float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
 
     XrInstance mInstance { XR_NULL_HANDLE };
     XrSession mSession { XR_NULL_HANDLE };


### PR DESCRIPTION
This series fixes several issues with current hand-tracking support that allow enabling it for Pico4 devices.
 
Unfortunately we still need to use XR_FB_hand_tracking_aim to resolve  beam and pointer transform. In a future revision we will get that information entirely from hand joint locations to avoid depending on a vendor extension. Good news is that Pico4 implements it (although they don't seem to advertise it).

Some caveats and comments:
* The weird positioning and movement of hands has been fixed and now they are shown in the correct position on both Quest2 and Pico4.
* Pico4 XR_EXT_hand_tracking extension doesn't provide the joint radius, so the spheres are all equal sized and looks a bit poorer compared to Quest2. We will change the hand rendering soon anyway so this is not a big deal.
* The color of the joint spheres was changed to gray as suggested earlier. The size was also reduced since they were too big on Pico4.
