### PR TITLE
Keep hands shown also when no aim state

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -501,9 +501,9 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
     }
 
     if (controller.pointer) {
-      controller.pointer->SetVisible(hitWidget.get() != nullptr);
+      controller.pointer->SetVisible(hitWidget.get() != nullptr && controller.hasAim);
       controller.pointer->SetHitWidget(hitWidget);
-      if (hitWidget) {
+      if (hitWidget && controller.hasAim) {
         vrb::Matrix translation = vrb::Matrix::Translation(hitPoint);
         vrb::Matrix localRotation = vrb::Matrix::Rotation(hitNormal);
         vrb::Matrix reorient = rootTransparent->GetTransform();
@@ -511,6 +511,9 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
         controller.pointer->SetScale(hitPoint, device->GetHeadTransform());
       }
     }
+
+    if (controller.beamToggle)
+      controller.beamToggle->ToggleAll(controller.hasAim);
 
     if (controller.focused && movingWidget && movingWidget->IsMoving(controller.index)) {
       if (!pressed && wasPressed) {

--- a/app/src/main/cpp/Controller.cpp
+++ b/app/src/main/cpp/Controller.cpp
@@ -77,6 +77,7 @@ Controller::operator=(const Controller& aController) {
   batteryLevel = aController.batteryLevel;
   handMeshToggle = aController.handMeshToggle;
   handJointTransforms = aController.handJointTransforms;
+  hasAim = aController.hasAim;
   return *this;
 }
 
@@ -125,6 +126,7 @@ Controller::Reset() {
   batteryLevel = -1;
   handJointTransforms.clear();
   handMeshToggle = nullptr;
+  hasAim = true;
 }
 
 vrb::Vector Controller::StartPoint() const {

--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -44,6 +44,7 @@ struct Controller {
   vrb::TogglePtr modelToggle;
   vrb::TogglePtr handMeshToggle;
   std::vector<vrb::TransformPtr> handJointTransforms;
+  bool hasAim;
   vrb::TransformPtr beamParent;
   PointerPtr pointer;
   vrb::Matrix transformMatrix;

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -250,6 +250,12 @@ void ControllerContainer::SetHandVisible(const int32_t aControllerIndex, bool aV
         controller.handMeshToggle->ToggleAll(aVisible);
 }
 
+void ControllerContainer::SetAimEnabled(const int32_t aControllerIndex, bool aEnabled) {
+    if (!m.Contains(aControllerIndex))
+        return;
+    m.list[aControllerIndex].hasAim = aEnabled;
+}
+
 void
 ControllerContainer::Reset() {
   for (Controller& controller: m.list) {

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -70,6 +70,7 @@ public:
   void SetGazeModeIndex(const int32_t aControllerIndex) override;
   void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix>& jointTransforms) override;
   void SetHandVisible(const int32_t aControllerIndex, bool aVisible = true) override;
+  void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) override;
   void SetFrameId(const uint64_t aFrameId);
 protected:
   struct State;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -67,6 +67,7 @@ public:
   virtual void SetGazeModeIndex(const int32_t aControllerIndex) = 0;
   virtual void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix>& jointTransforms) = 0;
   virtual void SetHandVisible(const int32_t aControllerIndex, bool aVisible = true) = 0;
+  virtual void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) = 0;
 protected:
   ControllerDelegate() {}
 private:


### PR DESCRIPTION
Currently the hand mesh is shown only when there was valid aim info obtained from EXT_FB_hand_tracking_aim extension. But there are platforms (e.g Quest) where system interactions disable the aim state stream but still provide hand joints. This change allows us to keep rendering the hands in those cases.