### PR TITLE
Correct Web app name in install dialog

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/InstallWebAppDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/InstallWebAppDialogWidget.java
@@ -39,10 +39,12 @@ public class InstallWebAppDialogWidget extends PromptDialogWidget {
             return;
         }
 
-        if (StringUtils.isEmpty(mWebApp.getName())) {
-            setTitle(R.string.web_apps_dialog_title);
-        } else {
+        if (!StringUtils.isEmpty(mWebApp.getShortName())) {
             setTitle(getContext().getString(R.string.web_apps_dialog_title_parameter, mWebApp.getShortName()));
+        } else if (!StringUtils.isEmpty(mWebApp.getName())) {
+            setTitle(getContext().getString(R.string.web_apps_dialog_title_parameter, mWebApp.getName()));
+        } else {
+            setTitle(R.string.web_apps_dialog_title);
         }
 
         SessionStore.get().getBrowserIcons().loadIntoView(mBinding.icon,


### PR DESCRIPTION
Most websites provide both a name and a short name in their manifest, but some of them (e.g. openstreetmap.org) only provide a name.

In the installation dialog, if the "short_name" value is not available, we will use the "name" value.