### PR TITLE
Message when the "Upload file" dialog is empty

### DIFF
--- a/app/src/main/res/layout/prompt_file.xml
+++ b/app/src/main/res/layout/prompt_file.xml
@@ -1,95 +1,131 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/layout"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@drawable/prompt_background"
-    android:orientation="vertical">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/promptTitle"
+    <data>
+
+        <variable
+            name="isEmpty"
+            type="boolean" />
+    </data>
+
+    <LinearLayout
+        android:id="@+id/layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="10dp"
-        android:layout_marginEnd="20dp"
-        android:layout_marginBottom="10dp"
-        android:ellipsize="end"
-        android:gravity="center_horizontal"
-        android:lines="1"
-        android:maxLines="2"
-        android:minLines="1"
-        android:textColor="@color/fog"
-        android:textSize="@dimen/text_bigger_size"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Title" />
+        android:background="@drawable/prompt_background"
+        android:orientation="vertical">
 
-    <com.igalia.wolvic.ui.views.CustomRecyclerView
-        android:id="@+id/filesList"
-        style="@style/customRecyclerViewStyle"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="10dp"
-        android:layout_marginEnd="20dp"
-        android:layout_weight="100"
-        android:fadingEdgeLength="60dp"
-        android:maxHeight="@dimen/prompt_content_max_height"
-        android:minHeight="400dp"
-        android:overScrollMode="never"
-        android:requiresFadingEdge="vertical"
-        android:smoothScrollbar="true"
-        app:layoutManager="com.igalia.wolvic.ui.adapters.CustomLinearLayoutManager" />
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/buttonsLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:layout_marginEnd="20dp"
-        android:layout_marginStart="20dp"
-        android:layout_marginBottom="20dp"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/bodyContainer">
-
-
-        <Button
-            android:id="@+id/negativeButton"
-            android:layout_width="wrap_content"
+        <TextView
+            android:id="@+id/promptTitle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="10dp"
-            android:background="@drawable/dialog_regular_button_background"
-            android:fontFamily="sans-serif"
-            android:minWidth="120dp"
-            android:padding="10dp"
-            android:scaleType="fitCenter"
-            android:text="@string/cancel_button"
-            android:textColor="@drawable/prompt_button_text_color"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toStartOf="@+id/positiveButton"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <Button
-            android:id="@+id/positiveButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/dialog_highlighted_button_background"
-            android:fontFamily="sans-serif"
-            android:minWidth="120dp"
-            android:padding="10dp"
-            android:scaleType="fitCenter"
-            android:text="@string/upload_button"
-            android:textColor="@drawable/prompt_button_text_color"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="10dp"
+            android:ellipsize="end"
+            android:gravity="center_horizontal"
+            android:lines="1"
+            android:maxLines="2"
+            android:minLines="1"
+            android:textColor="@color/fog"
+            android:textSize="@dimen/text_bigger_size"
             android:textStyle="bold"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Title" />
 
-</LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="20dp"
+            android:layout_weight="100"
+            android:gravity="center_vertical|center_horizontal"
+            android:maxHeight="@dimen/prompt_content_max_height"
+            android:minHeight="400dp"
+            android:orientation="vertical"
+            app:visibleGone="@{isEmpty}">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="35dp"
+                android:fontFamily="sans-serif"
+                android:text="@string/upload_list_empty"
+                android:textAlignment="center"
+                android:textAllCaps="false"
+                android:textColor="@color/fog"
+                android:textSize="@dimen/text_biggest_size"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <com.igalia.wolvic.ui.views.CustomRecyclerView
+            android:id="@+id/filesList"
+            style="@style/customRecyclerViewStyle"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="20dp"
+            android:layout_weight="100"
+            android:fadingEdgeLength="60dp"
+            android:maxHeight="@dimen/prompt_content_max_height"
+            android:minHeight="400dp"
+            android:overScrollMode="never"
+            android:requiresFadingEdge="vertical"
+            android:smoothScrollbar="true"
+            app:layoutManager="com.igalia.wolvic.ui.adapters.CustomLinearLayoutManager"
+            app:visibleGone="@{!isEmpty}" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/buttonsLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="20dp"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bodyContainer">
+
+            <Button
+                android:id="@+id/negativeButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:background="@drawable/dialog_regular_button_background"
+                android:fontFamily="sans-serif"
+                android:minWidth="120dp"
+                android:padding="10dp"
+                android:scaleType="fitCenter"
+                android:text="@string/cancel_button"
+                android:textColor="@drawable/prompt_button_text_color"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toStartOf="@+id/positiveButton"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/positiveButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/dialog_highlighted_button_background"
+                android:fontFamily="sans-serif"
+                android:minWidth="120dp"
+                android:padding="10dp"
+                android:scaleType="fitCenter"
+                android:text="@string/upload_button"
+                android:textColor="@drawable/prompt_button_text_color"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1745,6 +1745,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="addons_experimental_section_title">Experimental</string>
     <string name="download_addon_install_blocked">La instalación del complemento ha sido bloqueada</string>
     <string name="upload_button">Enviar</string>
