### PR TITLE
Parse Web App manifest early

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -19,7 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 import androidx.annotation.UiThread;
 
-import org.json.JSONObject;
+import com.igalia.wolvic.ui.adapters.WebApp;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -285,13 +285,14 @@ public interface WSession {
          * <p>The various colors (theme_color, background_color, etc.) present in the manifest have been
          * transformed into #AARRGGBB format.
          *
-         * @param session The ISession that contains the Web App Manifest
-         * @param manifest A parsed and validated {@link JSONObject} containing the manifest contents.
+         * @param session  The ISession that contains the Web App Manifest
+         * @param manifest A parsed and validated {@link WebApp} representing the manifest contents.
          * @see <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest specification</a>
          */
         @UiThread
         default void onWebAppManifest(
-                @NonNull final WSession session, @NonNull final JSONObject manifest) {}
+                @NonNull final WSession session, @NonNull final WebApp manifest) {
+        }
 
         /**
          * A script has exceeded its execution timeout value

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -53,9 +53,6 @@ import com.igalia.wolvic.utils.InternalPages;
 import com.igalia.wolvic.utils.SystemUtils;
 import com.igalia.wolvic.utils.UrlUtils;
 
-import org.json.JSONObject;
-
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -1363,20 +1360,12 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     }
 
     @Override
-    public void onWebAppManifest(@NonNull WSession aSession, @NonNull JSONObject manifest) {
+    public void onWebAppManifest(@NonNull WSession aSession, @NonNull WebApp webAppManifest) {
         if (mState.mSession == aSession) {
-            try {
-                mState.mWebAppManifest = new WebApp(manifest);
-                Log.d(LOGTAG, "onWebAppManifest: received Web app manifest from " + mState.mUri);
-            } catch (IOException e) {
-                Log.w(LOGTAG, "onWebAppManifest: malformed Web app manifest: " + e.getMessage());
-                mState.mWebAppManifest = null;
-            }
-
-            // TODO update the stored manifest??
-
+            mState.mWebAppManifest = webAppManifest;
+            Log.d(LOGTAG, "onWebAppManifest: received Web app manifest from " + mState.mUri);
             for (WSession.ContentDelegate listener : mContentListeners) {
-                listener.onWebAppManifest(aSession, manifest);
+                listener.onWebAppManifest(aSession, webAppManifest);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
@@ -5,7 +5,6 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 
 import com.igalia.wolvic.utils.StringUtils;
-import com.igalia.wolvic.utils.SystemUtils;
 
 import org.json.JSONObject;
 
@@ -25,11 +24,7 @@ import mozilla.components.concept.engine.manifest.WebAppManifestParser;
  * See https://www.w3.org/TR/appmanifest/ for reference.
  */
 public class WebApp {
-
-    protected final String LOGTAG = SystemUtils.createLogtag(this.getClass());
-
-    @NonNull
-    private String mIdentity;
+    @NonNull private String mIdentity;
     private WebAppManifest mManifest;
     private OptionalInt mHashCode = OptionalInt.empty();
 
@@ -45,7 +40,12 @@ public class WebApp {
             WebAppManifestParser.Result.Success successResult = (WebAppManifestParser.Result.Success) result;
             mManifest = successResult.getManifest();
         } else {
-            throw new IOException("Unable to parse the Web App manifest");
+            String reason = "unknown reason";
+            if (result instanceof WebAppManifestParser.Result.Failure) {
+                WebAppManifestParser.Result.Failure failure = (WebAppManifestParser.Result.Failure) result;
+                reason = failure.toString();
+            }
+            throw new IOException("Unable to parse the Web App manifest: " + reason);
         }
 
         // Algorithm for calculating Identity at https://www.w3.org/TR/appmanifest/#id-member

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -58,6 +58,7 @@ import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.downloads.DownloadJob;
 import com.igalia.wolvic.downloads.DownloadsManager;
 import com.igalia.wolvic.telemetry.TelemetryService;
+import com.igalia.wolvic.ui.adapters.WebApp;
 import com.igalia.wolvic.ui.viewmodel.WindowViewModel;
 import com.igalia.wolvic.ui.views.library.LibraryPanel;
 import com.igalia.wolvic.ui.widgets.dialogs.PromptDialogWidget;
@@ -69,7 +70,6 @@ import com.igalia.wolvic.utils.UrlUtils;
 import com.igalia.wolvic.utils.ViewUtils;
 
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONObject;
 
 import java.io.File;
 import java.net.URLConnection;
@@ -1830,7 +1830,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     @Override
-    public void onWebAppManifest(@NonNull WSession session, @NonNull JSONObject manifest) {
+    public void onWebAppManifest(@NonNull WSession session, @NonNull WebApp webAppManifest) {
         mViewModel.setIsWebApp(true);
     }
 


### PR DESCRIPTION
Parse the Web App manifest as soon as Gecko notifies us about it, so we can prevent errors in case it is malformed.