### PR TITLE
Support touch events & key events including IME

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PanZoomControllerImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PanZoomControllerImpl.java
@@ -7,10 +7,10 @@ import androidx.annotation.NonNull;
 
 import com.igalia.wolvic.browser.api.WPanZoomController;
 
-public class PanZoomCrontrollerImpl implements WPanZoomController {
+public class PanZoomControllerImpl implements WPanZoomController {
     SessionImpl mSession;
 
-    public PanZoomCrontrollerImpl(SessionImpl session) {
+    public PanZoomControllerImpl(SessionImpl session) {
         mSession = session;
     }
 

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PanZoomCrontrollerImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PanZoomCrontrollerImpl.java
@@ -1,6 +1,7 @@
 package com.igalia.wolvic.browser.api.impl;
 
 import android.view.MotionEvent;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 
@@ -15,11 +16,16 @@ public class PanZoomCrontrollerImpl implements WPanZoomController {
 
     @Override
     public void onTouchEvent(@NonNull MotionEvent event) {
-        // TODO: implement
+        getContentView().dispatchTouchEvent(event);
     }
 
     @Override
     public void onMotionEvent(@NonNull MotionEvent event) {
-        // TODO: implement
+        getContentView().dispatchGenericMotionEvent(event);
+    }
+
+    private ViewGroup getContentView() {
+        assert mSession != null;
+        return mSession.getContentView();
     }
 }

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
@@ -1,10 +1,15 @@
 package com.igalia.wolvic.browser.api.impl;
 
 import android.os.Handler;
+import android.os.IBinder;
+import android.os.ResultReceiver;
 import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -12,71 +17,153 @@ import androidx.annotation.Nullable;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.api.WTextInput;
 
+import org.chromium.content_public.browser.ImeAdapter;
+import org.chromium.content_public.browser.InputMethodManagerWrapper;
+import org.chromium.ui.base.WindowAndroid;
+
 public class TextInputImpl implements WTextInput {
     SessionImpl mSession;
     View mView;
     WSession.TextInputDelegate mDelegate;
 
+    public class InputMethodManagerWrapperImpl implements InputMethodManagerWrapper {
+        @Override
+        public void restartInput(View view) {
+            // TODO : Chromium doesn't have an interface for the restarting reason, and we would
+            //        consider to extend parameters if necessary.
+            mDelegate.restartInput(mSession, WSession.TextInputDelegate.RESTART_REASON_FOCUS);
+        }
+
+        @Override
+        public void showSoftInput(final View view, int flags, ResultReceiver resultReceiver) {
+            EditorInfo outAttrs = new EditorInfo();
+            view.onCreateInputConnection(outAttrs);
+            mDelegate.showSoftInput(mSession);
+
+            // We don't take content space for the keyboard, and we report back to the ImeAdapter
+            // that the keyboard was always showing.
+            resultReceiver.send(InputMethodManager.RESULT_UNCHANGED_SHOWN, null);
+        }
+
+        @Override
+        public boolean isActive(View view) {
+            return mView != null && mView == view;
+        }
+
+        @Override
+        public boolean hideSoftInputFromWindow(
+                IBinder windowToken, int flags, ResultReceiver resultReceiver) {
+            mDelegate.hideSoftInput(mSession);
+            return false;
+        }
+
+        @Override
+        public void updateSelection(
+                View view, int selStart, int selEnd, int candidatesStart, int candidatesEnd) {
+            // Chromium does not need to convey the update selection to the delegate since
+            // ImeAdapterImpl gets this notification first from the renderer and handles it inside.
+        }
+
+        @Override
+        public void updateCursorAnchorInfo(View view, CursorAnchorInfo cursorAnchorInfo) {
+            mDelegate.updateCursorAnchorInfo(mSession, cursorAnchorInfo);
+        }
+
+        @Override
+        public void updateExtractedText(
+                View view, int token, android.view.inputmethod.ExtractedText text) {
+            ExtractedTextRequest request = new ExtractedTextRequest();
+            request.token = token;
+            mDelegate.updateExtractedText(mSession, request, text);
+        }
+
+        @Override
+        public void onWindowAndroidChanged(WindowAndroid newWindowAndroid) {}
+
+        @Override
+        public void onInputConnectionCreated() {}
+    }
+
+    private InputMethodManagerWrapperImpl mInputMethodManagerWrapper;
+
     public TextInputImpl(SessionImpl session) {
         mSession = session;
+        mInputMethodManagerWrapper = new InputMethodManagerWrapperImpl();
     }
 
     @NonNull
     @Override
     public Handler getHandler(@NonNull Handler defHandler) {
-        return null;
+        ImeAdapter imeAdapter = ImeAdapter.fromWebContents(mSession.getCurrentWebContents());
+        if (imeAdapter == null) return defHandler;
+
+        InputConnection ic = imeAdapter.getActiveInputConnection();
+        if (ic == null) return defHandler;
+
+        return ic.getHandler();
     }
 
     @Nullable
     @Override
     public View getView() {
-        return null;
+        return mView;
     }
 
     @Override
     public void setView(@Nullable View view) {
+        // We allows only the ContentView to adapt IME.
+        View contentView = mSession.getContentView();
+        if (contentView == null || contentView != view) return;
+
         mView = view;
+        ImeAdapter imeAdapter = ImeAdapter.fromWebContents(mSession.getCurrentWebContents());
+        if (imeAdapter == null) return;
+        imeAdapter.setInputMethodManagerWrapper(mInputMethodManagerWrapper);
     }
 
     @Nullable
     @Override
     public InputConnection onCreateInputConnection(@NonNull EditorInfo attrs) {
-        return mView.onCreateInputConnection(attrs);
+        return ImeAdapter.fromWebContents(mSession.getCurrentWebContents()).onCreateInputConnection(attrs);
     }
 
     @Override
     public boolean onKeyPreIme(int keyCode, @NonNull KeyEvent event) {
-        // TODO: implement
-        return false;
+        View contentView = mSession.getContentView();
+        if (contentView == null) return false;
+        return contentView.onKeyPreIme(keyCode, event);
     }
 
     @Override
     public boolean onKeyDown(int keyCode, @NonNull KeyEvent event) {
-        // TODO: implement
-        return false;
+        View contentView = mSession.getContentView();
+        if (contentView == null) return false;
+        return contentView.onKeyDown(keyCode, event);
     }
 
     @Override
     public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
-        // TODO: implement
-        return false;
+        View contentView = mSession.getContentView();
+        if (contentView == null) return false;
+        return contentView.onKeyUp(keyCode, event);
     }
 
     @Override
     public boolean onKeyLongPress(int keyCode, @NonNull KeyEvent event) {
-        // TODO: implement
-        return false;
+        View contentView = mSession.getContentView();
+        if (contentView == null) return false;
+        return contentView.onKeyLongPress(keyCode, event);
     }
 
     @Override
     public boolean onKeyMultiple(int keyCode, int repeatCount, @NonNull KeyEvent event) {
-        // TODO: implement
-        return false;
+        View contentView = mSession.getContentView();
+        if (contentView == null) return false;
+        return contentView.onKeyMultiple(keyCode, repeatCount, event);
     }
 
     @Override
     public void setDelegate(@Nullable WSession.TextInputDelegate delegate) {
-        // TODO: Implement
         mDelegate = delegate;
     }
 

--- a/app/src/common/chromium/org/chromium/components/embedder_support/view/WolvicContentRenderView.java
+++ b/app/src/common/chromium/org/chromium/components/embedder_support/view/WolvicContentRenderView.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.graphics.PixelFormat;
 import android.view.Surface;
 
+import androidx.annotation.Nullable;
+
+import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.WindowAndroid;
 
 public class WolvicContentRenderView extends ContentViewRenderView {
@@ -39,4 +42,7 @@ public class WolvicContentRenderView extends ContentViewRenderView {
         assert mNativeContentViewRenderView != 0;
         ContentViewRenderViewJni.get().surfaceDestroyed(mNativeContentViewRenderView, this);
     }
+
+    @Nullable
+    public WebContents getCurrentWebContents() { return mWebContents; }
 }


### PR DESCRIPTION
- Add ContentView managed by WebContents to implement PanZoomControllerImpl for touch events.
- Use ImeAdapter & ContentView that communicate native <-> java to implement TextInputImpl for key events including IME.