### PR TITLE
[OculusVR] Regression: draw controllers again

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -431,6 +431,8 @@ struct DeviceDelegateOculusVR::State {
         continue;
       }
 
+      controller->SetMode(controllerState.index, ControllerMode::Device);
+
       device::CapabilityFlags flags = 0;
       if (controllerState.capabilities.ControllerCapabilities & ovrControllerCaps_HasOrientationTracking) {
         auto &orientation = tracking.HeadPose.Pose.Orientation;


### PR DESCRIPTION
Commit 6d71d4b added some enhancements to the hand tracking code.
The downside was that it broke the controllers rendering in OculusVR 
backend. It's true that official releases do use OpenXR but we haven't 
deprecated OculusVR yet, and basic stuff should still work.