### PR TITLE
Add an input mapping for Pico 4E

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -245,7 +245,33 @@ namespace crow {
                     { kPathHaptic, OpenXRHandFlags::Both },
             },
     };
-    
+
+    const OpenXRInputMapping Pico4E {
+            "/interaction_profiles/pico/neo3_controller",
+            "PICO 4 Enterprise",
+            IS_6DOF,
+            "vr_controller_pico4_left.obj",
+            "vr_controller_pico4_right.obj",
+            device::PicoXR,
+            std::vector<OpenXRInputProfile> { "generic-trigger-squeeze-thumbstick" },
+            std::vector<OpenXRButton> {
+                    { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
+                    { OpenXRButtonType::Squeeze, kPathSqueeze, OpenXRButtonFlags::Value, OpenXRHandFlags::Both },
+                    { OpenXRButtonType::Thumbstick, kPathThumbstick, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Both },
+                    { OpenXRButtonType::ButtonX, kPathButtonX, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left },
+                    { OpenXRButtonType::ButtonY, kPathButtonY, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left,  },
+                    { OpenXRButtonType::ButtonA, kPathButtonA, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
+                    { OpenXRButtonType::ButtonB, kPathButtonB, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
+                    { OpenXRButtonType::Back, kPathBack, OpenXRButtonFlags::Click, OpenXRHandFlags::Both, ControllerDelegate::Button::BUTTON_APP, true }
+            },
+            std::vector<OpenXRAxis> {
+                    { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
+            },
+            std::vector<OpenXRHaptic> {
+                    { kPathHaptic, OpenXRHandFlags::Both },
+            },
+    };
+
     // HVR 3DOF: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-trigger-touchpad.json
     const OpenXRInputMapping Hvr3DOF {
             "/interaction_profiles/huawei/controller",
@@ -331,8 +357,8 @@ namespace crow {
             },
     };
 
-    const std::array<OpenXRInputMapping, 8> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4, Hvr6DOF, Hvr3DOF, LynxR1, KHRSimple
+    const std::array<OpenXRInputMapping, 9> OpenXRInputMappings {
+        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4, Pico4E, Hvr6DOF, Hvr3DOF, LynxR1, KHRSimple
     };
 
 } // namespace crow


### PR DESCRIPTION
PicoOS < 5.4 was returning "Pico HMD" as the device name for both Pico 4 and Pico 4E devices. However after 5.4 it properly names both devices. That broke the code that loads the controller models in Pico4 (fixed in 7b50d3a) and also in 4E (fixed by this commit).

Note that we are just adding an input mapping, there is no need to create a new device nor adding new 3D controller models because from our POV the Pico4 and the Pico4E are basically the same device.

Fixes #564