### PR TITLE
Use legacy User-Agent by default, add more settings

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoWebExtension.kt
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoWebExtension.kt
@@ -267,7 +267,7 @@ class GeckoWebExtension(
                 val activeSession: Session = SessionStore.get().activeSession;
                 val session: Session = SessionStore.get().createWebExtensionSession(false, activeSession.isPrivateMode);
                 session.setParentSession(activeSession)
-                session.uaMode = GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
+                session.setUaMode(GeckoSessionSettings.USER_AGENT_MODE_DESKTOP, true)
                 val geckoEngineSession = WolvicEngineSession(session)
                 ext.metaData?.optionsPageUrl?.let { optionsPageUrl ->
                     tabHandler.onNewTab(

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -83,6 +83,7 @@ public class SettingsStore {
     public final static boolean SPEECH_DATA_COLLECTION_DEFAULT = false;
     public final static boolean SPEECH_DATA_COLLECTION_REVIEWED_DEFAULT = false;
     public final static int UA_MODE_DEFAULT = WSessionSettings.USER_AGENT_MODE_VR;
+    public final static boolean USE_WOLVIC_UA_DEFAULT = false;
     public final static int INPUT_MODE_DEFAULT = 1;
     public final static float DISPLAY_DENSITY_DEFAULT = 1.0f;
     public final static int WINDOW_WIDTH_DEFAULT = 800;
@@ -339,6 +340,17 @@ public class SettingsStore {
         }
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putInt(mContext.getString(R.string.settings_key_user_agent_version), checkedMode);
+        editor.commit();
+    }
+
+    public boolean getUseWolvicUA() {
+        return mPrefs.getBoolean(
+                mContext.getString(R.string.settings_key_use_wolvic_ua), USE_WOLVIC_UA_DEFAULT);
+    }
+
+    public void setUseWolvicUA(boolean useWolvicUA) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(mContext.getString(R.string.settings_key_use_wolvic_ua), useWolvicUA);
         editor.commit();
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
@@ -38,7 +38,7 @@ class WolvicWebExtensionRuntime(
             val activeSession = SessionStore.get().activeSession
             val session: Session = SessionStore.get().createWebExtensionSession(activeSession.isPrivateMode);
             session.setParentSession(activeSession)
-            session.uaMode = WSessionSettings.USER_AGENT_MODE_DESKTOP
+            session.setUaMode(WSessionSettings.USER_AGENT_MODE_DESKTOP, true)
             val engineSession = WolvicEngineSession(session)
             (context as WidgetManagerDelegate).windows.onTabSelect(session)
             return webExtensionDelegate?.onToggleActionPopup(extension, engineSession, action)

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -76,7 +76,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     private static UriOverride sDesktopModeOverrides;
     private static final long KEEP_ALIVE_DURATION_MS = 1000; // 1 second.
 
-    private static final String WOLVIC_USER_AGENT_MOBILE = "Mozilla/5.0 (Android 10; Mobile; rv:105.0) Gecko/105.0 Wolvic/" + BuildConfig.VERSION_NAME + " Firefox/105.0 OculusBrowser/25.3.0.4.30.438623098 VR Safari/537.36";
+    private static final String WOLVIC_USER_AGENT_MOBILE = "Mozilla/5.0 (Android 10; Mobile; rv:105.0) Gecko/105.0 Wolvic/" + BuildConfig.VERSION_NAME;
     // This matches GeckoViewSettings.jsm
     private static final String WOLVIC_USER_AGENT_VR = WOLVIC_USER_AGENT_MOBILE.replace("Mobile", "Mobile VR");
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1027,8 +1027,13 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         return true;
     }
 
-    public void setUaMode(int mode) {
+    public void setUaMode(int mode, boolean reload) {
+        // the UA mode value did not change
         if (!trySetUaMode(mode))
+            return;
+
+        // the value did change, but we don't need to force a reload
+        if (!reload)
             return;
 
         String overrideUri = mode == WSessionSettings.USER_AGENT_MODE_DESKTOP ? checkForMobileSite(mState.mUri) : null;
@@ -1749,7 +1754,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
             }
         } else if (key.equals(mContext.getString(R.string.settings_key_user_agent_version))) {
             if (mState.mSettings.getUserAgentMode() != WSessionSettings.USER_AGENT_MODE_DESKTOP) {
-                setUaMode(SettingsStore.getInstance(mContext).getUaMode());
+                setUaMode(SettingsStore.getInstance(mContext).getUaMode(), false);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -76,7 +76,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     private static UriOverride sDesktopModeOverrides;
     private static final long KEEP_ALIVE_DURATION_MS = 1000; // 1 second.
 
-    private static final String WOLVIC_USER_AGENT_MOBILE = "Mozilla/5.0 (Android 10; Mobile; rv:105.0) Gecko/105.0 Wolvic/" + BuildConfig.VERSION_NAME;
+    private static final String WOLVIC_USER_AGENT_MOBILE = "Mozilla/5.0 (Android 10; Mobile; rv:105.0) Gecko/105.0 Wolvic/" + BuildConfig.VERSION_NAME + " Firefox/105.0 OculusBrowser/25.3.0.4.30.438623098 VR Safari/537.36";
     // This matches GeckoViewSettings.jsm
     private static final String WOLVIC_USER_AGENT_VR = WOLVIC_USER_AGENT_MOBILE.replace("Mobile", "Mobile VR");
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1140,7 +1140,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         if (aSession == mState.mSession) {
             String userAgentOverride = sUserAgentOverride.lookupOverride(uri);
 
-            Log.e(LOGTAG, "checking override: " + uri);
+            Log.d(LOGTAG, "User-Agent override: " + userAgentOverride);
 
             // Update the User-Agent according to the current settings, unless we are
             // in Desktop mode (which sets its own user agent). These settings define:

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1229,11 +1229,11 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
                 if (uaMode == WSessionSettings.USER_AGENT_MODE_DESKTOP) {
                     final int defaultUaMode = SettingsStore.getInstance(mAppContext).getUaMode();
                     mHamburgerMenu.setUAMode(defaultUaMode);
-                    mAttachedWindow.getSession().setUaMode(defaultUaMode);
+                    mAttachedWindow.getSession().setUaMode(defaultUaMode, true);
 
                 } else {
                     mHamburgerMenu.setUAMode(WSessionSettings.USER_AGENT_MODE_DESKTOP);
-                    mAttachedWindow.getSession().setUaMode(WSessionSettings.USER_AGENT_MODE_DESKTOP);
+                    mAttachedWindow.getSession().setUaMode(WSessionSettings.USER_AGENT_MODE_DESKTOP, true);
                 }
 
                 hideMenu();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
@@ -6,6 +6,7 @@
 package com.igalia.wolvic.ui.widgets.settings;
 
 import android.content.Context;
+import android.graphics.Point;
 import android.view.LayoutInflater;
 import android.view.View;
 
@@ -16,8 +17,10 @@ import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.OptionsDeveloperBinding;
+import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 
 class DeveloperOptionsView extends SettingsView {
 
@@ -76,6 +79,13 @@ class DeveloperOptionsView extends SettingsView {
 
         mBinding.localAddonSwitch.setOnCheckedChangeListener(mLocalAddonListener);
         setLocalAddon(SettingsStore.getInstance(getContext()).isLocalAddonAllowed(), false);
+
+        mBinding.wolvicUserAgentSwitch.setOnCheckedChangeListener(mUseWolvicUAListener);
+        setUseWolvicUA(SettingsStore.getInstance(getContext()).getUseWolvicUA(), false);
+
+        int uaMode = SettingsStore.getInstance(getContext()).getUaMode();
+        mBinding.uaRadio.setOnCheckedChangeListener(mUaModeListener);
+        setUaMode(mBinding.uaRadio.getIdForValue(uaMode), false);
     }
 
     private SwitchSetting.OnCheckedChangeListener mRemoteDebuggingListener = (compoundButton, value, doApply) -> {
@@ -104,6 +114,13 @@ class DeveloperOptionsView extends SettingsView {
 
     private SwitchSetting.OnCheckedChangeListener mLocalAddonListener = (compoundButton, value, doApply) -> {
         setLocalAddon(value, doApply);
+    };
+
+    private SwitchSetting.OnCheckedChangeListener mUseWolvicUAListener = (compoundButton, enabled, apply) ->
+            setUseWolvicUA(enabled, true);
+
+    private RadioGroupSetting.OnCheckedChangeListener mUaModeListener = (radioGroup, checkedId, doApply) -> {
+        setUaMode(checkedId, true);
     };
 
     private OnClickListener mResetListener = (view) -> {
@@ -137,6 +154,14 @@ class DeveloperOptionsView extends SettingsView {
 
         if (mBinding.localAddonSwitch.isChecked() != SettingsStore.LOCAL_ADDON_ALLOWED) {
             setLocalAddon(SettingsStore.LOCAL_ADDON_ALLOWED, true);
+        }
+
+        if (mBinding.wolvicUserAgentSwitch.isChecked() != SettingsStore.USE_WOLVIC_UA_DEFAULT) {
+            setUseWolvicUA(SettingsStore.USE_WOLVIC_UA_DEFAULT, true);
+        }
+
+        if (!mBinding.uaRadio.getValueForId(mBinding.uaRadio.getCheckedRadioButtonId()).equals(SettingsStore.UA_MODE_DEFAULT)) {
+            setUaMode(mBinding.uaRadio.getIdForValue(SettingsStore.UA_MODE_DEFAULT), true);
         }
 
         if (restart) {
@@ -219,9 +244,33 @@ class DeveloperOptionsView extends SettingsView {
         }
     }
 
+    private void setUseWolvicUA(boolean value, boolean doApply) {
+        mBinding.wolvicUserAgentSwitch.setOnCheckedChangeListener(null);
+        mBinding.wolvicUserAgentSwitch.setValue(value, false);
+        mBinding.wolvicUserAgentSwitch.setOnCheckedChangeListener(mUseWolvicUAListener);
+
+        if (doApply) {
+            SettingsStore.getInstance(getContext()).setUseWolvicUA(value);
+        }
+    }
+
+    private void setUaMode(int checkId, boolean doApply) {
+        mBinding.uaRadio.setOnCheckedChangeListener(null);
+        mBinding.uaRadio.setChecked(checkId, doApply);
+        mBinding.uaRadio.setOnCheckedChangeListener(mUaModeListener);
+
+        SettingsStore.getInstance(getContext()).setUaMode((Integer) mBinding.uaRadio.getValueForId(checkId));
+    }
+
+    @Override
+    public Point getDimensions() {
+        return new Point(WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
+                WidgetPlacement.dpDimension(getContext(), R.dimen.developer_options_height));
+    }
+
     @Override
     protected SettingViewType getType() {
-        return SettingViewType.LANGUAGE_VOICE;
+        return SettingViewType.DEVELOPER;
     }
 
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
@@ -251,6 +251,11 @@ class DeveloperOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setUseWolvicUA(value);
+
+            if (value != SettingsStore.USE_WOLVIC_UA_DEFAULT) {
+                showAlert(getContext().getString(R.string.developer_options_wolvic_user_agent_warning_title),
+                        getContext().getString(R.string.developer_options_wolvic_user_agent_warning_body));
+            }
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -55,10 +55,6 @@ class DisplayOptionsView extends SettingsView {
         mBinding.curvedDisplaySwitch.setOnCheckedChangeListener(mCurvedDisplayListener);
         setCurvedDisplay(SettingsStore.getInstance(getContext()).getCylinderDensity() > 0.0f, false);
 
-        int uaMode = SettingsStore.getInstance(getContext()).getUaMode();
-        mBinding.uaRadio.setOnCheckedChangeListener(mUaModeListener);
-        setUaMode(mBinding.uaRadio.getIdForValue(uaMode), false);
-
         int msaaLevel = SettingsStore.getInstance(getContext()).getMSAALevel();
         mBinding.msaaRadio.setOnCheckedChangeListener(mMSSAChangeListener);
         setMSAAMode(mBinding.msaaRadio.getIdForValue(msaaLevel), false);
@@ -123,10 +119,6 @@ class DisplayOptionsView extends SettingsView {
         return editing;
     }
 
-    private RadioGroupSetting.OnCheckedChangeListener mUaModeListener = (radioGroup, checkedId, doApply) -> {
-        setUaMode(checkedId, true);
-    };
-
     private RadioGroupSetting.OnCheckedChangeListener mMSSAChangeListener = (radioGroup, checkedId, doApply) -> {
         setMSAAMode(checkedId, true);
     };
@@ -178,16 +170,12 @@ class DisplayOptionsView extends SettingsView {
     private OnClickListener mResetListener = (view) -> {
         boolean restart = false;
 
-        if (!mBinding.uaRadio.getValueForId(mBinding.uaRadio.getCheckedRadioButtonId()).equals(SettingsStore.UA_MODE_DEFAULT)) {
-            setUaMode(mBinding.uaRadio.getIdForValue(SettingsStore.UA_MODE_DEFAULT), true);
-        }
         if (!mBinding.msaaRadio.getValueForId(mBinding.msaaRadio.getCheckedRadioButtonId()).equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
             setMSAAMode(mBinding.msaaRadio.getIdForValue(SettingsStore.MSAA_DEFAULT_LEVEL), true);
         }
 
         restart = restart | setDisplayDensity(SettingsStore.DISPLAY_DENSITY_DEFAULT);
         restart = restart | setDisplayDpi(SettingsStore.DISPLAY_DPI_DEFAULT);
-
 
         setHomepage(mDefaultHomepageUrl);
         setAutoplay(SettingsStore.AUTOPLAY_ENABLED, true);
@@ -225,14 +213,6 @@ class DisplayOptionsView extends SettingsView {
         mBinding.homepageEdit.setFirstText(newHomepage);
         SettingsStore.getInstance(getContext()).setHomepage(newHomepage);
         mBinding.homepageEdit.setOnClickListener(mHomepageListener);
-    }
-
-    private void setUaMode(int checkId, boolean doApply) {
-        mBinding.uaRadio.setOnCheckedChangeListener(null);
-        mBinding.uaRadio.setChecked(checkId, doApply);
-        mBinding.uaRadio.setOnCheckedChangeListener(mUaModeListener);
-
-        SettingsStore.getInstance(getContext()).setUaMode((Integer)mBinding.uaRadio.getValueForId(checkId));
     }
 
     private void setMSAAMode(int checkedId, boolean doApply) {

--- a/app/src/main/res/layout/options_developer.xml
+++ b/app/src/main/res/layout/options_developer.xml
@@ -79,6 +79,20 @@
                     android:layout_height="wrap_content"
                     app:description="@string/allow_local_addon_switch" />
 
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/wolvic_user_agent_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/developer_options_wolvic_user_agent" />
+
+                <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
+                    android:id="@+id/ua_radio"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/developer_options_ua_mode"
+                    app:options="@array/developer_options_ua_modes"
+                    app:values="@array/developer_options_ua_mode_values" />
+
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -44,13 +44,11 @@
                     android:layout_height="wrap_content"
                     app:description="@string/developer_options_curved_display" />
 
-                <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
-                    android:id="@+id/ua_radio"
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/autoplaySwitch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:description="@string/developer_options_ua_mode"
-                    app:options="@array/developer_options_ua_modes"
-                    app:values="@array/developer_options_ua_mode_values" />
+                    app:description="@string/security_options_autoplay" />
 
                 <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
                     android:id="@+id/msaa_radio"
@@ -59,12 +57,6 @@
                     app:description="@string/developer_options_msaa"
                     app:options="@array/developer_options_msaa"
                     app:values="@array/developer_options_msaa_mode_values" />
-
-                <com.igalia.wolvic.ui.views.settings.SwitchSetting
-                    android:id="@+id/autoplaySwitch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/security_options_autoplay" />
 
                 <com.igalia.wolvic.ui.views.settings.SingleEditSetting
                     android:id="@+id/homepage_edit"

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -399,9 +399,12 @@
     <string name="developer_options_msaa_2">2x</string>
     <!-- This string is used to label the MSAA radio button that enables two times MSAA in Immersive Mode. -->
     <string name="developer_options_msaa_4">4x</string>
+    <!-- This string is used to label a switch that allows the user to use
+         a Wolvic-specific User-Agent value. -->
+    <string name="developer_options_wolvic_user_agent">Emplear el valor de \"User-Agent\" específico de Wolvic</string>
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          User-Agent (UA) string of the browser. -->
-    <string name="developer_options_ua_mode">Modo de agente de usuario</string>
+    <string name="developer_options_ua_mode">Modo de \"User-Agent\" por defecto</string>
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          default downloads storage. -->
     <string name="security_options_downloads_storage">Almacenamiento predeterminado para descargas</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -402,6 +402,10 @@
     <!-- This string is used to label a switch that allows the user to use
          a Wolvic-specific User-Agent value. -->
     <string name="developer_options_wolvic_user_agent">Emplear el valor de \"User-Agent\" específico de Wolvic</string>
+    <!-- This string is the title of a dialog explaining the risk of changing the default User-Agent. -->
+    <string name="developer_options_wolvic_user_agent_warning_title">Atención</string>
+    <!-- This string is the body of a dialog explaining the risk of changing the default User-Agent. -->
+    <string name="developer_options_wolvic_user_agent_warning_body">Cambiar el valor por defecto de \"User-Agent\" es una functionalidad experimental que podría hacer que algunas páginas Web no funcionasen correctamente.</string>
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          User-Agent (UA) string of the browser. -->
     <string name="developer_options_ua_mode">Modo de \"User-Agent\" por defecto</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -183,7 +183,8 @@
     <string name="developer_options_msaa_2">2x</string>
     <string name="developer_options_msaa_4">4x</string>
     <string name="security_options_downloads_storage">Almacenamento por defecto para descargas</string>
-    <string name="developer_options_ua_mode">Modo User-Agent</string>
+    <string name="developer_options_wolvic_user_agent">Empregar o valor de \"User-Agent\" específico de Wolvic</string>
+    <string name="developer_options_ua_mode">Modo de \"User-Agent\" por defecto</string>
     <string name="developer_options_ua_vr">VR</string>
     <string name="privacy_options_downloads_storage_internal">Interno</string>
     <string name="privacy_options_downloads_storage_external">Externo</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -184,6 +184,8 @@
     <string name="developer_options_msaa_4">4x</string>
     <string name="security_options_downloads_storage">Almacenamento por defecto para descargas</string>
     <string name="developer_options_wolvic_user_agent">Empregar o valor de \"User-Agent\" específico de Wolvic</string>
+    <string name="developer_options_wolvic_user_agent_warning_title">Atención</string>
+    <string name="developer_options_wolvic_user_agent_warning_body">Cambiar o valor por defecto de \"User-Agent\" é una functionalidade experimental que podería facer que algunhas páxinas Web non funcionasen correctamente.</string>
     <string name="developer_options_ua_mode">Modo de \"User-Agent\" por defecto</string>
     <string name="developer_options_ua_vr">VR</string>
     <string name="privacy_options_downloads_storage_internal">Interno</string>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -245,6 +245,9 @@
     <!-- Language and voice settings -->
     <dimen name="language_options_height">380dp</dimen>
 
+    <!-- Display settings -->
+    <dimen name="developer_options_height">420dp</dimen>
+
     <!-- JS Prompt dialogs -->
     <item name="js_prompt_y_distance" format="float" type="dimen">1.2</item>
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -17,6 +17,7 @@
     <string name="settings_key_tracking_protection_level" translatable="false">settings_tracking_protection_level</string>
     <string name="settings_key_speech_data_collection" translatable="false">settings_key_speech_data_collection</string>
     <string name="settings_key_speech_data_collection_reviewed" translatable="false">settings_key_speech_data_collection_accept</string>
+    <string name="settings_key_use_wolvic_ua" translatable="false">settings_key_use_wolvic_user_agent</string>
     <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version_v2</string>
     <string name="settings_key_input_mode" translatable="false">settings_touch_mode</string>
     <string name="settings_key_display_density" translatable="false">settings_display_density</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -547,9 +547,13 @@
     <!-- This string is used to label the MSAA radio button that enables two times MSAA in Immersive Mode. -->
     <string name="developer_options_msaa_4">4x</string>
 
+    <!-- This string is used to label a switch that allows the user to use
+         a Wolvic-specific User-Agent value. -->
+    <string name="developer_options_wolvic_user_agent">Use Wolvic\'s own \"User-Agent\"</string>
+
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          User-Agent (UA) string of the browser. -->
-    <string name="developer_options_ua_mode">User-Agent Mode</string>
+    <string name="developer_options_ua_mode">Default User-Agent Mode</string>
 
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          default downloads storage. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -551,6 +551,12 @@
          a Wolvic-specific User-Agent value. -->
     <string name="developer_options_wolvic_user_agent">Use Wolvic\'s own \"User-Agent\"</string>
 
+    <!-- This string is the title of a dialog explaining the risk of changing the default User-Agent. -->
+    <string name="developer_options_wolvic_user_agent_warning_title">Warning</string>
+
+    <!-- This string is the body of a dialog explaining the risk of changing the default User-Agent. -->
+    <string name="developer_options_wolvic_user_agent_warning_body">Changing the default \"User-Agent\" value is an experimental feature and might break some websites.</string>
+
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          User-Agent (UA) string of the browser. -->
     <string name="developer_options_ua_mode">Default User-Agent Mode</string>


### PR DESCRIPTION
Our User-Agent by default (when not in Desktop mode) becomes:

    Mozilla/5.0 (Android 10; Mobile VR; rv:105.0) Gecko/105.0 Firefox/105.0

This can be modified through the settings:

- use Wolvic's own UA: report ourselves as "Firefox" (the GeckoView default) or "Wolvic"
- UA mode: "Mobile" or "Mobile VR"

User-Agent settings have been moved to the Developer section.

Add a new setting to decide whether to use Wolvic's own User-Agent or GeckoView's default one.

Add "Mobile" and "Mobile VR" variants to Wolvic's User-Agent, to match what GeckoView does.

Update the User-Agent when a page is reloaded, so changes to the settings can be effective immediately.

English, Spanish, and Galician translations.