### PR TITLE
Add some dependency conflict resoluton strategies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -652,6 +652,9 @@ dependencies {
     geckoImplementation deps.gecko_view."${branch}_x86_64"
     geckoImplementation deps.gecko_view."${branch}_arm64"
     configurations.all {
+         resolutionStrategy {
+            force 'org.jetbrains.kotlin:kotlin-stdlib:1.4.10', 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10', 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10', 'org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10','org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2', 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2', 'androidx.annotation:annotation:1.1.0'
+         }
          resolutionStrategy.capabilitiesResolution.withCapability('org.mozilla.geckoview:geckoview') {
             def abi = getName().toLowerCase().contains('x86_64') ? 'x86_64' : 'arm64'
             def candidate = "geckoview-${branch}-${abi}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -652,8 +652,16 @@ dependencies {
     geckoImplementation deps.gecko_view."${branch}_x86_64"
     geckoImplementation deps.gecko_view."${branch}_arm64"
     configurations.all {
-         resolutionStrategy {
-            force 'org.jetbrains.kotlin:kotlin-stdlib:1.4.10', 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10', 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10', 'org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10','org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2', 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2', 'androidx.annotation:annotation:1.1.0'
+        // TODO(jfernandez): Instead of solving the conflicts this way, we would need to determine which packages
+        // are the culprit and define their dependencies so that we can let gradle to resolve them automatically.
+        // See https://docs.gradle.org/current/userguide/dependency_resolution.html for details.
+         resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.jetbrains.kotlin') {
+                details.useVersion '1.4.10'
+            } else if (details.requested.group == 'org.jetbrains.kotlinx'
+                    && details.requested.name.contains('coroutines')) {
+                details.useVersion '1.4.2'
+            }
          }
          resolutionStrategy.capabilitiesResolution.withCapability('org.mozilla.geckoview:geckoview') {
             def abi = getName().toLowerCase().contains('x86_64') ? 'x86_64' : 'arm64'

--- a/versions.gradle
+++ b/versions.gradle
@@ -103,7 +103,7 @@ deps.app_services = app_services
 deps.openwnn = "jp.co.omronsoft.openwnn:openwnn:$versions.openwnn"
 
 def support = [:]
-support.annotations = "androidx.annotation:annotation:1.6.0"
+support.annotations = "androidx.annotation:annotation:1.1.0"
 support.app_compat = "androidx.appcompat:appcompat:1.4.2"
 support.recyclerview = "androidx.recyclerview:recyclerview:1.2.1"
 support.cardview = "androidx.cardview:cardview:1.0.0"


### PR DESCRIPTION
This PR tries to address some dependency conflicts caused by the [PR#519](https://github.com/Igalia/wolvic/pull/519)). 

It seems that some of the dependencies are defined using 'strict' versions and are incompatible with some of the versions we raised recently in Wolvic (eg kotlin-stdlib:1810)). These generate problems when building release flavors:

> Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.8.0, expected version is 1.4.0.

We have added some resolution strategies for the case of conflicts with 'org.jetbrains.kotlin.* and 'org.jetbrains.kotlinx.coroutines' packages. We aim to use packages built with Kotlin 1.8.10 when possible, but when needed we keep the ones built with 1.4.  