### PR TITLE
Fix #573: Ensure that store builds use OpenXR"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -388,6 +388,11 @@ android {
         // MetaStore and AppLab only apply to oculusvr builds.
         if ((store == 'metaStore' || store == "appLab") && !platform.startsWith('oculusvr'))
             variant.setIgnore(true);
+        
+        // Throw an error if a store flavor is built with openxr=false
+        if (store == 'generic' && !project.hasProperty('openxr') || project.getProperty('openxr') == false) {
+            throw new GradleException('Cannot build a store flavor with openxr=false')
+        }
     }
 
     sourceSets {

--- a/app/src/main/cpp/VRVideo.cpp
+++ b/app/src/main/cpp/VRVideo.cpp
@@ -260,6 +260,22 @@ struct VRVideo::State {
     leftEye = create180LayerToggle(equirect);
   }
 
+  void create180LRProjectionLayer() {
+    vrb::CreationContextPtr create = context.lock();
+    DeviceDelegatePtr device = deviceWeak.lock();
+    VRLayerEquirectPtr equirect = device->CreateLayerEquirect(window->GetLayer());
+    layer = equirect;
+
+    equirect->SetTextureRect(device::Eye::Left, device::EyeRect(0.0f, 0.0f, 0.5f, 1.0f));
+    equirect->SetTextureRect(device::Eye::Right, device::EyeRect(0.5f, 0.0f, 0.5f, 1.0f));
+    auto UVtransform = vrb::Matrix::Identity().Scale(vrb::Vector(2.0f, 1.0f, 1.0f)).Translate(vrb::Vector(-0.5, 0.0, 0.0));
+    equirect->SetUVTransform(device::Eye::Left, UVtransform);
+    equirect->SetUVTransform(device::Eye::Right, UVtransform);
+    equirect->SetUseSameLayerForBothEyes(false);
+
+    leftEye = create180LayerToggle(equirect);
+  }
+  
 #ifdef OPENXR
   void create180LRProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();

--- a/app/src/main/cpp/VRVideo.cpp
+++ b/app/src/main/cpp/VRVideo.cpp
@@ -260,22 +260,6 @@ struct VRVideo::State {
     leftEye = create180LayerToggle(equirect);
   }
 
-  void create180LRProjectionLayer() {
-    vrb::CreationContextPtr create = context.lock();
-    DeviceDelegatePtr device = deviceWeak.lock();
-    VRLayerEquirectPtr equirect = device->CreateLayerEquirect(window->GetLayer());
-    layer = equirect;
-
-    equirect->SetTextureRect(device::Eye::Left, device::EyeRect(0.0f, 0.0f, 0.5f, 1.0f));
-    equirect->SetTextureRect(device::Eye::Right, device::EyeRect(0.5f, 0.0f, 0.5f, 1.0f));
-    auto UVtransform = vrb::Matrix::Identity().Scale(vrb::Vector(2.0f, 1.0f, 1.0f)).Translate(vrb::Vector(-0.5, 0.0, 0.0));
-    equirect->SetUVTransform(device::Eye::Left, UVtransform);
-    equirect->SetUVTransform(device::Eye::Right, UVtransform);
-    equirect->SetUseSameLayerForBothEyes(false);
-
-    leftEye = create180LayerToggle(equirect);
-  }
-  
 #ifdef OPENXR
   void create180LRProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();
@@ -292,7 +276,7 @@ struct VRVideo::State {
 
     leftEye = create180LayerToggle(equirect);
   }
-#elif OCULUSVR
+#else
   void create180LRProjectionLayer() {
     vrb::CreationContextPtr create = context.lock();
     DeviceDelegatePtr device = deviceWeak.lock();


### PR DESCRIPTION
This pull request fixes #573. It prevents from submitting a non OpenXR build to an store. It throw an error if a store flavor is built with openxr=false.