### PR TITLE
Increase the default window size to 1024×576, maximum to 1440x840

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -88,8 +88,8 @@ public class SettingsStore {
     public final static int WINDOW_WIDTH_DEFAULT = 1000;
     public final static int WINDOW_HEIGHT_DEFAULT = 600;
     public final static int DISPLAY_DPI_DEFAULT = 96;
-    public final static int MAX_WINDOW_WIDTH_DEFAULT = 1200;
-    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 1200;
+    public final static int MAX_WINDOW_WIDTH_DEFAULT = 1400;
+    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 840;
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;
     public final static String ENV_DEFAULT = "cyberpunk";

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -85,8 +85,8 @@ public class SettingsStore {
     public final static int UA_MODE_DEFAULT = WSessionSettings.USER_AGENT_MODE_VR;
     public final static int INPUT_MODE_DEFAULT = 1;
     public final static float DISPLAY_DENSITY_DEFAULT = 1.0f;
-    public final static int WINDOW_WIDTH_DEFAULT = 800;
-    public final static int WINDOW_HEIGHT_DEFAULT = 450;
+    public final static int WINDOW_WIDTH_DEFAULT = 1000;
+    public final static int WINDOW_HEIGHT_DEFAULT = 600;
     public final static int DISPLAY_DPI_DEFAULT = 96;
     public final static int MAX_WINDOW_WIDTH_DEFAULT = 1200;
     public final static int MAX_WINDOW_HEIGHT_DEFAULT = 1200;

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -85,11 +85,11 @@ public class SettingsStore {
     public final static int UA_MODE_DEFAULT = WSessionSettings.USER_AGENT_MODE_VR;
     public final static int INPUT_MODE_DEFAULT = 1;
     public final static float DISPLAY_DENSITY_DEFAULT = 1.0f;
-    public final static int WINDOW_WIDTH_DEFAULT = 1000;
-    public final static int WINDOW_HEIGHT_DEFAULT = 600;
+    public final static int WINDOW_WIDTH_DEFAULT = 1024;
+    public final static int WINDOW_HEIGHT_DEFAULT = 576;
     public final static int DISPLAY_DPI_DEFAULT = 96;
-    public final static int MAX_WINDOW_WIDTH_DEFAULT = 1400;
-    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 840;
+    public final static int MAX_WINDOW_WIDTH_DEFAULT = 1440;
+    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 810;
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;
     public final static String ENV_DEFAULT = "cyberpunk";

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -104,6 +104,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public static final int DEACTIVATE_CURRENT_SESSION = 0;
     public static final int LEAVE_CURRENT_SESSION_ACTIVE = 1;
 
+    private final float DEFAULT_SCALE = 1.0f;
+    private final float MAX_SCALE = 3.0f;
+
     private Surface mSurface;
     private int mWidth;
     private int mHeight;
@@ -1493,11 +1496,27 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public @NonNull Pair<Float, Float> getSizeForScale(float aScale, float aAspect) {
-        float worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) *
-                (float)SettingsStore.getInstance(getContext()).getWindowWidth() / (float)SettingsStore.WINDOW_WIDTH_DEFAULT;
-        float worldHeight = worldWidth / aAspect;
-        float area = worldWidth * worldHeight * aScale;
-        float targetWidth = (float) Math.sqrt(area * aAspect);
+        final float defaultWidthWorld = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+        final float maxWidthWorld = SettingsStore.MAX_WINDOW_WIDTH_DEFAULT * (defaultWidthWorld/SettingsStore.WINDOW_WIDTH_DEFAULT);
+        float targetWidth;
+
+        if (aScale < DEFAULT_SCALE) {
+            // Reduce the area of the window according to the desired scale.
+            float worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+            float worldHeight = worldWidth / aAspect;
+            float targetArea = worldWidth * worldHeight * aScale;
+            targetWidth = (float) Math.sqrt(targetArea * aAspect);
+        } else if (aScale == DEFAULT_SCALE) {
+            // Default window size.
+            targetWidth = defaultWidthWorld;
+        } else if (aScale >= MAX_SCALE) {
+            // Maximum window size.
+            targetWidth = maxWidthWorld;
+        } else {
+            // Proportional between the default and maximum sizes.
+            targetWidth = defaultWidthWorld + (maxWidthWorld - defaultWidthWorld) * (aScale - DEFAULT_SCALE) / (MAX_SCALE - DEFAULT_SCALE);
+        }
+
         float targetHeight = targetWidth / aAspect;
         return Pair.create(targetWidth, targetHeight);
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1496,8 +1496,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public @NonNull Pair<Float, Float> getSizeForScale(float aScale, float aAspect) {
-        final float defaultWidthWorld = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
-        final float maxWidthWorld = SettingsStore.MAX_WINDOW_WIDTH_DEFAULT * (defaultWidthWorld/SettingsStore.WINDOW_WIDTH_DEFAULT);
+        final float defaultWorldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+        final float maxWidthWorld = SettingsStore.MAX_WINDOW_WIDTH_DEFAULT * (defaultWorldWidth/SettingsStore.WINDOW_WIDTH_DEFAULT);
         float targetWidth;
 
         if (aScale < DEFAULT_SCALE) {
@@ -1508,13 +1508,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             targetWidth = (float) Math.sqrt(targetArea * aAspect);
         } else if (aScale == DEFAULT_SCALE) {
             // Default window size.
-            targetWidth = defaultWidthWorld;
+            targetWidth = defaultWorldWidth;
         } else if (aScale >= MAX_SCALE) {
             // Maximum window size.
             targetWidth = maxWidthWorld;
         } else {
             // Proportional between the default and maximum sizes.
-            targetWidth = defaultWidthWorld + (maxWidthWorld - defaultWidthWorld) * (aScale - DEFAULT_SCALE) / (MAX_SCALE - DEFAULT_SCALE);
+            targetWidth = defaultWorldWidth + (maxWidthWorld - defaultWorldWidth) * (aScale - DEFAULT_SCALE) / (MAX_SCALE - DEFAULT_SCALE);
         }
 
         float targetHeight = targetWidth / aAspect;

--- a/app/src/main/cpp/Cylinder.cpp
+++ b/app/src/main/cpp/Cylinder.cpp
@@ -29,7 +29,8 @@ namespace crow {
 // It should match the values defined in WindowWidget.
 // 800px is the default window size for a 4m world size.
 // TODO: For now, this value remains the same even if the default window size changes
-//       because otherwise the default windows are not correctly mapped on the cylinder.
+//       to ensure that three windows at the default size cover 180° of the cylinder
+//       (which is not the case if we increase this value).
 float Cylinder::kWorldDensityRatio =  800.0f / 4.0f;
 
 struct Cylinder::State {

--- a/app/src/main/cpp/Cylinder.cpp
+++ b/app/src/main/cpp/Cylinder.cpp
@@ -28,6 +28,8 @@ namespace crow {
 // Ratio between world size and cylinder surface size.
 // It should match the values defined in WindowWidget.
 // 800px is the default window size for a 4m world size.
+// TODO: For now, this value remains the same even if the default window size changes
+//       because otherwise the default windows are not correctly mapped on the cylinder.
 float Cylinder::kWorldDensityRatio =  800.0f / 4.0f;
 
 struct Cylinder::State {

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- World -->
-    <dimen name="world_width">800px</dimen>
+    <dimen name="world_width">1000px</dimen>
 
     <!-- Browser window -->
     <item name="window_world_width" format="float" type="dimen">4.0</item>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- World -->
-    <dimen name="world_width">1000px</dimen>
+    <dimen name="world_width">1024px</dimen>
 
     <!-- Browser window -->
     <item name="window_world_width" format="float" type="dimen">4.0</item>


### PR DESCRIPTION
Use 1024×576 as the default size for Web browser windows.

All widely used CSS frameworks have a breakpoint around 1024px
so they can target tablets and regular desktop windows.

The aspect ratio of the default window remains 16:9. 

The maximum size is 1440×810, which preserves the same aspect ratio
while remaining (more or less) readable.

Between the default and maximum values, we will scale the windows
proportionally.