### PR TITLE
Add initial support for API layers

### DIFF
--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -14,6 +14,8 @@ namespace crow {
     static void Initialize();
     static void LoadExtensions(XrInstance instance);
     static bool IsExtensionSupported(const char*);
+    static void LoadApiLayers(XrInstance instance);
+    static bool IsApiLayerSupported(const char*);
 
     static PFN_xrGetOpenGLESGraphicsRequirementsKHR sXrGetOpenGLESGraphicsRequirementsKHR;
     static PFN_xrCreateSwapchainAndroidSurfaceKHR sXrCreateSwapchainAndroidSurfaceKHR;
@@ -29,5 +31,6 @@ namespace crow {
     static PFN_xrRequestDisplayRefreshRateFB sXrRequestDisplayRefreshRateFB;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
+     static std::unordered_set<std::string> sSupportedApiLayers;
   };
 } // namespace crow


### PR DESCRIPTION
OpenXR allows users to insert API layers in between the application and the runtime. Those API layers might enhance the current OpenXR APIs or even modify behaviours. We'll very likely have to use them for some of the upcoming new platforms so this PR adds the bare minimum to be able in the future to add infor about API layers to the XrInstanceCreateInfo structure.