### PR TITLE
Add git submodule instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ For more info on localization, how it works in the Wolvic XR project, and how to
 git clone git@github.com:Igalia/wolvic.git
 cd wolvic
 ```
-
+*Initialize and update the Git submodules.*
+This will include the vrb submodule.
+```bash
+git submodule init
+git submodule update
+```
 *Clone the third-party repo.*
 
 If you're developing for the Oculus, Huawei, Pico, or VIVE, you need to clone the repo with third-party SDK files.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ git clone git@github.com:Igalia/wolvic.git
 cd wolvic
 ```
 *Initialize and update the Git submodules.*
+
 This will include the vrb submodule.
+
 ```bash
 git submodule init
 git submodule update


### PR DESCRIPTION
During my attempt to clone and build the Wolvic repository, I encountered the following error message: `CMake Error at CMakeLists.txt:14 (add_subdirectory): add_subdirectory given source "src/main/cpp/vrb/src" which is not an existing directory. `After some investigation, I realized that the error was caused by the vrb submodule not being included in the repository.

To help new contributors avoid running into the same issue, I've updated the readme file to include the commands necessary to fetch the vrb submodule: `git submodule init` and `git submodule update`. This will ensure that the submodule is properly included in the repository and that the build process can proceed smoothly.