### PR TITLE
Use github's issues page as the bug report URL

### DIFF
--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name" translatable="false">Wolvic VR Browser</string>
-    <string name="bug_report_url" translatable="false">mzl.la/fxr</string>
+    <string name="bug_report_url" translatable="false">github.com/Igalia/wolvic/issues</string>
     <!-- You can test a local file using: "resource://android/assets/webvr/index.html" -->
     <string name="homepage_url" translatable="false">https://wolvic.com/start</string>
     <string name="settings_key_homepage" translatable="false">settings_homepage</string>


### PR DESCRIPTION
Previously a short URL pointing to Mozilla's infrastructure was used. It should really link
to our issues page in the github project page.