### PR TITLE
Handle Back button on Phone mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -278,8 +278,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         registerReceiver(mCrashReceiver, intentFilter, BuildConfig.APPLICATION_ID + "." + getString(R.string.app_permission_name), null);
 
         mLastGesture = NoGesture;
-        super.onCreate(savedInstanceState);
-
         mWidgetUpdateListeners = new LinkedList<>();
         mPermissionListeners = new LinkedList<>();
         mFocusChangeListeners = new LinkedList<>();
@@ -288,10 +286,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mBackHandlers = new LinkedList<>();
         mBrightnessQueue = new LinkedList<>();
         mCurrentBrightness = Pair.create(null, 1.0f);
-
         mWidgets = new ConcurrentHashMap<>();
-        mWidgetContainer = new FrameLayout(this);
 
+        super.onCreate(savedInstanceState);
+
+        mWidgetContainer = new FrameLayout(this);
         runtime.setFragmentManager(mFragmentController.getSupportFragmentManager(), mWidgetContainer);
 
         mPermissionDelegate = new PermissionDelegate(this, this);

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -46,7 +46,7 @@ import org.json.JSONObject;
 
 import java.util.Calendar;
 
-public class PlatformActivity extends Activity implements SurfaceHolder.Callback {
+public abstract class PlatformActivity extends Activity implements SurfaceHolder.Callback, WidgetManagerDelegate {
     public static final String TAG = "PlatformActivity";
     private SurfaceView mView;
     private Context mContext = null;
@@ -54,6 +54,7 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
     private Dialog mActiveDialog;
     private SharedPreferences mPrefs;
     private BroadcastReceiver mHmsMessageBroadcastReceiver;
+    private Runnable mPhoneBackHandler = super::onBackPressed;
 
     static {
         Log.i(TAG, "LoadLibrary");
@@ -214,6 +215,7 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
             @Override
             public void onDisplayAdded(int displayId) {
                 // create the activity again, so the theme is set up properly
+                popBackHandler(mPhoneBackHandler);
                 recreate();
             }
 
@@ -229,6 +231,7 @@ public class PlatformActivity extends Activity implements SurfaceHolder.Callback
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         setTheme(R.style.Theme_WolvicPhone);
         setContentView(R.layout.activity_main);
+        pushBackHandler(mPhoneBackHandler);
     }
 
     private void initializeVR() {


### PR DESCRIPTION
Wolvic's phone UI was not handling the Back button properly, because of some code in VRBrowserActivity which assumed a VR environment. The solution is to register a Back button handler specifically for the phone mode which simply calls Android's usual behaviour.