### PR TITLE
Warning when precise location is not available

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
@@ -14,7 +14,6 @@ import android.os.Bundle;
 import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.TextView;
 
 import androidx.databinding.DataBindingUtil;
 
@@ -83,32 +82,32 @@ class PrivacyOptionsView extends SettingsView {
             SessionStore.get().clearCache(WRuntime.ClearFlags.ALL_CACHES);
         });
 
-        TextView permissionsTitleText = findViewById(R.id.permissionsTitle);
-        permissionsTitleText.setText(getContext().getString(R.string.security_options_permissions_title, getContext().getString(R.string.app_name)));
+        mBinding.permissionsTitle.setText(getContext().getString(R.string.security_options_permissions_title, getContext().getString(R.string.app_name)));
 
         mPermissionButtons = new ArrayList<>();
-        mPermissionButtons.add(Pair.create(findViewById(R.id.microphonePermissionSwitch), Manifest.permission.RECORD_AUDIO));
-        mPermissionButtons.add(Pair.create(findViewById(R.id.storagePermissionSwitch), Manifest.permission.WRITE_EXTERNAL_STORAGE));
+        mPermissionButtons.add(Pair.create(mBinding.microphonePermissionSwitch, Manifest.permission.RECORD_AUDIO));
+        mPermissionButtons.add(Pair.create(mBinding.storagePermissionSwitch, Manifest.permission.WRITE_EXTERNAL_STORAGE));
 
         if (DeviceType.isOculusBuild() || DeviceType.isWaveBuild() || DeviceType.isPicoVR()) {
-            findViewById(R.id.cameraPermissionSwitch).setVisibility(View.GONE);
+            mBinding.cameraPermissionSwitch.setVisibility(View.GONE);
         } else {
-            mPermissionButtons.add(Pair.create(findViewById(R.id.cameraPermissionSwitch), Manifest.permission.CAMERA));
+            mPermissionButtons.add(Pair.create(mBinding.cameraPermissionSwitch, Manifest.permission.CAMERA));
         }
 
         if (DeviceType.isOculusBuild()) {
-            findViewById(R.id.locationPermissionSwitch).setVisibility(View.GONE);
+            mBinding.locationPermissionSwitch.setVisibility(View.GONE);
         } else {
-            mPermissionButtons.add(Pair.create(findViewById(R.id.locationPermissionSwitch), Manifest.permission.ACCESS_FINE_LOCATION));
+            mPermissionButtons.add(Pair.create(mBinding.locationPermissionSwitch, Manifest.permission.ACCESS_FINE_LOCATION));
+
+            // Display a warning message if approximate location is available but precise location is not.
+            boolean hasCoarseLocation = mWidgetManager.isPermissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION);
+            boolean hasFineLocation = mWidgetManager.isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION);
+            mBinding.locationPermissionWarning.setVisibility((hasCoarseLocation && !hasFineLocation) ? VISIBLE : GONE);
         }
 
         for (Pair<SwitchSetting, String> button : mPermissionButtons) {
             if (button.second.equals(Manifest.permission.ACCESS_FINE_LOCATION)) {
-                boolean hasCoarseLocation = mWidgetManager.isPermissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION);
-                boolean hasFineLocation = mWidgetManager.isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION);
-                button.first.setChecked(hasFineLocation);
-                View locationWarning = findViewById(R.id.locationPermissionWarning);
-                locationWarning.setVisibility((hasCoarseLocation && !hasFineLocation) ? VISIBLE : GONE);
+                button.first.setChecked(mWidgetManager.isPermissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION));
             } else {
                 button.first.setChecked(mWidgetManager.isPermissionGranted(button.second));
             }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
