### PR TITLE
OpenXR: Increase pinch threshold a bit to avoid phantom events

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -13,7 +13,7 @@ const float kClickThreshold = 0.91f;
 // Distance threshold to consider that two hand joints touch
 // Used to detect pinch events between thumb-tip joint and the
 // rest of the finger tips.
-const float kPinchThreshold = 0.015;
+const float kPinchThreshold = 0.019;
 
 // These two are used to measure a pinch factor between [0,1]
 // between the thumb and the index fingertips, where 0 is no


### PR DESCRIPTION
Right now the pinch threshold is in the limit of the precision that Oculus devices provide, and it causes phantom clicks while scrolling because the grab is lost when the distance in at least one frame surpasses the threshold.

This patch increases the threshold a bit to avoid these situations, while avoiding undesirable pinches when not scrolling. The value has been obtained empirically and could be further adjusted.