### PR TITLE
Use API level 30 for lynx target SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -276,6 +276,7 @@ android {
 
         lynx {
             dimension "platform"
+            targetSdkVersion build_versions.target_sdk_lynx
             externalNativeBuild {
                 cmake {
                     cppFlags " -DLYNX -DOPENXR -I" + file("src/openxr/cpp").absolutePath

--- a/versions.gradle
+++ b/versions.gradle
@@ -185,6 +185,7 @@ build_versions.min_sdk = 24
 build_versions.min_sdk_wave = 25
 build_versions.target_sdk = 31
 build_versions.target_sdk_hvr = 30
+build_versions.target_sdk_lynx = 30
 build_versions.target_sdk_wave = 31
 build_versions.compile_sdk = 31
 build_versions.build_tools = "30.0.3"


### PR DESCRIPTION
If we try to use 31+ then Wolvic refuses to start due to the change of behaviour[1] of pending intents.

[1] https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE