### PR TITLE
Hand tracking improvements

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1249,7 +1249,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Keep
     @SuppressWarnings("unused")
-    void renderPointerLayer(final Surface aSurface, final long aNativeCallback) {
+    void renderPointerLayer(final Surface aSurface, int color, final long aNativeCallback) {
         runOnUiThread(() -> {
             try {
                 Canvas canvas = aSurface.lockHardwareCanvas();
@@ -1257,7 +1257,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 Paint paint = new Paint();
                 paint.setAntiAlias(true);
                 paint.setDither(true);
-                paint.setColor(Color.WHITE);
+                paint.setColor(color);
                 paint.setStyle(Paint.Style.FILL);
                 final float x = canvas.getWidth() * 0.5f;
                 final float y = canvas.getHeight() * 0.5f;

--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -24,6 +24,7 @@ struct Controller {
   int32_t index;
   bool enabled;
   bool focused;
+  ControllerMode mode = ControllerMode::None;
   uint32_t widget;
   float pointerX;
   float pointerY;
@@ -45,6 +46,7 @@ struct Controller {
   vrb::TogglePtr handMeshToggle;
   std::vector<vrb::TransformPtr> handJointTransforms;
   bool hasAim;
+  float pinchFactor;
   vrb::TransformPtr beamParent;
   PointerPtr pointer;
   vrb::Matrix transformMatrix;

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -240,14 +240,18 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
     }
 }
 
-void ControllerContainer::SetHandVisible(const int32_t aControllerIndex, bool aVisible)
+void ControllerContainer::SetMode(const int32_t aControllerIndex, ControllerMode aMode)
 {
-    if (!m.Contains(aControllerIndex)) {
-        return;
-    }
-    Controller &controller = m.list[aControllerIndex];
-    if (controller.handMeshToggle)
-        controller.handMeshToggle->ToggleAll(aVisible);
+  if (!m.Contains(aControllerIndex))
+    return;
+  m.list[aControllerIndex].mode = aMode;
+}
+
+void ControllerContainer::SetPinchFactor(const int32_t aControllerIndex, float aFactor)
+{
+  if (!m.Contains(aControllerIndex))
+    return;
+  m.list[aControllerIndex].pinchFactor = aFactor;
 }
 
 void ControllerContainer::SetAimEnabled(const int32_t aControllerIndex, bool aEnabled) {
@@ -398,17 +402,9 @@ ControllerContainer::SetEnabled(const int32_t aControllerIndex, const bool aEnab
   m.list[aControllerIndex].enabled = aEnabled;
   if (!aEnabled) {
     m.list[aControllerIndex].focused = false;
+    SetMode(aControllerIndex, ControllerMode::None);
   }
   m.SetVisible(m.list[aControllerIndex], aEnabled);
-}
-
-void
-ControllerContainer::SetModelVisible(const int32_t aControllerIndex, const bool aVisible) {
-    if (!m.Contains(aControllerIndex))
-        return;
-
-    assert(m.list[aControllerIndex].modelToggle != nullptr);
-    m.list[aControllerIndex].modelToggle->ToggleAll(aVisible);
 }
 
 void

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -44,7 +44,6 @@ public:
   void DestroyController(const int32_t aControllerIndex) override;
   void SetCapabilityFlags(const int32_t aControllerIndex, const device::CapabilityFlags aFlags) override;
   void SetEnabled(const int32_t aControllerIndex, const bool aEnabled) override;
-  void SetModelVisible(const int32_t aControllerIndex, const bool aVisible) override;
   void SetControllerType(const int32_t aControllerIndex, device::DeviceType aType) override;
   void SetTargetRayMode(const int32_t aControllerIndex, device::TargetRayMode aMode) override;
   void SetTransform(const int32_t aControllerIndex, const vrb::Matrix& aTransform) override;
@@ -69,8 +68,9 @@ public:
   void SetVisible(const bool aVisible) override;
   void SetGazeModeIndex(const int32_t aControllerIndex) override;
   void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix>& jointTransforms) override;
-  void SetHandVisible(const int32_t aControllerIndex, bool aVisible = true) override;
   void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) override;
+  void SetMode(const int32_t aControllerIndex, ControllerMode aMode = ControllerMode::None) override;
+  void SetPinchFactor(const int32_t aControllerIndex, float aFactor = 1.0f) override;
   void SetFrameId(const uint64_t aFrameId);
 protected:
   struct State;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -19,6 +19,8 @@ namespace crow {
 class ControllerDelegate;
 typedef std::shared_ptr<ControllerDelegate> ControllerDelegatePtr;
 
+enum class ControllerMode { None, Device, Hand };
+
 class ControllerDelegate {
 public:
   enum Button {
@@ -42,7 +44,6 @@ public:
   virtual uint32_t GetControllerCount() = 0;
   virtual void SetCapabilityFlags(const int32_t aControllerIndex, const device::CapabilityFlags aFlags) = 0;
   virtual void SetEnabled(const int32_t aControllerIndex, const bool aEnabled) = 0;
-  virtual void SetModelVisible(const int32_t aControllerIndex, const bool aVisible) = 0;
   virtual void SetControllerType(const int32_t aControllerIndex, device::DeviceType aType) = 0;
   virtual void SetTargetRayMode(const int32_t aControllerIndex, device::TargetRayMode aMode) = 0;
   virtual void SetTransform(const int32_t aControllerIndex, const vrb::Matrix& aTransform) = 0;
@@ -66,8 +67,9 @@ public:
   virtual void SetVisible(const bool aVisible) = 0;
   virtual void SetGazeModeIndex(const int32_t aControllerIndex) = 0;
   virtual void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix>& jointTransforms) = 0;
-  virtual void SetHandVisible(const int32_t aControllerIndex, bool aVisible = true) = 0;
   virtual void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) = 0;
+  virtual void SetMode(const int32_t aControllerIndex, ControllerMode aMode = ControllerMode::None) = 0;
+  virtual void SetPinchFactor(const int32_t aControllerIndex, float aFactor = 1.0f) = 0;
 protected:
   ControllerDelegate() {}
 private:

--- a/app/src/main/cpp/Pointer.cpp
+++ b/app/src/main/cpp/Pointer.cpp
@@ -172,7 +172,13 @@ Pointer::SetTransform(const vrb::Matrix& aTransform) {
 void
 Pointer::SetScale(const vrb::Vector& aHitPoint, const vrb::Matrix& aHeadTransform) {
   const float scale = (aHitPoint - aHeadTransform.MultiplyPosition(vrb::Vector(0.0f, 0.0f, 0.0f))).Magnitude();
-  m.pointerScale->SetTransform(vrb::Matrix::Identity().ScaleInPlace(vrb::Vector(scale, scale, scale)));
+  if (m.layer) {
+    float size = kOuterRadius *  2.0f * scale;
+    m.layer->SetWorldSize(size, size);
+  } else {
+    m.pointerScale->SetTransform(vrb::Matrix::Identity().ScaleInPlace(
+              vrb::Vector(scale, scale, 1.0)));
+  }
 }
 
 void

--- a/app/src/main/cpp/Pointer.cpp
+++ b/app/src/main/cpp/Pointer.cpp
@@ -143,7 +143,13 @@ Pointer::Load(const DeviceDelegatePtr& aDevice) {
     layer->SetSurfaceChangedDelegate([](const VRLayer& aLayer, VRLayer::SurfaceChange aChange, const std::function<void()>& aCallback) {
        auto& quad = static_cast<const VRLayerQuad&>(aLayer);
        if (aChange == VRLayer::SurfaceChange::Create) {
-         VRBrowser::RenderPointerLayer(quad.GetSurface(), aCallback);
+           auto pointerColor = quad.GetTintColor();
+           // @FIXME: Move this to vrb::Color::toAndroidColor() eventually.
+           int32_t color = ((int32_t) 0xFF << 24) |
+                   ((int32_t) (255.0f * pointerColor.Red()) << 16) |
+                   ((int32_t) (255.0f * pointerColor.Green()) << 8) |
+                   ((int32_t) (255.0f * pointerColor.Blue()));
+         VRBrowser::RenderPointerLayer(quad.GetSurface(), color, aCallback);
        }
     });
     vrb::CreationContextPtr create = m.context.lock();
@@ -171,9 +177,13 @@ Pointer::SetScale(const vrb::Vector& aHitPoint, const vrb::Matrix& aHeadTransfor
 
 void
 Pointer::SetPointerColor(const vrb::Color& aColor) {
+  if (aColor == m.pointerColor)
+      return;
+
   m.pointerColor = aColor;
   if (m.layer) {
     m.layer->SetTintColor(aColor);
+    m.layer->NotifySurfaceChanged(VRLayer::SurfaceChange::Create, NULL);
   } if (m.geometry) {
     m.geometry->GetRenderState()->SetMaterial(aColor, aColor, vrb::Color(0.0f, 0.0f, 0.0f), 0.0f);
   }

--- a/app/src/main/cpp/Pointer.cpp
+++ b/app/src/main/cpp/Pointer.cpp
@@ -170,8 +170,7 @@ Pointer::SetTransform(const vrb::Matrix& aTransform) {
 }
 
 void
-Pointer::SetScale(const vrb::Vector& aHitPoint, const vrb::Matrix& aHeadTransform) {
-  const float scale = (aHitPoint - aHeadTransform.MultiplyPosition(vrb::Vector(0.0f, 0.0f, 0.0f))).Magnitude();
+Pointer::SetScale(const float scale) {
   if (m.layer) {
     float size = kOuterRadius *  2.0f * scale;
     m.layer->SetWorldSize(size, size);

--- a/app/src/main/cpp/Pointer.cpp
+++ b/app/src/main/cpp/Pointer.cpp
@@ -142,7 +142,8 @@ Pointer::Load(const DeviceDelegatePtr& aDevice) {
     layer->SetWorldSize(size, size);
     layer->SetSurfaceChangedDelegate([](const VRLayer& aLayer, VRLayer::SurfaceChange aChange, const std::function<void()>& aCallback) {
        auto& quad = static_cast<const VRLayerQuad&>(aLayer);
-       if (aChange == VRLayer::SurfaceChange::Create) {
+       if (aChange == VRLayer::SurfaceChange::Create ||
+           aChange == VRLayer::SurfaceChange::Invalidate) {
            auto pointerColor = quad.GetTintColor();
            // @FIXME: Move this to vrb::Color::toAndroidColor() eventually.
            int32_t color = ((int32_t) 0xFF << 24) |
@@ -188,7 +189,7 @@ Pointer::SetPointerColor(const vrb::Color& aColor) {
   m.pointerColor = aColor;
   if (m.layer) {
     m.layer->SetTintColor(aColor);
-    m.layer->NotifySurfaceChanged(VRLayer::SurfaceChange::Create, NULL);
+    m.layer->NotifySurfaceChanged(VRLayer::SurfaceChange::Invalidate, NULL);
   } if (m.geometry) {
     m.geometry->GetRenderState()->SetMaterial(aColor, aColor, vrb::Color(0.0f, 0.0f, 0.0f), 0.0f);
   }

--- a/app/src/main/cpp/Pointer.h
+++ b/app/src/main/cpp/Pointer.h
@@ -27,7 +27,7 @@ public:
   bool IsLoaded() const;
   void SetVisible(bool aVisible);
   void SetTransform(const vrb::Matrix& aTransform);
-  void SetScale(const vrb::Vector& aHitPoint, const vrb::Matrix& aHeadTransform);
+  void SetScale(const float scale);
   void SetPointerColor(const vrb::Color& aColor);
   void SetHitWidget(const WidgetPtr& aWidget);
 

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -39,7 +39,7 @@ const char* const kOnDismissWebXRInterstitialSignature = "()V";
 const char* const kOnWebXRRenderStateChangeName = "onWebXRRenderStateChange";
 const char* const kOnWebXRRenderStateChangeSignature = "(Z)V";
 const char* const kRenderPointerLayerName = "renderPointerLayer";
-const char* const kRenderPointerLayerSignature = "(Landroid/view/Surface;J)V";
+const char* const kRenderPointerLayerSignature = "(Landroid/view/Surface;IJ)V";
 const char* const kGetStorageAbsolutePathName = "getStorageAbsolutePath";
 const char* const kGetStorageAbsolutePathSignature = "()Ljava/lang/String;";
 const char* const kIsOverrideEnvPathEnabledName = "isOverrideEnvPathEnabled";
@@ -300,13 +300,13 @@ void VRBrowser::OnWebXRRenderStateChange(const bool aRendering) {
 }
 
 void
-VRBrowser::RenderPointerLayer(jobject aSurface, const std::function<void()>& aFirstCompositeCallback) {
+VRBrowser::RenderPointerLayer(jobject aSurface, const int32_t color, const std::function<void()>& aFirstCompositeCallback) {
   if (!ValidateMethodID(sEnv, sActivity, sRenderPointerLayer, __FUNCTION__)) { return; }
   jlong callback = 0;
   if (aFirstCompositeCallback) {
     callback = reinterpret_cast<jlong>(new std::function<void()>(aFirstCompositeCallback));
   }
-  sEnv->CallVoidMethod(sActivity, sRenderPointerLayer, aSurface, callback);
+  sEnv->CallVoidMethod(sActivity, sRenderPointerLayer, aSurface, color, callback);
   CheckJNIException(sEnv, __FUNCTION__);
 }
 

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -33,7 +33,7 @@ void OnEnterWebXR();
 void OnExitWebXR(const std::function<void()>& aCallback);
 void OnDismissWebXRInterstitial();
 void OnWebXRRenderStateChange(const bool aRendering);
-void RenderPointerLayer(jobject aSurface, const std::function<void()>& aFirstCompositeCallback);
+void RenderPointerLayer(jobject aSurface, const int32_t color, const std::function<void()>& aFirstCompositeCallback);
 std::string GetStorageAbsolutePath(const std::string& aRelativePath);
 bool isOverrideEnvPathEnabled();
 std::string GetActiveEnvironment();

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -32,7 +32,8 @@ public:
 
   enum class SurfaceChange {
     Create,
-    Destroy
+    Destroy,
+    Invalidate,
   };
   typedef std::function<void(const VRLayer& aLayer,
                              SurfaceChange aChange,


### PR DESCRIPTION
This is the first of a few series that aim at improving the hand-tracking support in Wolvic, by implementing behavior that is closer to established usability practices in other VR apps.

The first two patches in the series improve the Pointer class, which handles the drawing of two circles that represent the intersection between the controllers or hands (when hand-tracking is active) with the elements of the UI. Namely, it fixes setting the scale and color in the presence of layers, a functionality that is currently broken.

The third patch gets the behavior of Wolvic closer to that of Pico and Quest by rendering a pointer target whose radius varies based on the distance between index and thumb; and changes color to 'azure' blue (the background color for selected items) when the pinch action is triggered.