### PR TITLE
Handle downloaded file URIs correctly

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -68,12 +68,12 @@ public class DownloadsManager {
         mExecutor = new ScheduledThreadPoolExecutor(1);
     }
 
-    public  void init() {
+    public void init() {
         mContext.registerReceiver(mDownloadReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
         List<Download> downloads = getDownloads();
         downloads.forEach(download -> {
-            if (mDownloadManager != null &&
-                    !new File(UrlUtils.stripProtocol(download.getOutputFileUri())).exists()) {
+            File downloadedFile = download.getOutputFile();
+            if (mDownloadManager != null && (downloadedFile == null || !downloadedFile.exists())) {
                 mDownloadManager.remove(download.getId());
             }
         });
@@ -222,9 +222,9 @@ public class DownloadsManager {
         Download download = getDownload(downloadId);
         if (download != null) {
             if (!deleteFiles) {
-                File file = new File(UrlUtils.stripProtocol(download.getOutputFileUri()));
-                if (file.exists()) {
-                    File newFile = new File(UrlUtils.stripProtocol(download.getOutputFileUri().concat(".bak")));
+                File file = download.getOutputFile();
+                if (file != null && file.exists()) {
+                    File newFile = new File(file.getAbsolutePath().concat(".bak"));
                     file.renameTo(newFile);
                     if (mDownloadManager != null) {
                         mDownloadManager.remove(downloadId);
@@ -370,12 +370,12 @@ public class DownloadsManager {
         contentValues.put(MediaStore.Downloads.DOWNLOAD_URI, download.getUri());
 
         String mimeFromExtension = null;
-        String extension = MimeTypeMap.getFileExtensionFromUrl(download.getOutputFilePath());
+        String extension = MimeTypeMap.getFileExtensionFromUrl(download.getOutputFileUriAsString());
         if (extension != null) {
             mimeFromExtension = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
         }
 
-        File downloadedFile = new File(download.getOutputFilePath());
+        File downloadedFile = download.getOutputFile();
         Uri downloadedFileUri = Uri.fromFile(downloadedFile);
         String mimeFromFile = contentResolver.getType(downloadedFileUri);
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
@@ -156,12 +156,12 @@ public class DownloadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 binding.thumbnail.setImageResource(R.drawable.ic_error_circle);
                 break;
             case Download.SUCCESSFUL: {
-                String fileUri = downloadItem.getOutputFileUri();
+                Uri fileUri = downloadItem.getOutputFileUri();
                 if (fileUri == null) {
                     // If this ever happens, we mark the item as unavailable.
                     binding.thumbnail.setImageResource(R.drawable.ic_error_circle);
                 } else {
-                    ThumbnailAsyncTask task = new ThumbnailAsyncTask(binding.layout.getContext(), Uri.parse(fileUri),
+                    ThumbnailAsyncTask task = new ThumbnailAsyncTask(binding.layout.getContext(), fileUri,
                             bitmap -> {
                                 if (bitmap == null || binding.getItem() == null || !Objects.equals(fileUri, binding.getItem().getOutputFileUri()))
                                     binding.thumbnail.setImageResource(R.drawable.ic_generic_file);

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
@@ -157,7 +157,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                                     LocalExtension.install(
                                             SessionStore.get().getWebExtensionRuntime(),
                                             UUID.randomUUID().toString(),
-                                            item.getOutputFileUri(),
+                                            item.getOutputFileUriAsString(),
                                             ((VRBrowserActivity) getContext()).getServicesProvider().getAddons()
                                     );
                                 }
@@ -171,7 +171,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                     );
                 }
             } else {
-                SessionStore.get().getActiveSession().loadUri(item.getOutputFileUri());
+                SessionStore.get().getActiveSession().loadUri(item.getOutputFileUriAsString());
 
                 WindowWidget window = mWidgetManager.getFocusedWindow();
                 window.hidePanel();
@@ -253,7 +253,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                     view,
                     new DownloadsContextMenuWidget(getContext(),
                             new DownloadsContextMenuWidget.DownloadsContextMenuItem(
-                                    item.getOutputFileUri(),
+                                    item.getOutputFileUriAsString(),
                                     item.getTitle(),
                                     item.getId()),
                             mWidgetManager.canOpenNewWindow(),

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/FilePromptWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/FilePromptWidget.java
@@ -146,7 +146,7 @@ public class FilePromptWidget extends PromptWidget implements DownloadsManager.D
                 filter(download -> download.getStatus() == Download.SUCCESSFUL).
                 map(download -> new FileUploadItem(
                         download.getFilename(),
-                        Uri.parse(download.getOutputFileUri()),
+                        download.getOutputFileUri(),
                         download.getMediaType(),
                         download.getSizeBytes())).
                 collect(Collectors.toList());

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
@@ -191,7 +191,7 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
             });
             String zipOutputPath = EnvironmentUtils.getEnvPath(mContext, env.getValue());
             if (zipOutputPath != null) {
-                unzip.start(download.getOutputFilePath(), zipOutputPath);
+                unzip.start(download.getOutputFile().getPath(), zipOutputPath);
             }
         }
     }


### PR DESCRIPTION
This PR implements additional functionality in the Download object to prevent errors when handling encoded and decoded file URIs:
- getOutputFileUri: returns a "file://" URI;
- getOutputFileUriAsString: returns the same URI in string format;
- getOutputFile: returns a File object pointing at the downloaded item.

For example, this fixes an issue when the name of a downloaded file contained spaces: the code to check if the file existed used the encoded URI directly to get the file path, which gave the wrong value (e.g. "%20" instead of spaces).