### PR TITLE
[OpenXR] Fix VR180 stereo left to right videos

### DIFF
--- a/app/src/main/cpp/VRVideo.cpp
+++ b/app/src/main/cpp/VRVideo.cpp
@@ -260,6 +260,23 @@ struct VRVideo::State {
     leftEye = create180LayerToggle(equirect);
   }
 
+#ifdef OPENXR
+  void create180LRProjectionLayer() {
+    vrb::CreationContextPtr create = context.lock();
+    DeviceDelegatePtr device = deviceWeak.lock();
+    VRLayerEquirectPtr equirect = device->CreateLayerEquirect(window->GetLayer());
+    layer = equirect;
+
+    equirect->SetTextureRect(device::Eye::Left, device::EyeRect(0.0f, 0.0f, 0.5f, 1.0f));
+    equirect->SetTextureRect(device::Eye::Right, device::EyeRect(0.5f, 0.0f, 0.5f, 1.0f));
+    auto UVtransform = vrb::Matrix::Identity().Scale(vrb::Vector(2.0f, 1.0f, 1.0f)).Translate(vrb::Vector(-0.5, 0.0, 0.0));
+    equirect->SetUVTransform(device::Eye::Left, UVtransform);
+    equirect->SetUVTransform(device::Eye::Right, UVtransform);
+    equirect->SetUseSameLayerForBothEyes(false);
+
+    leftEye = create180LayerToggle(equirect);
+  }
+#elif OCULUSVR
   void create180LRProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();
     DeviceDelegatePtr device = deviceWeak.lock();
@@ -273,6 +290,7 @@ struct VRVideo::State {
     leftEye = create180LayerToggle(equirect);
     rightEye = create180LayerToggle(equirect);
   }
+#endif
 
   void create180TBProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -212,9 +212,7 @@ OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
   const uint numXRLayers = GetNumXRLayers();
   for (int i = 0; i < numXRLayers; ++i) {
     device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
-    // Map video orientation
-    vrb::Matrix transform = XrPoseToMatrix(aPose).PostMultiply(layer->GetModelTransform(eye));
-    xrLayers[i].pose =  XrPoseIdentity(); //MatrixToXrPose(transform);
+    xrLayers[i].pose =  XrPoseIdentity();
 
     // Map surface and rect
     device::EyeRect rect = layer->GetTextureRect(eye);


### PR DESCRIPTION
With the transition from OculusVR to OpenXR some of the VR video formats started to fail. Some time ago we fixed the 3D side-by-side by modifying the code in VRVideo that creates the proper projection layer to render the video.

Now is the time for VR180 stereo from left to right. This commit adds an alternative implementation of create180LRProjectionLayer() that does not require a equirect for each eye as in the case of OculusVR. With OpenXR we can just create one and assign a different rectangle to be shown on each eye.

In addition it also removes an unneeded extra matrix multiplication from the equirect OpenXRLayers code.

Fixes #562