### PR TITLE
Remove WAKE_LOCK and FOREGROUND_SERVICE permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.igalia.wolvic">
     <uses-feature android:glEsVersion="0x00030000"/>
 
@@ -13,6 +14,10 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+
+    <!-- Requested by GeckoView but not needed in VR -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
 
     <permission android:name="${applicationId}.CRASH_RECEIVER_PERMISSION"
                 android:protectionLevel="signature"/>

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -12,10 +12,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
 
-    <!-- Requested by GeckoView but not needed in VR -->
-    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
-
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -16,10 +16,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
 
-    <!-- Requested by GeckoView but not needed in VR -->
-    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
-
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 


### PR DESCRIPTION
WAKE_LOCK and FOREGROUND_SERVICE are two permissions requested by GeckoView which are not really needed in VR environments.

Note that by default GeckoView expects these permissions to be available, even if they are not actually going to be needed.

PR https://github.com/Igalia/gecko-dev/pull/4 prevents any crashes when these permissions are not available.