### PR TITLE
Fix FILE_AND_LINE and use pragma once in Assertions.h

### DIFF
--- a/app/src/main/cpp/Assertions.h
+++ b/app/src/main/cpp/Assertions.h
@@ -1,9 +1,9 @@
-#ifndef ASSERTIONS_H
-#define ASSERTIONS_H
+#pragma once
 
 // MACROS to define to-string and logging function utils
 #define STRINGIFY(x) #x
-#define FILE_AND_LINE __FILE__ ":" STRINGIFY(__LINE__)
+#define FILE_AND_LINE_INTERNAL(LINE) __FILE__ ":" STRINGIFY(LINE)
+#define FILE_AND_LINE FILE_AND_LINE_INTERNAL(__LINE__)
 
 #define THROW(msg) Throw(msg, nullptr, FILE_AND_LINE);
 
@@ -26,5 +26,3 @@
     throw std::logic_error(FILE_AND_LINE);  \
   }                                         \
 }
-
-#endif // ASSERTIONS_H


### PR DESCRIPTION
This file was recently added with some utilities that were only available for OpenXR but that should be accessible to other parts of native code. It contains a macro called FILE_AND_LINE which prints the filename and the line that triggered some exception. However the line number was never printed (__LINE__ was shown instead). We should use an extra level of macros to allow the preprocessor to perform the required substitutions.

Apart from that we use the more modern "#pragma once" instead of the old-school ifdefs for not duplicating headers' contents.