### PR TITLE
Append "Wolvic/1.2" to the default GeckoView User-Agent

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoWebExtension.kt
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoWebExtension.kt
@@ -267,7 +267,7 @@ class GeckoWebExtension(
                 val activeSession: Session = SessionStore.get().activeSession;
                 val session: Session = SessionStore.get().createWebExtensionSession(false, activeSession.isPrivateMode);
                 session.setParentSession(activeSession)
-                session.uaMode = GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
+                session.setUaMode(GeckoSessionSettings.USER_AGENT_MODE_DESKTOP, true)
                 val geckoEngineSession = WolvicEngineSession(session)
                 ext.metaData?.optionsPageUrl?.let { optionsPageUrl ->
                     tabHandler.onNewTab(

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -5,6 +5,7 @@ import android.graphics.Matrix;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.api.WContentBlocking;
 import com.igalia.wolvic.browser.api.WDisplay;
 import com.igalia.wolvic.browser.api.WMediaSession;
@@ -35,6 +36,11 @@ public class SessionImpl implements WSession {
     private TextInputImpl mTextInput;
     private PanZoomControllerImpl mPanZoomController;
     private Method mGeckoLocationMethod;
+
+    // The difference between "Mobile" and "VR" matches GeckoViewSettings.jsm
+    private static final String WOLVIC_USER_AGENT_MOBILE = GeckoSession.getDefaultUserAgent() + " Wolvic/" + BuildConfig.VERSION_NAME;
+    private static final String WOLVIC_USER_AGENT_VR = WOLVIC_USER_AGENT_MOBILE.replace("Mobile", "Mobile VR");
+    private static final String WOLVIC_USER_AGENT_DESKTOP = "Mozilla/5.0 (X11; Linux x86_64; rv:105.0) Gecko/20100101 Firefox/105.0";
 
     public SessionImpl(@Nullable WSessionSettings settings) {
         if (settings == null) {
@@ -123,6 +129,20 @@ public class SessionImpl implements WSession {
     @Override
     public WSessionSettings getSettings() {
         return mSettings;
+    }
+
+    @NonNull
+    @Override
+    public String getDefaultUserAgent(int mode) {
+        switch (mode) {
+            case WSessionSettings.USER_AGENT_MODE_DESKTOP:
+                return WOLVIC_USER_AGENT_DESKTOP;
+            case WSessionSettings.USER_AGENT_MODE_VR:
+                return WOLVIC_USER_AGENT_VR;
+            case WSessionSettings.USER_AGENT_MODE_MOBILE:
+            default:
+                return WOLVIC_USER_AGENT_MOBILE;
+        }
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -2569,6 +2569,16 @@ public interface WSession {
     @NonNull
     WSessionSettings getSettings();
 
+    /**
+     * Get the default user-agent for the given mode.
+     *
+     * @param mode {@link WSessionSettings#USER_AGENT_MODE_MOBILE},
+     *             {@link WSessionSettings#USER_AGENT_MODE_DESKTOP},
+     *             or {@link WSessionSettings#USER_AGENT_MODE_VR}.
+     */
+    @AnyThread
+    @NonNull
+    String getDefaultUserAgent(final int mode);
 
     /** Exits fullscreen mode */
     @AnyThread

--- a/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/WolvicWebExtensionRuntime.kt
@@ -38,7 +38,7 @@ class WolvicWebExtensionRuntime(
             val activeSession = SessionStore.get().activeSession
             val session: Session = SessionStore.get().createWebExtensionSession(activeSession.isPrivateMode);
             session.setParentSession(activeSession)
-            session.uaMode = WSessionSettings.USER_AGENT_MODE_DESKTOP
+            session.setUaMode(WSessionSettings.USER_AGENT_MODE_DESKTOP, true)
             val engineSession = WolvicEngineSession(session)
             (context as WidgetManagerDelegate).windows.onTabSelect(session)
             return webExtensionDelegate?.onToggleActionPopup(extension, engineSession, action)

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -53,6 +53,8 @@ import com.igalia.wolvic.utils.InternalPages;
 import com.igalia.wolvic.utils.SystemUtils;
 import com.igalia.wolvic.utils.UrlUtils;
 
+import org.mozilla.geckoview.GeckoSession;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -72,7 +74,10 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     private static UriOverride sUserAgentOverride;
     private static UriOverride sDesktopModeOverrides;
     private static final long KEEP_ALIVE_DURATION_MS = 1000; // 1 second.
-    private static final String DEFAULT_USER_AGENT = "Mozilla/5.0 (Android 10; Mobile VR; rv:105.0) Gecko/105.0 Wolvic/" + BuildConfig.VERSION_NAME;
+
+    // The difference between "Mobile" and "VR" matches GeckoViewSettings.jsm
+    private static final String WOLVIC_USER_AGENT_MOBILE = GeckoSession.getDefaultUserAgent() + " Wolvic/" + BuildConfig.VERSION_NAME;
+    private static final String WOLVIC_USER_AGENT_VR = WOLVIC_USER_AGENT_MOBILE.replace("Mobile", "Mobile VR");
 
     private transient CopyOnWriteArrayList<WSession.NavigationDelegate> mNavigationListeners;
     private transient CopyOnWriteArrayList<WSession.ProgressDelegate> mProgressListeners;
@@ -190,11 +195,8 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         mDrmStateStateListeners = new CopyOnWriteArrayList<>();
         mMedia = new Media();
 
-        if (mPrefs != null) {
-            mPrefs.registerOnSharedPreferenceChangeListener(this);
-        }
-
         mPrefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        mPrefs.registerOnSharedPreferenceChangeListener(this);
 
         InternalPages.PageResources pageResources = InternalPages.PageResources.create(R.raw.private_mode, R.raw.private_style);
         mPrivatePage = InternalPages.createAboutPage(mContext, pageResources);
@@ -1022,8 +1024,13 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         return true;
     }
 
-    public void setUaMode(int mode) {
+    public void setUaMode(int mode, boolean reload) {
+        // the UA mode value did not change
         if (!trySetUaMode(mode))
+            return;
+
+        // the value did change, but we don't need to force a reload
+        if (!reload)
             return;
 
         String overrideUri = mode == WSessionSettings.USER_AGENT_MODE_DESKTOP ? checkForMobileSite(mState.mUri) : null;
@@ -1136,14 +1143,11 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
             String userAgentOverride = sUserAgentOverride.lookupOverride(uri);
 
-            // Here we set a default user agent if no override was found, BUT
-            // only if UA Mode is not Desktop, because the UA override
-            // takes precedence over mode overrides so if we set it, it will
-            // invalidate desktop mode UA. For VR and Mobile modes we don't change
-            // the UA so they are not affected.
-            if (mState.mSettings.getUserAgentMode() != WSessionSettings.USER_AGENT_MODE_DESKTOP &&
-                    userAgentOverride == null) {
-                userAgentOverride = DEFAULT_USER_AGENT;
+            // Set the User-Agent according to the current UA settings
+            // unless we are in Desktop mode, which uses its own User-Agent value.
+            int mode = mState.mSettings.getUserAgentMode();
+            if (mode != WSessionSettings.USER_AGENT_MODE_DESKTOP && userAgentOverride == null) {
+                userAgentOverride = (mode == WSessionSettings.USER_AGENT_MODE_MOBILE) ? WOLVIC_USER_AGENT_MOBILE : WOLVIC_USER_AGENT_VR;
             }
 
             aSession.getSettings().setUserAgentOverride(userAgentOverride);
@@ -1727,12 +1731,17 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (mContext != null) {
-            if (key.equals(mContext.getString(R.string.settings_key_geolocation_data))) {
-                GeolocationData data = GeolocationData.parse(sharedPreferences.getString(key, null));
-                if (data != null) {
-                    setRegion(data.getCountryCode());
-                }
+        if (mContext == null)
+            return;
+
+        if (key.equals(mContext.getString(R.string.settings_key_geolocation_data))) {
+            GeolocationData data = GeolocationData.parse(sharedPreferences.getString(key, null));
+            if (data != null) {
+                setRegion(data.getCountryCode());
+            }
+        } else if (key.equals(mContext.getString(R.string.settings_key_user_agent_version))) {
+            if (mState.mSettings.getUserAgentMode() != WSessionSettings.USER_AGENT_MODE_DESKTOP) {
+                setUaMode(SettingsStore.getInstance(mContext).getUaMode(), false);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -23,7 +23,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
-import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.Media;
 import com.igalia.wolvic.browser.SessionChangeListener;
@@ -53,8 +52,6 @@ import com.igalia.wolvic.utils.InternalPages;
 import com.igalia.wolvic.utils.SystemUtils;
 import com.igalia.wolvic.utils.UrlUtils;
 
-import org.mozilla.geckoview.GeckoSession;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -74,10 +71,6 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     private static UriOverride sUserAgentOverride;
     private static UriOverride sDesktopModeOverrides;
     private static final long KEEP_ALIVE_DURATION_MS = 1000; // 1 second.
-
-    // The difference between "Mobile" and "VR" matches GeckoViewSettings.jsm
-    private static final String WOLVIC_USER_AGENT_MOBILE = GeckoSession.getDefaultUserAgent() + " Wolvic/" + BuildConfig.VERSION_NAME;
-    private static final String WOLVIC_USER_AGENT_VR = WOLVIC_USER_AGENT_MOBILE.replace("Mobile", "Mobile VR");
 
     private transient CopyOnWriteArrayList<WSession.NavigationDelegate> mNavigationListeners;
     private transient CopyOnWriteArrayList<WSession.ProgressDelegate> mProgressListeners;
@@ -1146,8 +1139,8 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
             // Set the User-Agent according to the current UA settings
             // unless we are in Desktop mode, which uses its own User-Agent value.
             int mode = mState.mSettings.getUserAgentMode();
-            if (mode != WSessionSettings.USER_AGENT_MODE_DESKTOP && userAgentOverride == null) {
-                userAgentOverride = (mode == WSessionSettings.USER_AGENT_MODE_MOBILE) ? WOLVIC_USER_AGENT_MOBILE : WOLVIC_USER_AGENT_VR;
+            if (userAgentOverride == null) {
+                userAgentOverride = mState.mSession.getDefaultUserAgent(mode);
             }
 
             aSession.getSettings().setUserAgentOverride(userAgentOverride);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1229,11 +1229,11 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
                 if (uaMode == WSessionSettings.USER_AGENT_MODE_DESKTOP) {
                     final int defaultUaMode = SettingsStore.getInstance(mAppContext).getUaMode();
                     mHamburgerMenu.setUAMode(defaultUaMode);
-                    mAttachedWindow.getSession().setUaMode(defaultUaMode);
+                    mAttachedWindow.getSession().setUaMode(defaultUaMode, true);
 
                 } else {
                     mHamburgerMenu.setUAMode(WSessionSettings.USER_AGENT_MODE_DESKTOP);
-                    mAttachedWindow.getSession().setUaMode(WSessionSettings.USER_AGENT_MODE_DESKTOP);
+                    mAttachedWindow.getSession().setUaMode(WSessionSettings.USER_AGENT_MODE_DESKTOP, true);
                 }
 
                 hideMenu();


### PR DESCRIPTION
Our User-Agent will be the one returned by default by GeckoView, plus "Wolvic/" and its version.

This is a compromise between compatibility and visibility: sites that are aware of Wolvic will be able to detect it, whereas the rest will be able to identify us as a GeckoView browser.

The Session object is updated when the "User-Agent mode" setting changes. Note that the page will not always be automatically reloaded, so we can prevent reloading all tabs when the user changes this value in the Settings dialog.