### PR TITLE
Use a safer Firefox-based User Agent

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -72,7 +72,8 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     private static UriOverride sUserAgentOverride;
     private static UriOverride sDesktopModeOverrides;
     private static final long KEEP_ALIVE_DURATION_MS = 1000; // 1 second.
-    private static final String DEFAULT_USER_AGENT = "Mozilla/5.0 (Android 10; Mobile VR; rv:105.0) Gecko/105.0 Wolvic/" + BuildConfig.VERSION_NAME;
+    // FIXME: this is Gecko dependant and should not be implemented this way.
+    private static final String DEFAULT_USER_AGENT = "Mozilla/5.0 (Android 10; Mobile VR; rv:105.0) Gecko/105.0 Firefox/105.0 Wolvic/" + BuildConfig.VERSION_NAME;
 
     private transient CopyOnWriteArrayList<WSession.NavigationDelegate> mNavigationListeners;
     private transient CopyOnWriteArrayList<WSession.ProgressDelegate> mProgressListeners;


### PR DESCRIPTION
We recently changed our UA to be in the form of "Gecko/x.x Wolvic/x.x". This gives us more
visibility but it's actually causing issues, as many services out there doing UA filtering do not 
recognize our UA yet. An example is the very popular DelightXR player (a WebXR video player) 
which does not work with our current UA but will work if we mention Firefox.

So in order to remain very compatible and visible at the same time we have decided to update 
the UA so it is made of the Gecko's default UA + "Wolvic/version".