### PR TITLE
Fix a crash when exiting the application

### DIFF
--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -335,7 +335,7 @@ VRLayerSurface::VRLayerSurface(State& aState, LayerType aLayerType): VRLayer(aSt
 }
 
 VRLayerSurface::~VRLayerSurface() {
-  if (m.surface) {
+  if (m.surface && VRBrowser::Env()) {
     VRBrowser::Env()->DeleteGlobalRef(m.surface);
   }
 }


### PR DESCRIPTION
It might happen that by the time a VRLayerSurface is freed, the Java context has been already
 released. In those cases trying to delete the global reference kept by the surface causes a crash 
due to a null pointer exception. In those cases we just simply have to bail out.