### PR TITLE
Simplify permissions for Oculus

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -8,6 +8,14 @@
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 
+    <!-- Not needed in Android 10 (API >= 29) -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
+
+    <!-- Requested by GeckoView but not needed in VR -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
+
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -12,6 +12,14 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" tools:node="remove"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove"/>
 
+    <!-- Not needed in Android 10 (API >= 29) -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
+
+    <!-- Requested by GeckoView but not needed in VR -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
+
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 


### PR DESCRIPTION
This change removes four permissions from our Oculus builds.

READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE are not needed in Android 10.

WAKE_LOCK and FOREGROUND_SERVICE are requested by GeckoView but they are not needed in VR.

https://github.com/Igalia/gecko-dev/pull/4 will take care that this does not cause any crashes in Gecko.