### PR TITLE
Revert "Configure some gradle options to enable faster builds"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,16 +16,6 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-# Enables incubating configuration on demand, where Gradle will attempt to configure only necessary
-# projects. Default is false.
-# https://docs.gradle.org/current/userguide/build_environment.html
-org.gradle.configureondemand=true
-
-# Gradle will try to reuse outputs from previous builds for all builds, unless explicitly disabled
-# with --no-build-cache.
-# https://docs.gradle.org/current/userguide/build_cache.html
-org.gradle.caching=true
-
 android.injected.testOnly=false
 
 android.useAndroidX=true


### PR DESCRIPTION
Reverts Igalia/wolvic#568

Looks like it causes issues when configuring projects. Seems like AndroidStudio cannot handle it properly