### PR TITLE
[l10n] Update translations to Danish

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -506,7 +506,7 @@
     <string name="fxa_account_options_syncing">Synkroniserer...</string>
     <!-- This string is used in the FxA account manager panel as a header for the sync options for syncing
          history, bookmarks, passwords, etc. -->
-    <string name="fxa_account_options_sync_description">Vælg hvad du vil synkronisere på dine enheder med Wolvic </string>
+    <string name="fxa_account_options_sync_description">Vælg hvad du vil synkronisere på dine enheder med Firefox Sync</string>
     <!-- This string is used to in the FxA account manage panel as a description for the Bookmarks sync switch. -->
     <string name="fxa_account_options_bookmarks_sync">Bogmærker</string>
     <!-- This string is used to in the FxA account manage panel as a description for the History sync switch. -->
@@ -1625,4 +1625,35 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="settings_language_galician">Galicisk</string>
     <string name="permissions_dialog_remember_choice">Husk denne beslutning</string>
     <string name="settings_language_portuguese_br">Portugisisk (Brasilien)</string>
+    <string name="hamburger_menu_save_web_app">Gem webapp…</string>
+    <string name="web_apps_loading">Indlæsning af webapps</string>
+    <string name="download_context_copy_to_content_uri">Del med andre apps</string>
+    <string name="download_copy_to_content_uri_error_body_v1">Der opstod en fejl under kopiering af %1$s</string>
+    <string name="upload_button">Upload</string>
+    <string name="addons_experimental_section_title">Eksperimentelt</string>
+    <string name="web_apps_title">Web apps</string>
+    <string name="web_apps_description">Klik på knappen Gem webapp... når du er på en side for at tilføje den til dine webapps.</string>
+    <string name="web_apps_empty">Din webappliste er tom</string>
+    <string name="web_apps_dialog_title">Installer webapp</string>
+    <string name="web_apps_dialog_title_parameter">Installer %1$s</string>
+    <string name="web_apps_dialog_body">Vil du installere følgende webapp\? Den vil være tilgængelig i Apps-biblioteket.</string>
+    <string name="web_apps_dialog_install">Installer</string>
+    <string name="web_apps_dialog_cancel">Annuller</string>
+    <string name="web_apps_saved_notification">Web-app tilføjet!</string>
+    <string name="download_addon_install">Installer Addon</string>
+    <string name="download_addon_install_cancel">Annuller</string>
+    <string name="download_addon_install_confirm_install">Installer</string>
+    <string name="download_addon_install_blocked">Lokal addon-installation blokeret</string>
+    <string name="download_addon_install_blocked_body">Tillad lokal addon-installation i Udviklingsindstillinger for at fortsætte.</string>
+    <string name="download_copy_to_content_uri_confirm_title">Vil du kopiere filen\?</string>
+    <string name="download_copy_to_content_uri_confirm_body">Dette vil oprette en kopi af denne fil i systemets downloads-mappe, hvor den kan tilgås af andre apps.
+\n
+\nVil du fortsætte\?</string>
+    <string name="download_copy_to_content_uri_success_title">Kopieret med succes</string>
+    <string name="download_copy_to_content_uri_success_body">Filen blev kopieret med succes og er tilgængelig i systemets Downloads.</string>
+    <string name="download_copy_to_content_uri_error_title">Kopieringsfejl</string>
+    <string name="download_copy_to_content_uri_error_body">Der opstod en fejl under kopiering af den downloadede fil.</string>
+    <string name="notifications_loading">Indlæsning af notifikationer</string>
+    <string name="notifications_empty">Din notifikationsliste er tom</string>
+    <string name="notifications_title">Notifikationer</string>
 </resources>


### PR DESCRIPTION
Via Weblate, currently translated at 99.2% (627 of 632 strings).