### PR TITLE
[OpenXR] Recenter view in X-Y axis

### DIFF
--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -24,7 +24,7 @@ typedef std::shared_ptr<WidgetPlacement> WidgetPlacementPtr;
 class Widget;
 typedef std::shared_ptr<Widget> WidgetPtr;
 
-class BrowserWorld {
+class BrowserWorld : public DeviceDelegate::ReorientClient {
 public:
   static BrowserWorld& Instance();
   static void Destroy();
@@ -74,6 +74,7 @@ public:
   void SetIsServo(const bool aIsServo);
   void SetCPULevel(const device::CPULevel aLevel);
   JNIEnv* GetJNIEnv() const;
+  void OnReorient() override;
 #if HVR
   bool WasButtonAppPressed();
 #endif

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -100,12 +100,20 @@ public:
   virtual void OnControllersReady(const std::function<void()>& callback) {
     callback();
   }
+  class ReorientClient {
+  public:
+    virtual void OnReorient() = 0;
+    virtual ~ReorientClient() {};
+  };
+  void SetReorientClient(ReorientClient* client) { mReorientClient = client; }
+
 protected:
   DeviceDelegate() {}
 
   virtual ~DeviceDelegate() {}
 
   bool mShouldRender { false };
+  ReorientClient* mReorientClient { nullptr };
 private:
   VRB_NO_DEFAULTS(DeviceDelegate)
 };

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -180,7 +180,7 @@ struct Widget::State {
     auto setCylinderLayerTransformIfNeeded = [&](const vrb::Matrix& rotation) {
         if (!hasCylinderLayer)
           return;
-        cylinder->GetLayer()->SetRotation(uiYaw ? rotation.PostMultiply(*uiYaw) : rotation);
+        cylinder->GetLayer()->SetRotation(uiYaw ? rotation.PreMultiply(*uiYaw) : rotation);
     };
 
     if (x != 0.0f && placement->cylinderMapRadius > 0) {

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -899,6 +899,8 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
   }
 
   if (reoriented && m.renderMode == device::RenderMode::StandAlone) {
+      if (mReorientClient)
+          mReorientClient->OnReorient();
       m.reorientMatrix = DeviceUtils::CalculateReorientationMatrix(head, kAverageHeight);
   }
 }


### PR DESCRIPTION
OpenXR does not generally give us access to input/system, the button which after a long press
is generally used to recenter the view. That's why we use a significant change in the orientation
of the head between two consecutive frames to detect recenterings. Moving the head, even fast
enough, does not cause the abrupt changes we try to detect.

This should allow users to recenter the view in the 3D space, allowing use cases like watching
a movie looking upwards while lying down.

Fixes #484,  