### PR TITLE
Exclude unsupported textures from Pico packages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -250,6 +250,11 @@ android {
                     arguments "-DVR_SDK_LIB=picoxr-lib", "-DPICOXR=ON", "-DOPENXR=ON"
                 }
             }
+            aaptOptions {
+                // Exclude unsupported skybox textures from Pico builds. Unfortunately, ignoreAssetsPattern
+                // only supports a very basic syntax and we have to list each individual file name.
+                ignoreAssetsPattern "posx.ktx:posy.ktx:posz.ktx:negx.ktx:negy.ktx:negz.ktx:posx_srgb.ktx:posy_srgb.ktx:posz_srgb.ktx:negx_srgb.ktx:negy_srgb.ktx:negz_srgb.ktx"
+            }
         }
 
         lynx {


### PR DESCRIPTION
Pico devices use PNG files to paint their skybox.

This PR adds a filter to exclude unsupported textures (KTX format) from Pico packages.

Unfortunately, "ignoreAssetsPattern" (Gradle) only supports a basic syntax so we have to list each individual file name.

This is a partial fix for issue #522.