@@ -87,20 +87,31 @@ class PrivacyOptionsView extends SettingsView {
         permissionsTitleText.setText(getContext().getString(R.string.security_options_permissions_title, getContext().getString(R.string.app_name)));
 
         mPermissionButtons = new ArrayList<>();
-        mPermissionButtons.add(Pair.create(findViewById(R.id.cameraPermissionSwitch), Manifest.permission.CAMERA));
         mPermissionButtons.add(Pair.create(findViewById(R.id.microphonePermissionSwitch), Manifest.permission.RECORD_AUDIO));
-        mPermissionButtons.add(Pair.create(findViewById(R.id.locationPermissionSwitch), Manifest.permission.ACCESS_FINE_LOCATION));
         mPermissionButtons.add(Pair.create(findViewById(R.id.storagePermissionSwitch), Manifest.permission.WRITE_EXTERNAL_STORAGE));
 
         if (DeviceType.isOculusBuild() || DeviceType.isWaveBuild() || DeviceType.isPicoVR()) {
             findViewById(R.id.cameraPermissionSwitch).setVisibility(View.GONE);
-        }
-        if (DeviceType.isOculusBuild()) {
-            findViewById(R.id.locationPermissionSwitch).setVisibility(View.GONE);
+        } else {
+            mPermissionButtons.add(Pair.create(findViewById(R.id.cameraPermissionSwitch), Manifest.permission.CAMERA));
         }
 
-        for (Pair<SwitchSetting, String> button: mPermissionButtons) {
-            button.first.setChecked(mWidgetManager.isPermissionGranted(button.second));
+        if (DeviceType.isOculusBuild()) {
+            findViewById(R.id.locationPermissionSwitch).setVisibility(View.GONE);
+        } else {
+            mPermissionButtons.add(Pair.create(findViewById(R.id.locationPermissionSwitch), Manifest.permission.ACCESS_FINE_LOCATION));
+        }
+
+        for (Pair<SwitchSetting, String> button : mPermissionButtons) {
+            if (button.second.equals(Manifest.permission.ACCESS_FINE_LOCATION)) {
+                boolean hasCoarseLocation = mWidgetManager.isPermissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION);
+                boolean hasFineLocation = mWidgetManager.isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION);
+                button.first.setChecked(hasFineLocation);
+                View locationWarning = findViewById(R.id.locationPermissionWarning);
+                locationWarning.setVisibility((hasCoarseLocation && !hasFineLocation) ? VISIBLE : GONE);
+            } else {
+                button.first.setChecked(mWidgetManager.isPermissionGranted(button.second));
+            }
             button.first.setOnCheckedChangeListener((compoundButton, enabled, apply) ->
                     togglePermission(button.first, button.second));
         }

--- a/app/src/main/res/layout/options_privacy.xml
+++ b/app/src/main/res/layout/options_privacy.xml
@@ -180,6 +180,25 @@
                     app:description="@string/security_options_permission_microphone" />
 
                 <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/notificationsPermissionSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="40dp"
+                    android:visibility="gone"
+                    app:description="@string/security_options_permission_notifications"
+                    app:off_text="@string/permission_reject"
+                    app:on_text="@string/permission_allow" />
+
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/storagePermissionSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="40dp"
+                    app:description="@string/security_options_permission_storage"
+                    app:off_text="@string/permission_reject"
+                    app:on_text="@string/permission_allow" />
+
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
                     android:id="@+id/locationPermissionSwitch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -188,24 +207,31 @@
                     app:off_text="@string/permission_reject"
                     app:description="@string/security_options_permission_location" />
 
-                <com.igalia.wolvic.ui.views.settings.SwitchSetting
-                    android:id="@+id/notificationsPermissionSwitch"
+                <LinearLayout
+                    android:id="@+id/locationPermissionWarning"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="40dp"
-                    android:visibility="gone"
-                    app:on_text="@string/permission_allow"
-                    app:off_text="@string/permission_reject"
-                    app:description="@string/security_options_permission_notifications" />
+                    android:layout_marginStart="60dp"
+                    android:gravity="center_vertical"
+                    android:minHeight="40dp"
+                    android:visibility="gone">
 
