### PR TITLE
Fix package name for mainland China

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -698,7 +698,7 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
 androidComponents {
     onVariants(selector().all(), { variant ->
         // HVR packages for China must use different applicationIds.
-        def hvrChinaBuildPattern = ~/hvr\p{Alnum}+Cn(Release|Debug)/
+        def hvrChinaBuildPattern = ~/hvr\p{Alnum}+Cn\p{Alnum}+(Release|Debug)/
         if (hvrChinaBuildPattern.matcher(variant.name).matches())
             variant.applicationId = variant.applicationId.get().replace('com.igalia','com.cn.igalia')
     })


### PR DESCRIPTION
For mainland China, the package name is com.cn.igalia.wolvic, which is different from the one for overseas. We do have code that automatically does the replacement when generating the package. However the recent changes in the build system that added more flavours broke it.

Adjusted the pattern used to detect HVR builds for mainland China so that it properly replaces the package name automatically.