### PR TITLE
[OpenXR] Pause media playing on unfocus

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -49,6 +49,7 @@ import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.igalia.wolvic.audio.AudioEngine;
 import com.igalia.wolvic.browser.Accounts;
+import com.igalia.wolvic.browser.Media;
 import com.igalia.wolvic.browser.PermissionDelegate;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WRuntime;
@@ -208,6 +209,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private LinkedHashMap<Integer, WidgetPlacement> mPendingNativeWidgetUpdates = new LinkedHashMap<>();
     private ScheduledThreadPoolExecutor mPendingNativeWidgetUpdatesExecutor = new ScheduledThreadPoolExecutor(1);
     private ScheduledFuture<?> mNativeWidgetUpdatesTask = null;
+    private Media mPrevActiveMedia = null;
 
     private boolean callOnAudioManager(Consumer<AudioManager> fn) {
         if (mAudioManager == null) {
@@ -1408,6 +1410,23 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         int plugged = intent == null ? -1 : intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
         boolean isCharging = plugged == BatteryManager.BATTERY_PLUGGED_AC || plugged == BatteryManager.BATTERY_PLUGGED_USB || plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS;
         mTray.setBatteryLevels(battery, isCharging, leftLevel, rightLevel);
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
+    private void onAppFocusChanged(final boolean aIsFocused) {
+        runOnUiThread(() -> {
+            Session session = SessionStore.get().getActiveSession();
+            if (session.getActiveVideo() == null || !session.getActiveVideo().isActive())
+                return;
+            if (aIsFocused) {
+                if (mPrevActiveMedia != null && mPrevActiveMedia == session.getActiveVideo())
+                    mPrevActiveMedia.play();
+            } else if (session.getActiveVideo().isPlaying()) {
+                mPrevActiveMedia = session.getActiveVideo();
+                mPrevActiveMedia.pause();
+            }
+        });
     }
 
     private SurfaceTexture createSurfaceTexture() {

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -64,6 +64,8 @@ const char* const kAppendAppNotesToCrashReport = "appendAppNotesToCrashReport";
 const char* const kAppendAppNotesToCrashReportSignature = "(Ljava/lang/String;)V";
 const char* const kUpdateControllerBatteryLevelsName = "updateControllerBatteryLevels";
 const char* const kUpdateControllerBatteryLevelsSignature = "(II)V";
+const char* const kOnAppFocusChangedName = "onAppFocusChanged";
+const char* const kOnAppFocusChangedSignature = "(Z)V";
 
 JNIEnv* sEnv = nullptr;
 jclass sBrowserClass = nullptr;
@@ -95,6 +97,7 @@ jmethodID sOnAppLink = nullptr;
 jmethodID sDisableLayers = nullptr;
 jmethodID sAppendAppNotesToCrashReport = nullptr;
 jmethodID sUpdateControllerBatteryLevels = nullptr;
+jmethodID sOnAppFocusChanged = nullptr;
 }
 
 namespace crow {
@@ -141,6 +144,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sDisableLayers = FindJNIMethodID(sEnv, sBrowserClass, kDisableLayers, kDisableLayersSignature);
   sAppendAppNotesToCrashReport = FindJNIMethodID(sEnv, sBrowserClass, kAppendAppNotesToCrashReport, kAppendAppNotesToCrashReportSignature);
   sUpdateControllerBatteryLevels = FindJNIMethodID(sEnv, sBrowserClass, kUpdateControllerBatteryLevelsName, kUpdateControllerBatteryLevelsSignature);
+  sOnAppFocusChanged = FindJNIMethodID(sEnv, sBrowserClass, kOnAppFocusChangedName, kOnAppFocusChangedSignature);
 }
 
 JNIEnv * VRBrowser::Env()
@@ -170,6 +174,7 @@ VRBrowser::ShutdownJava() {
   sHandleMoveEnd = nullptr;
   sHandleBack = nullptr;
   sRegisterExternalContext = nullptr;
+  sOnAppFocusChanged = nullptr;
   sOnEnterWebXR = nullptr;
   sOnExitWebXR = nullptr;
   sOnDismissWebXRInterstitial = nullptr;
@@ -421,5 +426,11 @@ VRBrowser::UpdateControllerBatteryLevels(const jint aLeftBatteryLevel, const jin
   CheckJNIException(sEnv, __FUNCTION__);
 }
 
+void
+VRBrowser::OnAppFocusChanged(const bool aIsFocused) {
+  if (!ValidateMethodID(sEnv, sActivity, sOnAppFocusChanged, __FUNCTION__)) { return; }
+  sEnv->CallVoidMethod(sActivity, sOnAppFocusChanged, (jboolean) aIsFocused);
+  CheckJNIException(sEnv, __FUNCTION__);
+}
 
 } // namespace crow

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -46,6 +46,7 @@ void OnAppLink(const std::string& aJSON);
 void DisableLayers();
 void AppendAppNotesToCrashLog(const std::string& aNotes);
 void UpdateControllerBatteryLevels(const jint aLeftBatteryLevel, const jint aRightBatteryLevel);
+void OnAppFocusChanged(const bool aIsFocused);
 } // namespace VRBrowser;
 
 } // namespace crow


### PR DESCRIPTION
Whenever the system dialog is shown on top of Wolvic (like after pressing the system
button of the right controller in Meta, Pico...) the application should stop the playback
of any media.

We can achieve that by listening to application state changes. When the menu is
shown the app transitions from FOCUSED to VISIBLE state. The difference in OpenXR
is that the former gets user input while the later don't.

This behaviour fits very well with what's stated in the specs which literally say "The
application should continue running its frame loop, rendering and submitting its
composition layers, although it may wish to pause its experience, as users cannot
interact with the application at this time"