### PR TITLE
Properly destroy all OpenXRSwapChain instances before destroying the XRInstance

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -656,8 +656,7 @@ struct DeviceDelegateOpenXR::State {
 
     // Shutdown OpenXR instance
     if (instance) {
-        VRB_DEBUG("OpenXR destroy the XRInstance");
-        CHECK_XRCMD(xrDestroyInstance(instance));
+      CHECK_XRCMD(xrDestroyInstance(instance));
       instance = XR_NULL_HANDLE;
     }
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -611,7 +611,6 @@ struct DeviceDelegateOpenXR::State {
 
     // Release Layers
     if (!uiLayers.empty()) {
-        VRB_DEBUG("OpenXR Destroying Ui Layers vector");
         uiLayers.clear();
     }
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -605,8 +605,24 @@ struct DeviceDelegateOpenXR::State {
 
   void Shutdown() {
     // Release swapChains
-    for (OpenXRSwapChainPtr swapChain: eyeSwapChains) {
-      swapChain->Destroy();
+    if (!eyeSwapChains.empty()) {
+        eyeSwapChains.clear();
+    }
+
+    // Release Layers
+    if (!uiLayers.empty()) {
+        VRB_DEBUG("OpenXR Destroying Ui Layers vector");
+        uiLayers.clear();
+    }
+
+    if (cubeLayer != XR_NULL_HANDLE) {
+      cubeLayer->Destroy();
+      cubeLayer = XR_NULL_HANDLE;
+    }
+
+    if (equirectLayer != XR_NULL_HANDLE) {
+      equirectLayer->Destroy();
+      equirectLayer = XR_NULL_HANDLE;
     }
 
     // Release spaces
@@ -640,7 +656,8 @@ struct DeviceDelegateOpenXR::State {
 
     // Shutdown OpenXR instance
     if (instance) {
-      CHECK_XRCMD(xrDestroyInstance(instance));
+        VRB_DEBUG("OpenXR destroy the XRInstance");
+        CHECK_XRCMD(xrDestroyInstance(instance));
       instance = XR_NULL_HANDLE;
     }
 
@@ -1253,7 +1270,6 @@ DeviceDelegateOpenXR::DeleteLayer(const VRLayerPtr& aLayer) {
   }
   for (int i = 0; i < m.uiLayers.size(); ++i) {
     if (m.uiLayers[i]->GetLayer() == aLayer) {
-      m.uiLayers[i]->Destroy();
       m.uiLayers.erase(m.uiLayers.begin() + i);
       return;
     }

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -179,7 +179,7 @@ public:
   }
 
 protected:
-  virtual ~OpenXRLayerBase() {}
+  virtual ~OpenXRLayerBase() { Destroy(); }
   XrSwapchainCreateInfo GetSwapChainCreateInfo(VRLayerSurface::SurfaceType aSurfaceType, uint32_t width, uint32_t height) {
     XrSwapchainCreateInfo info{XR_TYPE_SWAPCHAIN_CREATE_INFO};
     info.width = width;


### PR DESCRIPTION
The DeviceDelegateOpenXR::State's Destroy function must ensure that all the OpenXRSwapChain instances are destroyed before the XRInstance.

The instances stored in vectors can rely on the element's destruction function when invoking the clear() method.

It's also necessary to explicitly destroy the layers, since they have associated swapchains instances, which might be destroyed after the XRInstance. In case of vectors, we also rely on the element's destruction function. In order to do it we need to invoke the OpenXRLayerBase::Destroy function from the class delete operator.

Fixes #546