### PR TITLE
Add support for Passthrough on Oculus devices

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -205,6 +205,7 @@ struct BrowserWorld::State {
   bool wasWebXRRendering = false;
   double lastBatteryLevelUpdate = -1.0;
   bool reorientRequested = false;
+  VRLayerPassthroughPtr layerPassthrough;
 #if HVR
   bool wasButtonAppPressed = false;
 #elif defined(OCULUSVR) && defined(STORE_BUILD)
@@ -1076,6 +1077,23 @@ BrowserWorld::StartFrame() {
       m.loader->InitializeGL();
     }
   }
+
+  // @FIXME: Make this a state variable and toggle it with the menu item
+  //         Also replace the #if below with a proper SupportsPassthrough()
+  //         method based on build type.
+  bool passthroughEnabled = false;
+
+#if defined(OCULUSVR)
+  if (passthroughEnabled) {
+    // Lazily create Passthrough layer
+    if (!m.layerPassthrough) {
+      m.layerPassthrough = m.device->CreateLayerPassthrough();
+    }
+    m.layerPassthrough->RequestDraw();
+  } else if (m.layerPassthrough) {
+    m.layerPassthrough->ClearRequestDraw();
+  }
+#endif
 
 #if defined(OCULUSVR) && defined(STORE_BUILD)
   ProcessOVRPlatformEvents();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -94,6 +94,7 @@ public:
   virtual VRLayerProjectionPtr CreateLayerProjection(VRLayerSurface::SurfaceType aSurfaceType) { return nullptr; }
   virtual VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) { return nullptr; }
   virtual VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) { return nullptr; }
+  virtual VRLayerPassthroughPtr CreateLayerPassthrough() { return nullptr; }
   virtual void DeleteLayer(const VRLayerPtr& aLayer) {};
   virtual bool IsControllerLightEnabled() const { return true; }
   virtual vrb::LoadTask GetControllerModelTask(int32_t index) { return nullptr; } ;

--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -558,5 +558,17 @@ VRLayerEquirect::VRLayerEquirect(State& aState): VRLayer(aState, LayerType::EQUI
 
 VRLayerEquirect::~VRLayerEquirect() {}
 
+// Layer Passthrough
+
+struct VRLayerPassthrough::State: public VRLayer::State {
+  State() {}
+};
+
+VRLayerPassthrough::VRLayerPassthrough(State &aState): VRLayer(aState, LayerType::PASSTHROUGH), m(aState) {}
+
+VRLayerPassthroughPtr
+VRLayerPassthrough::Create() {
+  return std::make_shared<vrb::ConcreteClass<VRLayerPassthrough, VRLayerPassthrough::State>>();
+}
 
 } // namespace crow

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -27,7 +27,8 @@ public:
     QUAD,
     CUBEMAP,
     EQUIRECTANGULAR,
-    PROJECTION
+    PROJECTION,
+    PASSTHROUGH
   };
 
   enum class SurfaceChange {
@@ -211,6 +212,21 @@ private:
   State& m;
   VRB_NO_DEFAULTS(VRLayerEquirect)
 };
+
+class VRLayerPassthrough;
+typedef std::shared_ptr<VRLayerPassthrough> VRLayerPassthroughPtr;
+
+class VRLayerPassthrough: public VRLayer {
+  public:
+    static VRLayerPassthroughPtr Create();
+  protected:
+    struct State;
+    VRLayerPassthrough(State& aState);
+    virtual ~VRLayerPassthrough() = default;
+  private:
+    State& m;
+    VRB_NO_DEFAULTS(VRLayerPassthrough)
+  };
 
 } // namespace crow
 

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 
+    <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+
     <!-- Not needed in Android 10 (API >= 29) -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 
+    <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+
     <application
         android:name=".VRBrowserApplication"
         android:allowBackup="true"

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -191,6 +191,10 @@ struct DeviceDelegateOpenXR::State {
     if (OpenXRExtensions::IsExtensionSupported(XR_KHR_COMPOSITION_LAYER_COLOR_SCALE_BIAS_EXTENSION_NAME))
         extensions.push_back(XR_KHR_COMPOSITION_LAYER_COLOR_SCALE_BIAS_EXTENSION_NAME);
 
+    if (OpenXRExtensions::IsExtensionSupported(XR_FB_PASSTHROUGH_EXTENSION_NAME)) {
+      extensions.push_back(XR_FB_PASSTHROUGH_EXTENSION_NAME);
+    }
+
     java = {XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR};
     java.applicationVM = javaContext->vm;
     java.applicationActivity = javaContext->activity;

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -56,6 +56,7 @@ public:
   VRLayerCylinderPtr CreateLayerCylinder(const VRLayerSurfacePtr& aMoveLayer) override;
   VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) override;
   VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) override;
