### PR TITLE
Simplify an android initialization ifdef

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -136,7 +136,7 @@ struct DeviceDelegateOpenXR::State {
     }
     layersEnabled = VRBrowser::AreLayersEnabled();
 
-#if defined(OCULUSVR) || defined(PICOXR) || defined(LYNX) || defined(SPACES)
+#ifndef HVR
     PFN_xrInitializeLoaderKHR initializeLoaderKHR;
     CHECK_XRCMD(xrGetInstanceProcAddr(nullptr, "xrInitializeLoaderKHR", reinterpret_cast<PFN_xrVoidFunction*>(&initializeLoaderKHR)));
     XrLoaderInitInfoAndroidKHR loaderData;


### PR DESCRIPTION
All OpenXR platforms except HVR require us to call xrInitializeLoaderKHR to initialize the OpenXR loader. Instead of listing all those platforms in the ifdef we can just simply convert it to an "ifndef HVR" which makes the exception more explicit and does not require changes everytime we add a new platform.