### PR TITLE
Improve Android app lifecycle

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1010,6 +1010,11 @@ BrowserWorld::ShutdownGL() {
   m.glInitialized = false;
 }
 
+bool
+BrowserWorld::IsGLInitialized() const {
+  return m.glInitialized;
+}
+
 #if defined(OCULUSVR) && STORE_BUILD == 1
 void
 BrowserWorld::ProcessOVRPlatformEvents() {

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -35,6 +35,7 @@ public:
   bool IsPaused() const;
   void InitializeJava(JNIEnv* aEnv, jobject& aActivity, jobject& aAssetManager);
   void InitializeGL();
+  bool IsGLInitialized() const;
   void ShutdownJava();
   void ShutdownGL();
   void Draw(){


### PR DESCRIPTION
When Pico4 support was added, it introduced some workaround in the Android 
Application lifecycle code beause apparently both the APP_CMD_INIT_WINDOW
and APP_CMD_RESUME events were not being received as expected.

That was not the actual problem. The issue was that the code was starting to listen 
for those events too late, actually after those events were emitted. This commit changes 
that so we start to listen for those events as soon as possible.

That change has some side effects. Among other things it might cause crashes 
because there are strong interdependencies among the code that creates the 
DeviceDelegate and the code that initializes Java. For example the Java initialization 
requires access to the current DeviceDelegate, but the DeviceDelegate requires Java
during the initialization process for example to load the controller models.

The way to break that cycle is not to call EnterVR() (i.e. not to start the OpenXR 
session) just after getting the android native window (in the APP_CMD_INIT_WINDOW
event handler). Instead we pospone it until the DeviceDelegate is created and Java is 
initialized. Note that the DeviceDelegateOpenXR creation code might trigger the
APP_CMD_INIT_WINDOW event with the call that creates the XrInstance (in Pico
not in Meta platform). That means that the APP_CMD_* handler code can be called
before the DeviceDelegate instance is actually assigned to sAppContext->mDevice. 
That's the source of many of the issues.

The code that initializes GL and enters VR (creates XrSession) is now refactored and 
can be called in two different places:
1. Just after creating the device delegate and initializing Java. That's the case of Pico. 
    In this platform before entering the Android loop, the _RESUME and _INIT_WINDOW 
    events have been already emitted (that's why the old code was not capturing them).
2. Inside the render loop. That's the case of Oculus. In this platform the _RESUME 
    and _INIT_WINDOW events happen later, after calling ALooper_pollAll().