### PR TITLE
Add TabWebContentsObserver & initialize WebContents

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/DisplayImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/DisplayImpl.java
@@ -70,6 +70,6 @@ public class DisplayImpl implements WDisplay {
     @Override
     public WResult<Bitmap> capturePixelsWithAspectPreservingSize(int width) {
         // TODO: Implement
-        return null;
+        return new ResultImpl<>();
     }
 }

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -12,12 +12,10 @@ import org.chromium.content_public.browser.WebContentsObserver;
 import org.chromium.url.GURL;
 
 public class TabWebContentsObserver extends WebContentsObserver {
-    private @NonNull WebContents mWebContents;
     private @NonNull SessionImpl mSession;
 
     public TabWebContentsObserver(WebContents webContents, @NonNull SessionImpl session) {
         super(webContents);
-        mWebContents = webContents;
         mSession = session;
     }
 
@@ -56,8 +54,12 @@ public class TabWebContentsObserver extends WebContentsObserver {
     private void dispatchCanGoBackOrForward() {
         @Nullable WSession.NavigationDelegate delegate = mSession.getNavigationDelegate();
         if (delegate != null) {
-            delegate.onCanGoBack(mSession, mWebContents.getNavigationController().canGoBack());
-            delegate.onCanGoForward(mSession, mWebContents.getNavigationController().canGoForward());
+            WebContents webContents = mWebContents.get();
+            if (webContents == null)
+                return;
+
+            delegate.onCanGoBack(mSession, webContents.getNavigationController().canGoBack());
+            delegate.onCanGoForward(mSession, webContents.getNavigationController().canGoForward());
         }
     }
 

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -1,0 +1,80 @@
+package com.igalia.wolvic.browser.api.impl;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.igalia.wolvic.browser.api.WSession;
+
+import org.chromium.content_public.browser.LifecycleState;
+import org.chromium.content_public.browser.NavigationHandle;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.content_public.browser.WebContentsObserver;
+import org.chromium.url.GURL;
+
+public class TabWebContentsObserver extends WebContentsObserver {
+    private @NonNull WebContents mWebContents;
+    private @NonNull SessionImpl mSession;
+
+    public TabWebContentsObserver(WebContents webContents, @NonNull SessionImpl session) {
+        super(webContents);
+        mWebContents = webContents;
+        mSession = session;
+    }
+
+    @Override
+    public void didStartLoading(GURL url) {
+        @Nullable WSession.ProgressDelegate delegate = mSession.getProgressDelegate();
+        if (delegate != null) {
+            delegate.onPageStart(mSession, url.toString());
+        }
+        dispatchCanGoBackOrForward();
+    }
+
+    @Override
+    public void didRedirectNavigation(NavigationHandle navigationHandle) {
+        dispatchCanGoBackOrForward();
+    }
+
+    @Override
+    public void didStopLoading(GURL url, boolean isKnownValid) {
+        @Nullable WSession.ProgressDelegate delegate = mSession.getProgressDelegate();
+        if (delegate != null) {
+            delegate.onPageStop(mSession, true);
+        }
+        dispatchCanGoBackOrForward();
+    }
+
+    @Override
+    public void didFailLoad(boolean isInPrimaryMainFrame, int errorCode, GURL failingUrl, @LifecycleState int rfhLifecycleState) {
+        @Nullable WSession.ProgressDelegate delegate = mSession.getProgressDelegate();
+        if (delegate != null && isInPrimaryMainFrame) {
+            delegate.onPageStop(mSession, false);
+        }
+        dispatchCanGoBackOrForward();
+    }
+
+    private void dispatchCanGoBackOrForward() {
+        @Nullable WSession.NavigationDelegate delegate = mSession.getNavigationDelegate();
+        if (delegate != null) {
+            delegate.onCanGoBack(mSession, mWebContents.getNavigationController().canGoBack());
+            delegate.onCanGoForward(mSession, mWebContents.getNavigationController().canGoForward());
+        }
+    }
+
+    @Override
+    public void loadProgressChanged(float progress) {
+        @Nullable WSession.ProgressDelegate delegate = mSession.getProgressDelegate();
+        if (delegate != null) {
+            delegate.onProgressChange(mSession, (int)(progress * 100));
+        }
+    }
+
+    @Override
+    public void didFirstVisuallyNonEmptyPaint() {
+        @Nullable WSession.ContentDelegate delegate = mSession.getContentDelegate();
+        if (delegate != null) {
+            delegate.onFirstContentfulPaint(mSession);
+        }
+    }
+
+}

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -76,5 +76,4 @@ public class TabWebContentsObserver extends WebContentsObserver {
             delegate.onFirstContentfulPaint(mSession);
         }
     }
-
 }


### PR DESCRIPTION
This solves the issue of gray rectagle not disappearing in the content area.
- Add TabWebContentsObserver to switch to the content view
- Initialize/show WebContents
- Fix a minor build error/crash