### PR TITLE
Fix a crash when swapping the position of two windows

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -98,7 +98,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Hashtable;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
@@ -205,7 +205,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private float mCurrentCylinderDensity = 0;
     private boolean mHideWebXRIntersitial = false;
     private FragmentController mFragmentController;
-    private Hashtable<Integer, WidgetPlacement> mPendingNativeWidgetUpdates = new Hashtable<>();
+    private LinkedHashMap<Integer, WidgetPlacement> mPendingNativeWidgetUpdates = new LinkedHashMap<>();
     private ScheduledThreadPoolExecutor mPendingNativeWidgetUpdatesExecutor = new ScheduledThreadPoolExecutor(1);
     private ScheduledFuture<?> mNativeWidgetUpdatesTask = null;
 


### PR DESCRIPTION
Each widget in Wolvic is identified by a handle (integer). Each widget keeps track 
of the handle of its parent. The front window is special in Wolvic because it's the 
one whose parent is -1 (no parent). The right and left windows have the front window
 as its parent.

Moving the front window to the left/right (using the top bar) actually means exchanging 
the position with another window. This means that the handles of the parents will swap 
too. So the window on the side will become orphan (no parent, i.e., parent handle == -1)
and the front window will have the side window as new parent.

It's critical to do this switch in this exact order because otherwise we could end up having 
a cycle. For example if we first change the parent of the front window, at that point, the 
front window will have the side window as parent, and the side window will have the 
front window as parent. This cycle will create an "infinite" recursion in
BrowserWorld::UpdateWidgetRecursive().

This hasn't been a problem because from the Java side we were properly queueing those 
updates in the right order. However after eeb730cc6, those updates were not happening 
in order because we were enqueuing them by iterating a Hashtable, which in Java, does 
not guarantee to return the elements in the same order as they were inserted. By switching 
to a LinkedHashMap we could achieve the same results while keeping the updates of 
widgets in batches.