### PR TITLE
Fix the destructor of OpenXRLayerBase

### DIFF
--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -190,7 +190,7 @@ public:
   }
 
 protected:
-  virtual ~OpenXRLayerBase() { Destroy(); }
+  virtual ~OpenXRLayerBase() {}
   XrSwapchainCreateInfo GetSwapChainCreateInfo(VRLayerSurface::SurfaceType aSurfaceType, uint32_t width, uint32_t height) {
     XrSwapchainCreateInfo info{XR_TYPE_SWAPCHAIN_CREATE_INFO};
     info.width = width;


### PR DESCRIPTION
The URL bar could become unusable after opening and closing windows, and also when switching between regular and private mode.

The same could also happen to the top bar buttons.

The cause of the bug was that the default destructor of the OpenXRLayerBase class was calling the Destroy() method.

That change had been added in commit 2b3eb21 https://github.com/Igalia/wolvic/pull/554

Fixes #582