-                <com.igalia.wolvic.ui.views.settings.SwitchSetting
-                    android:id="@+id/storagePermissionSwitch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="40dp"
-                    app:on_text="@string/permission_allow"
-                    app:off_text="@string/permission_reject"
-                    app:description="@string/security_options_permission_storage" />
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:scaleType="fitXY"
+                        android:src="@drawable/ic_error_circle" />
+
+                    <TextView
+                        style="@style/settingsDescription"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:gravity="start|center_vertical"
+                        android:text="@string/security_options_permission_fine_location_warning" />
+
+                </LinearLayout>
 
                 <TextView
                     android:id="@+id/dataCollectionTitle"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -767,6 +767,10 @@
          geographic location, if the device supports determination of geographic location. -->
     <string name="security_options_permission_location">Ubicación</string>
 
+    <!-- This string describes the situation when the coarse location permission has been granted,
+         but the fine location permission has not. -->
+    <string name="security_options_permission_fine_location_warning">Wolvic sólo puede acceder a tu ubicación aproximada. Puedes cambiar esto en los ajustes del sistema.</string>
+
     <!-- This string labels the button that displays or enables the application to post system-wide
          notifications. -->
     <string name="security_options_permission_notifications">Notificaciones</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -589,6 +589,9 @@
     <!-- This string labels the button that displays or enables application access to the device's
          geographic location, if the device supports determination of geographic location. -->
     <string name="security_options_permission_location">Localisation</string>
+    <!-- This string describes the situation when the coarse location permission has been granted,
+             but the fine location permission has not. -->
+    <string name="security_options_permission_fine_location_warning">Wolvic ne peut accéder qu\'à votre position approximative. Vous pouvez modifier cela dans les paramètres du système.</string>
     <!-- This string labels the button that displays or enables the application to post system-wide
          notifications. -->
     <string name="security_options_permission_notifications">Notifications</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -224,6 +224,7 @@
     <string name="security_options_permissions_title">Permisos (Permitir a %1$s acceder a)</string>
     <string name="security_options_permissions_reject_message">Este permiso só se pode desactivar nos permisos do sistema</string>
     <string name="security_options_permission_location">Localización</string>
+    <string name="security_options_permission_fine_location_warning">Wolvic só pode acceder á tua ubicación aproximada. Podes cambiar isto nos axustes do sistema.</string>
     <string name="security_options_permission_storage">Almacenamento</string>
     <string name="security_options_permission_camera_and_microphone">Cámara e micrófono</string>
     <string name="security_options_block_pup_up_windows">Bloquear xanelas pop-up</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -394,6 +394,7 @@
     <string name="security_options_permission_camera">Câmera</string>
     <string name="security_options_permission_microphone">Microfone</string>
     <string name="security_options_permission_location">Localização</string>
+    <string name="security_options_permission_fine_location_warning">Wolvic só pode aceder à sua localização aproximada. Pode modificar isto nas configurações do sistema.</string>
     <string name="security_options_block_pup_up_windows">Bloquear janelas Pop-Up</string>
     <string name="security_options_block_pup_up_settings">Avançado</string>
     <string name="security_options_webxr_settings">Avançado</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -806,6 +806,10 @@
          geographic location, if the device supports determination of geographic location. -->
     <string name="security_options_permission_location">Location</string>
 
+    <!-- This string describes the situation when the coarse location permission has been granted,
+         but the fine location permission has not. -->
+    <string name="security_options_permission_fine_location_warning">Wolvic can only get your approximate location. This can be changed in the system settings.</string>
+
     <!-- This string labels the button that displays or enables the application to post system-wide
          notifications. -->
     <string name="security_options_permission_notifications">Notifications</string>


### PR DESCRIPTION
On some systems, the user can grant Wolvic access to their approximate location but not their precise location. This can be adjusted in the device's settings.

When the approximate ("coarse") location has been granted but the precise ("fine") location has not, we display a warning message in the Settings UI to inform the user.

String translations in EN, ES, PT, FR and GL.