### PR TITLE
[OpenXR] Fix rendering of 3D side by side video

### DIFF
--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -30,6 +30,7 @@ struct VRLayer::State {
   std::function<void()> pendingEvent;
   std::string name;
   bool composited;
+  bool useSameLayerForBothEyes;
   State():
       initialized(false),
       priority(0),
@@ -39,7 +40,8 @@ struct VRLayer::State {
       composited(false),
       currentEye(device::Eye::Left),
       clearColor(0),
-      tintColor(1.0f, 1.0f, 1.0f, 1.0f)
+      tintColor(1.0f, 1.0f, 1.0f, 1.0f),
+      useSameLayerForBothEyes(true)
   {
     for (int i = 0; i < 2; ++i) {
       modelTransform[i] = vrb::Matrix::Identity();
@@ -113,6 +115,10 @@ VRLayer::GetName() const {
 
 bool VRLayer::IsComposited() const {
   return m.composited;
+}
+
+bool VRLayer::GetUseSameLayerForBothEyes() const {
+  return m.useSameLayerForBothEyes;
 }
 
 bool
@@ -212,6 +218,11 @@ VRLayer::SetName(const std::string &aName) {
 void
 VRLayer::SetComposited(bool aComposited) {
   m.composited = aComposited;
+}
+
+void
+VRLayer::SetUseSameLayerForBothEyes(bool aUseSame) {
+  m.useSameLayerForBothEyes = aUseSame;
 }
 
 void VRLayer::NotifySurfaceChanged(SurfaceChange aChange, const std::function<void()>& aFirstCompositeCallback) {

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -51,6 +51,7 @@ public:
   bool GetDrawInFront() const;
   std::string GetName() const;
   bool IsComposited() const;
+  bool GetUseSameLayerForBothEyes() const;
 
   bool ShouldDrawBefore(const VRLayer& aLayer);
   void SetInitialized(bool aInitialized);
@@ -67,6 +68,7 @@ public:
   void SetDrawInFront(bool aDrawInFront);
   void SetName(const std::string& aName);
   void SetComposited(bool aComposited);
+  void SetUseSameLayerForBothEyes(bool aUseSame);
   void NotifySurfaceChanged(SurfaceChange aChange, const std::function<void()>& aFirstCompositeCallback);
 protected:
   struct State;

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -36,7 +36,8 @@ void
 OpenXRLayerQuad::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain)  {
   OpenXRLayerSurface<VRLayerQuadPtr, XrCompositionLayerQuad>::Update(aSpace, aPose, aClearSwapChain);
 
-  for (int i = 0; i < xrLayers.size(); ++i) {
+  const uint numXRLayers = GetNumXRLayers();
+  for (int i = 0; i < numXRLayers; ++i) {
     device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
 #if PICOXR
     // Seems like Pico does not properly use the layerSpace.
@@ -76,7 +77,8 @@ void
 OpenXRLayerCylinder::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain)  {
   OpenXRLayerSurface<VRLayerCylinderPtr, XrCompositionLayerCylinderKHR>::Update(aSpace, aPose, aClearSwapChain);
 
-  for (int i = 0; i < xrLayers.size(); ++i) {
+  const uint numXRLayers = GetNumXRLayers();
+  for (int i = 0; i < numXRLayers; ++i) {
     device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
 
     auto scale = layer->GetModelTransform(eye).GetScale();
@@ -154,11 +156,12 @@ void
 OpenXRLayerCube::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain)  {
   OpenXRLayerBase<VRLayerCubePtr, XrCompositionLayerCubeKHR>::Update(aSpace, aPose, aClearSwapChain);
 
-  for (auto& xrLayer: xrLayers) {
-    xrLayer.layerFlags = 0;
-    xrLayer.swapchain = swapchain->SwapChain();
-    xrLayer.imageArrayIndex = 0;
-    xrLayer.orientation = XrQuaternionf {0.0f, 0.0f, 0.0f, 1.0f};
+  const uint numXRLayers = GetNumXRLayers();
+  for (uint i = 0; i < numXRLayers; ++i) {
+    xrLayers[i].layerFlags = 0;
+    xrLayers[i].swapchain = swapchain->SwapChain();
+    xrLayers[i].imageArrayIndex = 0;
+    xrLayers[i].orientation = XrQuaternionf {0.0f, 0.0f, 0.0f, 1.0f};
   }
 }
 
@@ -206,7 +209,8 @@ OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
   }
   OpenXRLayerBase<VRLayerEquirectPtr, XrCompositionLayerEquirectKHR>::Update(aSpace, aPose, aClearSwapChain);
 
-  for (int i = 0; i < xrLayers.size(); ++i) {
+  const uint numXRLayers = GetNumXRLayers();
+  for (int i = 0; i < numXRLayers; ++i) {
     device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
     // Map video orientation
     vrb::Matrix transform = XrPoseToMatrix(aPose).PostMultiply(layer->GetModelTransform(eye));


### PR DESCRIPTION
3D SBS video rendering was broken with OpenXR backend. It actually never really worked because the current implementation is based on the requirements of the OculusVR backend. It required the use of multiple Quad layers and some transformations to get it right.

However for the OpenXR backend everything is much simpler. We can use a single layer, and specify different rects to be displayed on each eye by using the `XrEyeVisibility` attribute in the quad compositor layer. This brings the magic of the 3D SBS stereo rendering back to Wolvic.

In order to test it you could use any of the 3D SBS videos in Youtube like [this](https://www.youtube.com/watch?v=kfquE1nqM6A) or [this](https://www.youtube.com/watch?v=rLynxtGCFDI)

Fixes #436 