### PR TITLE
Refactor manifest files specification for oculusvr

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -398,33 +398,6 @@ android {
             ]
         }
 
-        oculusvrArm64WorldGeckoGenericDebug {
-            manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
-        }
-
-        oculusvrArm64WorldGeckoGenericRelease {
-            manifest.srcFile getUseDebugSigningOnRelease() ? "src/oculusvrArmDebug/AndroidManifest.xml"
-                                                           : "src/oculusvrArmRelease/AndroidManifest.xml"
-        }
-
-        oculusvrArm64WorldGeckoAppLabDebug {
-            manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
-        }
-
-        oculusvrArm64WorldGeckoAppLabRelease {
-            manifest.srcFile getUseDebugSigningOnRelease() ? "src/oculusvrArmDebug/AndroidManifest.xml"
-                    : "src/oculusvrArmRelease/AndroidManifest.xml"
-        }
-
-        oculusvrArm64WorldGeckoMetaStoreDebug {
-            manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
-        }
-
-        oculusvrArm64WorldGeckoMetaStoreRelease {
-            manifest.srcFile getUseDebugSigningOnRelease() ? "src/oculusvrArmDebug/AndroidManifest.xml"
-                    : "src/oculusvrArmRelease/AndroidManifest.xml"
-        }
-
         wavevr {
             java.srcDirs = [
                     'src/wavevr/java'
@@ -508,6 +481,21 @@ android {
             java.srcDirs = [
                     'src/common/webkit'
             ]
+        }
+    }
+
+    sourceSets.all {
+        // oculusvr needs a specific manifest file by its buildtype.
+        if (name.startsWith('oculusvr')) {
+           if (name.toLowerCase().contains('debug')) {
+                manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
+           }
+
+           if (name.toLowerCase().contains('release')) {
+               manifest.srcFile getUseDebugSigningOnRelease()
+                   ? "src/oculusvrArmDebug/AndroidManifest.xml"
+                   : "src/oculusvrArmRelease/AndroidManifest.xml"
+           }
         }
     }
 


### PR DESCRIPTION
oculusvr needs a specific manifest file by its build type or user properties. This PR refactos manifest files specification for oculusvr, so that we don't need to speficy manifest file location for all related build variants when new flavor is added.