### PR TITLE
Increase CPU level when displaying videos

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -288,9 +288,9 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     }
 
     private void dumpState(VideoAvailabilityListener aListener) {
-        mState.mMediaElements.forEach(element -> {
-            aListener.onVideoAvailabilityChanged(element,true);
-        });
+        Media activeMedia = getActiveVideo();
+        if (activeMedia != null)
+            aListener.onVideoAvailabilityChanged(activeMedia,true);
     }
 
     private void dumpState(WebXRStateChangedListener aListener) {
@@ -752,10 +752,6 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
     public boolean isSecure() {
         return mState.mSecurityInformation != null && mState.mSecurityInformation.isSecure;
-    }
-
-    public boolean isVideoAvailable() {
-        return mState.mMediaElements != null && mState.mMediaElements.size() > 0;
     }
 
     public boolean isFirstContentfulPaint() {

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionState.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionState.java
@@ -55,7 +55,6 @@ public class SessionState {
     public transient WSession mSession;
     public transient WDisplay mDisplay;
     public SessionSettings mSettings;
-    public transient ArrayList<Media> mMediaElements = new ArrayList<>();
     public transient @WebXRState int mWebXRState = WEBXR_UNUSED;
     public transient @PopupState int mPopUpState = POPUP_UNUSED;
     public transient @DrmState int mDrmState = DRM_UNUSED;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -544,7 +544,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
     public boolean isVideoAvailable() {
         for (WindowWidget window: getCurrentWindows()) {
-            if (window.getSession().isVideoAvailable()) {
+            if (window.getSession().getActiveVideo() != null) {
                 return true;
             }
         }


### PR DESCRIPTION
Whenever video was detected in any of the opened windows setCPULevel() was called so that we get extra performance from the hardware for smoother playback. However the code was always setting a NORMAL cpu level instead of HIGH because the code that was detecting the presence of a video was using some unused data structures. The code that was updating them was removed long time ago in e7b61b.

After replacing that code with the proper media detection calls the cpu levels are properly set now.