### PR TITLE
[Meta] Adjust controller positions

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -888,6 +888,10 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
     vrb::Vector offsets = vrb::Vector::Zero();
 #if defined(HVR)
     offsets.y() = -m.firstPose->position.y;
+#elif defined(OCULUSVR)
+    offsets.x() = -0.025;
+    offsets.y() = -0.05;
+    offsets.z() = 0.05;
 #endif
     m.input->Update(frameState, m.localSpace, head, offsets, m.renderMode, *m.controller);
   }

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -885,12 +885,11 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
 
   // Update controllers
   if (m.input && m.controller) {
+    vrb::Vector offsets = vrb::Vector::Zero();
 #if defined(HVR)
-    float offsetY = -m.firstPose->position.y;
-#else
-    float offsetY = 0;
+    offsets.y() = -m.firstPose->position.y;
 #endif
-    m.input->Update(frameState, m.localSpace, head, offsetY, m.renderMode, *m.controller);
+    m.input->Update(frameState, m.localSpace, head, offsets, m.renderMode, *m.controller);
   }
 }
 

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -65,7 +65,7 @@ XrResult OpenXRInput::Initialize(ControllerDelegate& delegate)
   return XR_SUCCESS;
 }
 
-XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, float offsetY, device::RenderMode renderMode, ControllerDelegate& delegate)
+XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, ControllerDelegate& delegate)
 {
   XrActiveActionSet activeActionSet {
     mActionSet->ActionSet(), XR_NULL_PATH
@@ -77,7 +77,7 @@ XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, 
   RETURN_IF_XR_FAILED(xrSyncActions(mSession, &syncInfo));
 
   for (auto& input : mInputSources) {
-    input->Update(frameState, baseSpace, head, offsetY, renderMode, delegate);
+    input->Update(frameState, baseSpace, head, offsets, renderMode, delegate);
   }
 
   return XR_SUCCESS;

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -33,7 +33,7 @@ private:
 public:
   static OpenXRInputPtr Create(XrInstance, XrSession, XrSystemProperties, ControllerDelegate& delegate);
   XrResult Initialize(ControllerDelegate& delegate);
-  XrResult Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, float offsetY, device::RenderMode renderMode, ControllerDelegate& delegate);
+  XrResult Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, ControllerDelegate& delegate);
   int32_t GetControllerModelCount() const;
   std::string GetControllerModelName(const int32_t aModelIndex) const;
   void UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -677,7 +677,8 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
       return;
     }
 
-    // Adjust to local is app is using stageSpace (e.g. HVR), otherwise offset will be 0.
+    // HVR: adjust to local if app is using stageSpace.
+    // Meta: adjust the position of the controllers which is not totally accurate.
     auto adjustPoseLocation = [&poseLocation](const vrb::Vector& offset) {
         poseLocation.pose.position.x += offset.x();
         poseLocation.pose.position.y += offset.y();

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -97,7 +97,7 @@ public:
 
     XrResult SuggestBindings(SuggestedBindings&) const;
     void EmulateControllerFromHand(device::RenderMode renderMode, ControllerDelegate& delegate);
-    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, float offsetY, device::RenderMode, ControllerDelegate& delegate);
+    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, ControllerDelegate& delegate);
     XrResult UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }


### PR DESCRIPTION
The positions of the controllers in the Meta flavour are not 100% accurate as there is a slight shift 
between their positions as rendered by Wolvic and the positions when rendered by the system. It 
can be seen when clicking on the Oculus button on the right controller.

This PR does some slight manual adjustments so we get a more accurate positioning.