+    <string name="upload_list_empty">No hay archivos disponibles para enviar</string>
     <string name="web_apps_title">Aplicaciones web</string>
     <string name="web_apps_dialog_body">¿Quieres instalar la siguiente aplicación web\? Estará disponible en tu biblioteca.</string>
     <string name="web_apps_description">Pulsa el botón Guardar aplicación web... cuando estés en una página para añadirla a tus aplicaciones web.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1726,6 +1726,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="notifications_title">Notifications</string>
     <string name="notifications_loading">Chargement des notifications</string>
     <string name="upload_button">Télécharger</string>
+    <string name="upload_list_empty">Aucun fichier disponible pour téléchargement</string>
     <string name="web_apps_title">Applications Web</string>
     <string name="web_apps_description">Cliquez sur le bouton Enregistrer L\'application Web quand vous êtes sur une page afin de l\'ajouter à vos applications web.</string>
     <string name="web_apps_empty">Votre liste d\'Applications Web est vide</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -732,5 +732,6 @@
     <string name="download_addon_install">Instalar engadido</string>
     <string name="download_addon_install_blocked">A instalación do engadido local foi bloqueada</string>
     <string name="upload_button">Enviar</string>
+    <string name="upload_list_empty">Non hai arquivos dispoñibles para enviar</string>
     <string name="settings_language_portuguese">Portugués</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1640,6 +1640,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_copy_to_content_uri_error_body_v1">%1$sをコピー中にエラーが発生しました</string>
     <string name="voice_service_metkai"></string>
     <string name="upload_button">アップロード</string>
+    <string name="upload_list_empty">プロードできるファイルがありません</string>
     <string name="addons_experimental_section_title">実験的</string>
     <string name="notifications_loading">通知を読み込んでいます</string>
     <string name="web_apps_title">ウェブアプリ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -719,6 +719,7 @@
     <string name="download_copy_to_content_uri_error_body_v1">Ocorreu um erro ao copiar %1$s</string>
     <string name="download_addon_install_confirm_install">Instalar</string>
     <string name="upload_button">Carregar</string>
+    <string name="upload_list_empty">Não há arquivos disponíveis para carregar</string>
     <string name="web_apps_dialog_title_parameter">Instalar %1$s</string>
     <string name="web_apps_dialog_cancel">Cancelar</string>
     <string name="web_apps_dialog_install">Instalar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -702,6 +702,7 @@
     <string name="settings_language_korean">Coreano</string>
     <string name="settings_language_italian">Italiano</string>
     <string name="upload_button">Carregar</string>
+    <string name="upload_list_empty">Não há arquivos disponíveis para carregar</string>
     <string name="web_apps_loading">A carregar Aplicações Web</string>
     <string name="web_apps_dialog_title">Instalar Aplicações Web</string>
     <string name="web_apps_dialog_title_parameter">Instalar %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -920,6 +920,9 @@
          This appears in such contexts as dialog boxes, `<select>` menus, etc. -->
     <string name="upload_button">Upload</string>
 
+    <!-- This string is used when the list of files that can be uploaded is empty. -->
+    <string name="upload_list_empty">No files available for upload</string>
+
     <!-- This string labels a button that is used to approve an action. -->
     <string name="back_button">Back</string>
 


### PR DESCRIPTION
Add a message that will be displayed when the list of files to upload is empty.

The message is "No files available for upload".

This situation can happen because the user has not downloaded anything yet,
or because the `<input>` element is using a filter that excludes all of the existing files.