### PR TITLE
Avoid percent-encoded filenames in dowload related widgets

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
@@ -41,7 +41,7 @@ public class DownloadJob {
         if (headers != null) {
             // TODO: We may want to create our own Content-Disposition parser, instead of relying on Android.
             String contentDisposition = Uri.decode(headers.get("content-disposition"));
-            job.mFilename =  Uri.decode(URLUtil.guessFileName(uri, contentDisposition, headers.get("content/type")));
+            job.mFilename = URLUtil.guessFileName(uri, contentDisposition, headers.get("content/type"));
         } else {
             job.mFilename = URLUtil.guessFileName(uri, null, null);
         }

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
@@ -1,6 +1,7 @@
 package com.igalia.wolvic.downloads;
 
 import android.webkit.URLUtil;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -38,7 +39,9 @@ public class DownloadJob {
         job.mUri = uri;
         job.mContentLength = 0;
         if (headers != null) {
-            job.mFilename = URLUtil.guessFileName(uri, headers.get("content-disposition"), headers.get("content/type"));
+            // TODO: We may want to create our own Content-Disposition parser, instead of relying on Android.
+            String contentDisposition = Uri.decode(headers.get("content-disposition"));
+            job.mFilename =  Uri.decode(URLUtil.guessFileName(uri, contentDisposition, headers.get("content/type")));
         } else {
             job.mFilename = URLUtil.guessFileName(uri, null, null);
         }


### PR DESCRIPTION
The Content-Disposition Header Field spec [1] recommends [2] to avoid the token form of the filename if it may contain invalid characters (eg, spaces). Instead, the quoted-string form is recommended.

We should be prepared to process headers from sites that don't fully follow the spec. However, we blindly rely on the android.webkit.URLUtil class to parse, if provided, the Content-Disposition header to get the filename.

This PR proposes to pass an decode version of the Content-Disposition header to the parser. Eventually, we may want to implement our own parser to fully follow the Headers specification.

Fixes #516