### PR TITLE
[HVR] Change the target SDK version to 30

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -278,6 +278,7 @@ android {
 
         hvr {
             dimension "platform"
+            targetSdkVersion build_versions.target_sdk_hvr
             externalNativeBuild {
                 cmake {
                     cppFlags " -DHVR -DOPENXR -I" + file("src/openxr/cpp").absolutePath

--- a/versions.gradle
+++ b/versions.gradle
@@ -186,6 +186,7 @@ def build_versions = [:]
 build_versions.min_sdk = 24
 build_versions.min_sdk_wave = 25
 build_versions.target_sdk = 31
+build_versions.target_sdk_hvr = 30
 build_versions.target_sdk_wave = 31
 build_versions.build_tools = "30.0.3"
 ext.build_versions = build_versions


### PR DESCRIPTION
We're using the default 31, but that was causing an issue with the system volume slider.
Instead of the slider a black opaque rectangle was shown. We should check why but in
the meantime this is a good workaround.

Fixes #322