### PR TITLE
Fix OpenXR crash on Pico v5.4.0

### DIFF
--- a/app/src/main/cpp/SystemUtils.h
+++ b/app/src/main/cpp/SystemUtils.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <algorithm>
+#include <sstream>
+
+namespace crow {
+
+#define ANDROID_OS_BUILD_ID "ro.build.id"
+
+// Get the Build ID of the current Android system.
+inline const char* GetBuildIdString(char* out) {
+  __system_property_get(ANDROID_OS_BUILD_ID, out);
+  return out;
+}
+
+// Parse a version string into an array of integers of size resultSize.
+inline void ParseVersionString(const std::string& aString, int result[], int resultSize) {
+  std::istringstream stringStream(aString);
+  // Read the first number
+  stringStream >> result[0];
+  for(int i = 1; i < resultSize; i++) {
+    // Skip period
+    stringStream.get();
+    // Read the next number
+    stringStream >> result[i];
+  }
+}
+
+// Compare two strings containing semantic versions in the MAJOR.MINOR.PATCH format.
+// Return: true if str1 is a lower version than str2, and false if it is the same or higher.
+inline bool CompareSemanticVersionStrings(const std::string& str1, const std::string& str2) {
+  int parsedStr1[3]{}, parsedStr2[3]{};
+  ParseVersionString(str1, parsedStr1, 3);
+  ParseVersionString(str2, parsedStr2, 3);
+  return std::lexicographical_compare(parsedStr1, parsedStr1 + 3, parsedStr2, parsedStr2 + 3);
+}
+
+}  // namespace crow

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -8,7 +8,9 @@
 #include <openxr/openxr_reflection.h>
 #include "vrb/Matrix.h"
 
+#include <algorithm>
 #include <string>
+#include <sstream>
 
 namespace crow {
 
@@ -146,6 +148,34 @@ inline XrPosef MatrixToXrPose(const vrb::Matrix& aMatrix) {
     result.orientation = XrQuaternionf{-q.x(), -q.y(), -q.z(), q.w()};
     result.position = XrVector3f{p.x(), p.y(), p.z()};
     return result;
+}
+
+#define ANDROID_OS_BUILD_ID "ro.build.id"
+
+inline const char* GetBuildIdString(char* out) {
+    __system_property_get(ANDROID_OS_BUILD_ID, out);
+    return out;
+}
+
+inline void ParseVersionString(const std::string& aString, int result[], int resultSize) {
+    std::istringstream stringStream(aString);
+    // Read the first number
+    stringStream >> result[0];
+    for(int i = 1; i < resultSize; i++) {
+        // Skip period
+        stringStream.get();
+        // Read the next number
+        stringStream >> result[i];
+    }
+}
+
+// This function compares two strings containing semantic versions in the MAJOR.MINOR.PATCH format.
+// It will return true if str1 is a lower version than str2, and false if it is the same or higher.
+inline bool CompareSemanticVersionStrings(const std::string& str1, const std::string& str2) {
+    int parsedStr1[3]{}, parsedStr2[3]{};
+    ParseVersionString(str1, parsedStr1, 3);
+    ParseVersionString(str2, parsedStr2, 3);
+    return std::lexicographical_compare(parsedStr1, parsedStr1 + 3, parsedStr2, parsedStr2 + 3);
 }
 
 }  // namespace crow

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -8,10 +8,6 @@
 #include <openxr/openxr_reflection.h>
 #include "vrb/Matrix.h"
 
