### PR TITLE
[OpenXR] Use a quad layer to render the keyboard

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -35,6 +35,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.engine.Session;
@@ -390,7 +391,8 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         aPlacement.rotation = (float)Math.toRadians(WidgetPlacement.floatDimension(context, R.dimen.keyboard_world_rotation));
         aPlacement.worldWidth = WidgetPlacement.floatDimension(context, R.dimen.keyboard_world_width);
         aPlacement.visible = false;
-        aPlacement.cylinder = true;
+        // FIXME: keyboard is misplaced when rendered in a cylinder layer.
+        aPlacement.cylinder = !((VRBrowserActivity) getContext()).areLayersEnabled();
         aPlacement.layerPriority = 1;
     }
 


### PR DESCRIPTION
With OpenXR the keyboard is totally misplaced when rendered using a cylinder layer, 
for example when there are multiple opened windows or when the curved mode is 
enabled. The fix is not obvious so let's use a quad layer for the 1.3 release and fix it later.