### PR TITLE
Fix accidental back navigation

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -420,9 +420,10 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
       controller.pointer->Load(device);
     }
 
-    if ((!(controller.lastButtonState & ControllerDelegate::BUTTON_APP) && (controller.buttonState & ControllerDelegate::BUTTON_APP)) ||
-      (!(controller.lastButtonState & ControllerDelegate::BUTTON_B) && (controller.buttonState & ControllerDelegate::BUTTON_B)) ||
-      (!(controller.lastButtonState & ControllerDelegate::BUTTON_Y) && (controller.buttonState & ControllerDelegate::BUTTON_Y))) {
+    if (controller.mode == ControllerMode::Device &&
+        ((!(controller.lastButtonState & ControllerDelegate::BUTTON_APP) && (controller.buttonState & ControllerDelegate::BUTTON_APP)) ||
+         (!(controller.lastButtonState & ControllerDelegate::BUTTON_B) && (controller.buttonState & ControllerDelegate::BUTTON_B)) ||
+         (!(controller.lastButtonState & ControllerDelegate::BUTTON_Y) && (controller.buttonState & ControllerDelegate::BUTTON_Y)))) {
       SimulateBack();
     }
 

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -655,12 +655,6 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
             delegate.SetSqueezeActionStop(mIndex);
         }
     }
-
-    // Menu button
-    bool ringPinching = GetDistanceBetweenJoints(XR_HAND_JOINT_THUMB_TIP_EXT,
-                                                 XR_HAND_JOINT_RING_TIP_EXT) < kPinchThreshold;
-    delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_APP, -1, ringPinching,
-                            ringPinching, 1.0);
 }
 
 void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, ControllerDelegate& delegate)


### PR DESCRIPTION
When hand tracking is active, touching your thumb and ring fingers
was being mapped to a click of the Menu button in the controller.
In turn, this click was interpreted as a request to navigate Back.

The consequence of that sequence was that many common actions
would trigger this gesture and cause an unwanted Back navigation.
     
One case where this happened often was simply picking up the controller.

This PR fixes that issues by removing the Menu gesture in hand tracking
and adding an extra check that these events come from the controllers.