+  VRLayerPassthroughPtr CreateLayerPassthrough() override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -14,6 +14,10 @@ PFN_xrGetHandMeshFB OpenXRExtensions::sXrGetHandMeshFB = nullptr;
 PFN_xrPerfSettingsSetPerformanceLevelEXT OpenXRExtensions::sXrPerfSettingsSetPerformanceLevelEXT = nullptr;
 PFN_xrEnumerateDisplayRefreshRatesFB OpenXRExtensions::sXrEnumerateDisplayRefreshRatesFB = nullptr;
 PFN_xrRequestDisplayRefreshRateFB OpenXRExtensions::sXrRequestDisplayRefreshRateFB = nullptr;
+PFN_xrCreatePassthroughFB OpenXRExtensions::sXrCreatePassthroughFB = nullptr;
+PFN_xrDestroyPassthroughFB OpenXRExtensions::sXrDestroyPassthroughFB = nullptr;
+PFN_xrCreatePassthroughLayerFB OpenXRExtensions::sXrCreatePassthroughLayerFB = nullptr;
+PFN_xrDestroyPassthroughLayerFB OpenXRExtensions::sXrDestroyPassthroughLayerFB = nullptr;
 
 void OpenXRExtensions::Initialize() {
     // Extensions.
@@ -77,6 +81,17 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
             CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrGetHandMeshFB",
                                             reinterpret_cast<PFN_xrVoidFunction *>(&sXrGetHandMeshFB)));
         }
+    }
+
+    if (IsExtensionSupported(XR_FB_PASSTHROUGH_EXTENSION_NAME)) {
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreatePassthroughFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreatePassthroughFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrDestroyPassthroughFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyPassthroughFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreatePassthroughLayerFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreatePassthroughLayerFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrDestroyPassthroughLayerFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyPassthroughLayerFB)));
     }
 }
 

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -29,6 +29,11 @@ namespace crow {
     static PFN_xrPerfSettingsSetPerformanceLevelEXT sXrPerfSettingsSetPerformanceLevelEXT;
     static PFN_xrEnumerateDisplayRefreshRatesFB sXrEnumerateDisplayRefreshRatesFB;
     static PFN_xrRequestDisplayRefreshRateFB sXrRequestDisplayRefreshRateFB;
+
+    static PFN_xrCreatePassthroughFB sXrCreatePassthroughFB;
+    static PFN_xrDestroyPassthroughFB sXrDestroyPassthroughFB;
+    static PFN_xrCreatePassthroughLayerFB sXrCreatePassthroughLayerFB;
+    static PFN_xrDestroyPassthroughLayerFB sXrDestroyPassthroughLayerFB;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
      static std::unordered_set<std::string> sSupportedApiLayers;

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -240,4 +240,36 @@ OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
   }
 }
 
+// OpenXRLayerPassthrough;
+
+OpenXRLayerPassthroughPtr
+OpenXRLayerPassthrough::Create(const VRLayerPassthroughPtr& aLayer) {
+  // @FIXME: Consider making this method an actual constructor. Same for similar methods in
+  //         the other layers above.
+  auto result = std::make_shared<crow::OpenXRLayerPassthrough>();
+  result->vrLayer = aLayer;
+
+  return result;
+}
+
+void
+OpenXRLayerPassthrough::Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext, const XrPassthroughFB& passthroughInstance) {
+  XrPassthroughLayerCreateInfoFB layerCreateInfo = {
+    .type = XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB,
+    .passthrough = passthroughInstance,
+    .flags = XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
+    .purpose = XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB
+  };
+  CHECK_XRCMD(OpenXRExtensions::sXrCreatePassthroughLayerFB(session, &layerCreateInfo, &xrLayer));
+}
+
+void
+OpenXRLayerPassthrough::Destroy() {
+  if (xrLayer == XR_NULL_HANDLE)
+    return;
+
+  CHECK_XRCMD(OpenXRExtensions::sXrDestroyPassthroughLayerFB (xrLayer));
+  xrLayer = XR_NULL_HANDLE;
+}
+
 }

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -415,4 +415,22 @@ public:
   bool IsDrawRequested() const override;
 };
 
+
+class OpenXRLayerPassthrough;
+
+typedef std::shared_ptr<OpenXRLayerPassthrough> OpenXRLayerPassthroughPtr;
+
+class OpenXRLayerPassthrough {
+  public:
+    VRLayerPassthroughPtr vrLayer;
+    XrPassthroughLayerFB xrLayer;
+
+    static OpenXRLayerPassthroughPtr
+    Create(const VRLayerPassthroughPtr& aLayer);
+    void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext, const XrPassthroughFB& passthroughInstance);
+    void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) {};
+    void Destroy();
+    bool IsDrawRequested() { return vrLayer->IsDrawRequested(); };
+};
+
 }


### PR DESCRIPTION
This series uses XR_FB_passthrough to enable basic AR-like, passthrough functionality to Wolvic running on Oculus devices.

It is missing UI to switch the feature on/off, which is being developed separately in branch [passthrough-menu-item](https://github.com/Igalia/wolvic/tree/passthrough-menu-item). So for now the support is hard-coded to OFF by default.

The support should run out of the box on Pico devices too when we add the needed flags/permissions to their Android manifest.
