### PR TITLE
Hide Web App icon in URL when the Library is open

### DIFF
--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -242,7 +242,7 @@
                     android:tint="@color/fog"
                     android:tooltipText="@string/hamburger_menu_save_web_app"
                     app:privateMode="@{viewmodel.isPrivateSession}"
-                    app:visibleGone="@{viewmodel.isWebApp &amp;&amp; !viewmodel.isFocused}" />
+                    app:visibleGone="@{viewmodel.isWebApp &amp;&amp; !(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}" />
 
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/bookmarkButton"


### PR DESCRIPTION
This PR hides the Web App icon in the URL bar when the Library is open.