### PR TITLE
Fix issue #599: undeclared identifier 'create180LRProjectionLayer' in VRVideo.cpp

### DIFF
--- a/app/src/main/cpp/VRVideo.cpp
+++ b/app/src/main/cpp/VRVideo.cpp
@@ -260,6 +260,22 @@ struct VRVideo::State {
     leftEye = create180LayerToggle(equirect);
   }
 
+  void create180LRProjectionLayer() {
+    vrb::CreationContextPtr create = context.lock();
+    DeviceDelegatePtr device = deviceWeak.lock();
+    VRLayerEquirectPtr equirect = device->CreateLayerEquirect(window->GetLayer());
+    layer = equirect;
+
+    equirect->SetTextureRect(device::Eye::Left, device::EyeRect(0.0f, 0.0f, 0.5f, 1.0f));
+    equirect->SetTextureRect(device::Eye::Right, device::EyeRect(0.5f, 0.0f, 0.5f, 1.0f));
+    auto UVtransform = vrb::Matrix::Identity().Scale(vrb::Vector(2.0f, 1.0f, 1.0f)).Translate(vrb::Vector(-0.5, 0.0, 0.0));
+    equirect->SetUVTransform(device::Eye::Left, UVtransform);
+    equirect->SetUVTransform(device::Eye::Right, UVtransform);
+    equirect->SetUseSameLayerForBothEyes(false);
+
+    leftEye = create180LayerToggle(equirect);
+  }
+  
 #ifdef OPENXR
   void create180LRProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();

--- a/app/src/main/cpp/VRVideo.cpp
+++ b/app/src/main/cpp/VRVideo.cpp
@@ -260,22 +260,6 @@ struct VRVideo::State {
     leftEye = create180LayerToggle(equirect);
   }
 
-  void create180LRProjectionLayer() {
-    vrb::CreationContextPtr create = context.lock();
-    DeviceDelegatePtr device = deviceWeak.lock();
-    VRLayerEquirectPtr equirect = device->CreateLayerEquirect(window->GetLayer());
-    layer = equirect;
-
-    equirect->SetTextureRect(device::Eye::Left, device::EyeRect(0.0f, 0.0f, 0.5f, 1.0f));
-    equirect->SetTextureRect(device::Eye::Right, device::EyeRect(0.5f, 0.0f, 0.5f, 1.0f));
-    auto UVtransform = vrb::Matrix::Identity().Scale(vrb::Vector(2.0f, 1.0f, 1.0f)).Translate(vrb::Vector(-0.5, 0.0, 0.0));
-    equirect->SetUVTransform(device::Eye::Left, UVtransform);
-    equirect->SetUVTransform(device::Eye::Right, UVtransform);
-    equirect->SetUseSameLayerForBothEyes(false);
-
-    leftEye = create180LayerToggle(equirect);
-  }
-  
 #ifdef OPENXR
   void create180LRProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();
@@ -292,7 +276,7 @@ struct VRVideo::State {
 
     leftEye = create180LayerToggle(equirect);
   }
-#elif OCULUSVR
+#else
   void create180LRProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();
     DeviceDelegatePtr device = deviceWeak.lock();


### PR DESCRIPTION
This PR fixes issue #599 , `create180LRProjectionLayer` function was declared only inside the `#ifdef OPENXR` and `#elif OCULUSVR` which i believe is the macros of the Build variant. While building the noapi variant I got an error `undeclared identifier 'create180LRProjectionLayer' in VRVideo.cpp`. so, I moved the function definition outside of the #ifdef block and the build completed sucessfully.