-#include <algorithm>
-#include <string>
-#include <sstream>
-
 namespace crow {
 
 #if defined(HVR)
@@ -148,34 +144,6 @@ inline XrPosef MatrixToXrPose(const vrb::Matrix& aMatrix) {
     result.orientation = XrQuaternionf{-q.x(), -q.y(), -q.z(), q.w()};
     result.position = XrVector3f{p.x(), p.y(), p.z()};
     return result;
-}
-
-#define ANDROID_OS_BUILD_ID "ro.build.id"
-
-inline const char* GetBuildIdString(char* out) {
-    __system_property_get(ANDROID_OS_BUILD_ID, out);
-    return out;
-}
-
-inline void ParseVersionString(const std::string& aString, int result[], int resultSize) {
-    std::istringstream stringStream(aString);
-    // Read the first number
-    stringStream >> result[0];
-    for(int i = 1; i < resultSize; i++) {
-        // Skip period
-        stringStream.get();
-        // Read the next number
-        stringStream >> result[i];
-    }
-}
-
-// This function compares two strings containing semantic versions in the MAJOR.MINOR.PATCH format.
-// It will return true if str1 is a lower version than str2, and false if it is the same or higher.
-inline bool CompareSemanticVersionStrings(const std::string& str1, const std::string& str2) {
-    int parsedStr1[3]{}, parsedStr2[3]{};
-    ParseVersionString(str1, parsedStr1, 3);
-    ParseVersionString(str2, parsedStr2, 3);
-    return std::lexicographical_compare(parsedStr1, parsedStr1 + 3, parsedStr2, parsedStr2 + 3);
 }
 
 }  // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -222,7 +222,7 @@ namespace crow {
     // Pico controller: this definition was created for the Pico 4, but the Neo 3 will likely also be compatible
     const OpenXRInputMapping Pico4 {
             "/interaction_profiles/pico/neo3_controller",
-            "Pico: PICO HMD",
+            "PICO 4",
             IS_6DOF,
             "vr_controller_pico4_left.obj",
             "vr_controller_pico4_right.obj",

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -2,6 +2,7 @@
 #include "OpenXRExtensions.h"
 #include <assert.h>
 #include <unordered_set>
+#include "SystemUtils.h"
 
 namespace crow {
 

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -58,7 +58,18 @@ XrResult OpenXRInputSource::Initialize()
 
     // Filter mappings
     for (auto& mapping: OpenXRInputMappings) {
-      if (mapping.systemFilter && strcmp(mapping.systemFilter, mSystemProperties.systemName) != 0) {
+      const char* systemFilter = mapping.systemFilter;
+#if defined(PICOXR)
+      // Pico versions before 5.4.0 use a different system id.
+      if (mapping.controllerType == device::PicoXR) {
+          char buildId[128] = {0};
+          if (CompareSemanticVersionStrings(GetBuildIdString(buildId), "5.4.0")) {
+              // System version is < 5.4.0
+              systemFilter = "Pico: PICO HMD";
+          }
+      }
+#endif
+      if (systemFilter && strcmp(systemFilter, mSystemProperties.systemName) != 0) {
         continue;
       }
       bool systemIs6DoF = mSystemProperties.trackingProperties.positionTracking == XR_TRUE;

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -185,8 +185,12 @@ protected:
     info.height = height;
     bool shouldZeroInitialize = aSurfaceType == VRLayerSurface::SurfaceType::AndroidSurface;
 #if defined(PICOXR)
-    // Circumvent a bug in the pico OpenXR runtime.
-    shouldZeroInitialize = false;
+    // Circumvent a bug in the pico OpenXR runtime in versions below 5.4.0.
+    char buildId[128] = {0};
+    if (CompareSemanticVersionStrings(GetBuildIdString(buildId), "5.4.0")) {
+      // System version is < 5.4.0
+      shouldZeroInitialize = false;
+    }
 #endif
     if (shouldZeroInitialize) {
       // These members must be zero

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -16,6 +16,7 @@
 #include "OpenXRHelpers.h"
 #include "OpenXRExtensions.h"
 #include <array>
+#include "SystemUtils.h"
 
 
 namespace crow {


### PR DESCRIPTION
Version 5.4.0 of Pico fixes a bug in the previous versions, but now our workaround for that bug is causing the app to crash on startup.

Additionally, v5.4.0 changed the system name from "Pico: PICO HMD" to "PICO 4", which broke the controller mappings.

Fixes #506