### PR TITLE
Enable and disable add-ons

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/WebExtensionControllerImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/WebExtensionControllerImpl.java
@@ -114,9 +114,12 @@ class WebExtensionControllerImpl implements WWebExtensionController {
     @NonNull
     @Override
     public WResult<List<WebExtension>> list() {
-        return new ResultImpl<>(mController.list().map(list -> list.stream()
-                .map(ext -> new GeckoWebExtension(ext, mRuntime))
-                .collect(Collectors.toList())));
+        return new ResultImpl<>(mController.list().map(list -> (list != null) ?
+                list.stream()
+                        .filter(ext -> ext != null && ext.id != null)
+                        .map(ext -> new GeckoWebExtension(ext, mRuntime))
+                        .collect(Collectors.toList())
+                : null));
     }
 
     @NonNull
@@ -135,6 +138,8 @@ class WebExtensionControllerImpl implements WWebExtensionController {
     }
 
     private WResult<WebExtension> map(GeckoResult<org.mozilla.geckoview.WebExtension> ext) {
-        return new ResultImpl<>(ext.map(value -> new GeckoWebExtension(value, mRuntime)));
+        return new ResultImpl<>(ext.map(value ->
+                (value != null) ? new GeckoWebExtension(value, mRuntime) : null)
+        );
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/addons/views/AddonOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/addons/views/AddonOptionsView.java
@@ -3,7 +3,6 @@ package com.igalia.wolvic.addons.views;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.Log;
-import android.view.Gravity;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -23,7 +22,6 @@ import com.igalia.wolvic.ui.widgets.prompts.PromptData;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 
 import mozilla.components.concept.engine.webextension.EnableSource;
 import mozilla.components.feature.addons.Addon;
@@ -114,21 +112,11 @@ public class AddonOptionsView extends RecyclerView.ViewHolder implements AddonOp
     }
 
     private void showRemoveAddonSuccessDialog(@NonNull Addon addon) {
-        String permissionsHtml = addon.translatePermissions(mContext).stream()
-                .map(str -> {
-                    return "<li>&nbsp;" + str + "</li>";
-                })
-                .sorted()
-                .collect(Collectors.joining());
         PromptData data = new PromptData.Builder()
                 .withIconRes(R.drawable.ic_icon_addons)
                 .withTitle(mContext.getString(
                         R.string.addons_remove_success_dialog_title,
                         ExtensionsKt.translateName(addon, mContext)))
-                .withBody(mContext.getString(
-                        R.string.addons_install_dialog_body,
-                        permissionsHtml))
-                .withBodyGravity(Gravity.START)
                 .withBtnMsg(new String[]{
                         mContext.getString(R.string.addons_remove_success_dialog_ok)
                 })

--- a/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
@@ -208,8 +208,10 @@ class WolvicWebExtensionRuntime(
             onError: (Throwable) -> Unit
     ) {
         runtime.webExtensionController.enable(extension, source.id).then({
-            webExtensionDelegate?.onEnabled(extension)
-            onSuccess(extension)
+            if (it != null) {
+                webExtensionDelegate?.onEnabled(it)
+                onSuccess(it)
+            }
             WResult.create<Void>()
         }, { throwable ->
             onError(throwable)
@@ -227,8 +229,10 @@ class WolvicWebExtensionRuntime(
             onError: (Throwable) -> Unit
     ) {
         runtime.webExtensionController.disable(extension, source.id).then({
-            webExtensionDelegate?.onDisabled(extension)
-            onSuccess(extension)
+            if (it != null) {
+                webExtensionDelegate?.onDisabled(it)
+                onSuccess(it)
+            }
             WResult.create<Void>()
         }, { throwable ->
             onError(throwable)


### PR DESCRIPTION
This PR fixes a bug that made it impossible to enable and disable add-ons in a consistent manner.

It also adds a couple of additional checks to prevent problems when an add-on has a NULL `id` field.

And it fixes a small UI problem in the dialog that we show when an add-on is removed.

Fixes #392