### PR TITLE
[OpenXR] Implement performance related settings

### DIFF
--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -10,6 +10,7 @@ PFN_xrCreateHandTrackerEXT OpenXRExtensions::sXrCreateHandTrackerEXT = nullptr;
 PFN_xrDestroyHandTrackerEXT OpenXRExtensions::sXrDestroyHandTrackerEXT = nullptr;
 PFN_xrLocateHandJointsEXT OpenXRExtensions::sXrLocateHandJointsEXT = nullptr;
 PFN_xrGetHandMeshFB OpenXRExtensions::sXrGetHandMeshFB = nullptr;
+PFN_xrPerfSettingsSetPerformanceLevelEXT OpenXRExtensions::sXrPerfSettingsSetPerformanceLevelEXT = nullptr;
 
 void OpenXRExtensions::Initialize() {
     uint32_t extensionCount { 0 };
@@ -34,6 +35,12 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
       CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreateSwapchainAndroidSurfaceKHR",
                                         reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreateSwapchainAndroidSurfaceKHR)));
   }
+
+  if (IsExtensionSupported(XR_EXT_PERFORMANCE_SETTINGS_EXTENSION_NAME)) {
+      CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrPerfSettingsSetPerformanceLevelEXT",
+                                        reinterpret_cast<PFN_xrVoidFunction*>(&sXrPerfSettingsSetPerformanceLevelEXT)));
+  }
+
     if (IsExtensionSupported(XR_EXT_HAND_TRACKING_EXTENSION_NAME)) {
         CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreateHandTrackerEXT",
                                         reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreateHandTrackerEXT)));

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -11,6 +11,8 @@ PFN_xrDestroyHandTrackerEXT OpenXRExtensions::sXrDestroyHandTrackerEXT = nullptr
 PFN_xrLocateHandJointsEXT OpenXRExtensions::sXrLocateHandJointsEXT = nullptr;
 PFN_xrGetHandMeshFB OpenXRExtensions::sXrGetHandMeshFB = nullptr;
 PFN_xrPerfSettingsSetPerformanceLevelEXT OpenXRExtensions::sXrPerfSettingsSetPerformanceLevelEXT = nullptr;
+PFN_xrEnumerateDisplayRefreshRatesFB OpenXRExtensions::sXrEnumerateDisplayRefreshRatesFB = nullptr;
+PFN_xrRequestDisplayRefreshRateFB OpenXRExtensions::sXrRequestDisplayRefreshRateFB = nullptr;
 
 void OpenXRExtensions::Initialize() {
     uint32_t extensionCount { 0 };
@@ -39,6 +41,13 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
   if (IsExtensionSupported(XR_EXT_PERFORMANCE_SETTINGS_EXTENSION_NAME)) {
       CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrPerfSettingsSetPerformanceLevelEXT",
                                         reinterpret_cast<PFN_xrVoidFunction*>(&sXrPerfSettingsSetPerformanceLevelEXT)));
+  }
+
+  if (IsExtensionSupported(XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME)) {
+      CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrEnumerateDisplayRefreshRatesFB",
+                                        reinterpret_cast<PFN_xrVoidFunction*>(&sXrEnumerateDisplayRefreshRatesFB)));
+      CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrRequestDisplayRefreshRateFB",
+                                        reinterpret_cast<PFN_xrVoidFunction*>(&sXrRequestDisplayRefreshRateFB)));
   }
 
     if (IsExtensionSupported(XR_EXT_HAND_TRACKING_EXTENSION_NAME)) {

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -23,6 +23,8 @@ namespace crow {
     static PFN_xrDestroyHandTrackerEXT sXrDestroyHandTrackerEXT;
     static PFN_xrLocateHandJointsEXT sXrLocateHandJointsEXT;
     static PFN_xrGetHandMeshFB sXrGetHandMeshFB;
+
+    static PFN_xrPerfSettingsSetPerformanceLevelEXT sXrPerfSettingsSetPerformanceLevelEXT;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
   };

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -25,6 +25,8 @@ namespace crow {
     static PFN_xrGetHandMeshFB sXrGetHandMeshFB;
 
     static PFN_xrPerfSettingsSetPerformanceLevelEXT sXrPerfSettingsSetPerformanceLevelEXT;
+    static PFN_xrEnumerateDisplayRefreshRatesFB sXrEnumerateDisplayRefreshRatesFB;
+    static PFN_xrRequestDisplayRefreshRateFB sXrRequestDisplayRefreshRateFB;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
   };


### PR DESCRIPTION
The OculusVR backend was able to dynamically set a couple of settings that affect performance:
* CPU/GPU performance levels
* Display refresh rate

We lost both with the OpenXR migration because they're using OculusVR APIs. However OpenXR still allows us to do the
same by means of a couple of extensions that allow similar functionality. In case the runtime supports those extensions
we'd be able to dynamically throttle the CPU/GPU (for example asking for more performance when watching videos or
in VR mode) and also set a higher refresh rate than the default one (for example Meta Quest2 uses 72hz by default, but
OpenXR runtime allows us to go to 90 or even 120).

Fixes #492, #499