### PR TITLE
Bring back background dimming with FS videos

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -188,7 +188,8 @@ struct DeviceDelegateOpenXR::State {
       extensions.push_back(XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME);
     }
 #endif
-
+    if (OpenXRExtensions::IsExtensionSupported(XR_KHR_COMPOSITION_LAYER_COLOR_SCALE_BIAS_EXTENSION_NAME))
+        extensions.push_back(XR_KHR_COMPOSITION_LAYER_COLOR_SCALE_BIAS_EXTENSION_NAME);
 
     java = {XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR};
     java.applicationVM = javaContext->vm;

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -232,14 +232,12 @@ OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
     xrLayers[i].scale.y = scale.y();
     xrLayers[i].bias.x = translation.x();
     xrLayers[i].bias.y = translation.y();
+
+#ifdef OCULUSVR
+    if (mLayerImageLayout != XR_NULL_HANDLE)
+      PushNextXrStructureInChain((XrBaseInStructure&)xrLayers[i], (XrBaseInStructure&)*mLayerImageLayout);
+#endif
   }
 }
-
-#if OCULUSVR
-const void*
-OpenXRLayerEquirect::GetNextStructureInChain() const {
-    return this->nextStructureInChain;
-}
-#endif
 
 }


### PR DESCRIPTION
When we switched the Meta flavour to OpenXR we regressed some use cases. One of them was the background dimming animation that happens whenever a video is put in fullscreen mode or when showing modal dialogs in Wolvic. The problem was that it was using some specific fields of the OculusVR layers implementation that are not available in OpenXR.
