### PR TITLE
Fix a crash when the projection menu widget was not created

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -330,17 +330,19 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
                 enterVRVideo(mAutoSelectedProjection);
                 return;
             }
-            boolean wasVisible = mProjectionMenu.isVisible();
+            boolean wasVisible = mProjectionMenu != null ? mProjectionMenu.isVisible() : false;
             closeFloatingMenus();
 
-            mProjectionMenu.mWidgetPlacement.cylinder = SettingsStore.getInstance(getContext()).isCurvedModeEnabled();
+            if (mProjectionMenu != null) {
+                mProjectionMenu.mWidgetPlacement.cylinder = SettingsStore.getInstance(getContext()).isCurvedModeEnabled();
 
-            if (!wasVisible) {
-                mProjectionMenu.show(REQUEST_FOCUS);
-            }
+                if (!wasVisible) {
+                    mProjectionMenu.show(REQUEST_FOCUS);
+                }
 
-            if (!mProjectionMenu.isVisible()) {
-                view.requestFocusFromTouch();
+                if (!mProjectionMenu.isVisible()) {
+                    view.requestFocusFromTouch();
+                }
             }
         });
 


### PR DESCRIPTION
It might happen, when going fullscreen, that the projection menu widget was not instantiated yet by the time the user clicks on the projection button. I have not found a reliable way to reproduce it but I hit that a couple of times.

Adding a null check to ensure that we don't access a null object.