### PR TITLE
Toggle also hand mesh visibility when SetVisible() is called on a controller

### DIFF
--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -87,6 +87,9 @@ struct ControllerContainer::State {
     if (controller.pointer && !aVisible) {
       controller.pointer->SetVisible(false);
     }
+    if (controller.handMeshToggle) {
+      root->ToggleChild(*controller.handMeshToggle, aVisible);
+    }
   }
 };
 


### PR DESCRIPTION
This is a bug left by latest changes in hand-tracking code, where we tried to centralize a bit all the logic for controller/hands.

This change fixes a bug where hand mesh kept frozen while the system UI is visible with the system hands shown.