### PR TITLE
[OpenXR] Set the proper eye on UI layers

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -917,6 +917,9 @@ DeviceDelegateOpenXR::BindEye(const device::Eye aWhich) {
   VRB_GL_CHECK(glViewport(0, 0, m.boundSwapChain->Width(), m.boundSwapChain->Height()));
   VRB_GL_CHECK(glClearColor(m.clearColor.Red(), m.clearColor.Green(), m.clearColor.Blue(), m.clearColor.Alpha()));
   VRB_GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+
+  for (const auto& layer: m.uiLayers)
+    layer->SetCurrentEye(aWhich);
 }
 
 void


### PR DESCRIPTION
3D side by side (SBS) videos are displayed by rendering half of a full video texture to each eye.
 Each half is slisght shifted apart, creating an stereoscopic effect. The problem was that when 
exiting a 3D SBS, the browser window was totally missplaced.

The problem was that the model transform was only applied to the right eye but not to the left 
one. Model transforms in layers are set in VRLayerNode::Draw() (called on frame end). That
method sets the transformation on the layer for the currently selected eye. That's the key, 
VRVideos set the current eye of a layer alternatively, first the left and then the right. This means
that when exiting the video the current eye in the layer is the right one. However the transformation 
was set on the left one (because for the "normal" browser window we just need to paint the same
texture to both eyes, i.e. the left one). So, the code was correctly updating the transformation of 
the layer (meaning that we're properly repositioning the browser window after exiting the 3D SBS
video) but on the wrong eye (we're updating the right eye which was not used). That's why the
window was fixed in the position where the full screen browser window was set to view the SBS video.

The solution is to set the current eye on each layer in the call to DeviceDelegateOpenXR::BindEye()
as we do in the OculusVR backend.