### PR TITLE
Make OpenXRLayerPassthrough an actual OpenXRLayer

### DIFF
--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -244,24 +244,24 @@ OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aC
 // OpenXRLayerPassthrough;
 
 OpenXRLayerPassthroughPtr
-OpenXRLayerPassthrough::Create(const VRLayerPassthroughPtr& aLayer) {
-  // @FIXME: Consider making this method an actual constructor. Same for similar methods in
-  //         the other layers above.
-  auto result = std::make_shared<crow::OpenXRLayerPassthrough>();
-  result->vrLayer = aLayer;
+OpenXRLayerPassthrough::Create(const VRLayerPassthroughPtr& aLayer, XrPassthroughFB passthroughInstance) {
+  auto result = std::make_shared<OpenXRLayerPassthrough>();
+  result->layer = aLayer;
+  result->mPassthroughInstance = passthroughInstance;
 
   return result;
 }
 
 void
-OpenXRLayerPassthrough::Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext, const XrPassthroughFB& passthroughInstance) {
+OpenXRLayerPassthrough::Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) {
   XrPassthroughLayerCreateInfoFB layerCreateInfo = {
     .type = XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB,
-    .passthrough = passthroughInstance,
+    .passthrough = mPassthroughInstance,
     .flags = XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
     .purpose = XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB
   };
   CHECK_XRCMD(OpenXRExtensions::sXrCreatePassthroughLayerFB(session, &layerCreateInfo, &xrLayer));
+  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Init(aEnv, session, aContext);
 }
 
 void
@@ -271,6 +271,7 @@ OpenXRLayerPassthrough::Destroy() {
 
   CHECK_XRCMD(OpenXRExtensions::sXrDestroyPassthroughLayerFB (xrLayer));
   xrLayer = XR_NULL_HANDLE;
+  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Destroy();
 }
 
 }


### PR DESCRIPTION
Make OpenXRLayerPassthrough an actual OpenXRLayer
    
The current implementation of OpenXRLayerPassthrough does not fit
well with the OpenXRLayer architecture because it does not inherit
from it. This causes several issues, among others there are explicit
calls in the code to Request/Clear draw of the layer.
    
The reason behind that is that there were some issues with the
structure defined by the passthrough extension, we're talking about
XrCompositionLayerPassthrough:
  1) It does not have eyeVisibility as other composition layers
  2) The layer flags are stored in an attribute called flags instead
of layerFlags as XrCompositionLayerBaseHeader defines.
    
The first issue was addressed in PR#620. We're fixing the second one
as part of this. The trick is simple, we just need to access the
structure using a XrCompositionLayerBaseHeader cast. The passthrough
struct is binary compatible, it's just that they decided to use
a different attribute name (flags vs layerFlags), but the types and
the location of the attributes is identical.
    
After doing that, we can safely make OpenXRLayerPassthrough extend
from OpenXRLayerBase. The Init, Update, etc... methods now do override
OpenXRLayerBase's. The benefit is that we don't need to explicitly
now request/clear draws as that is automatically done by the current
machinery. We just had to create a new rootnode that will add
the passthrough layer to the drawList whenever needed.
    
Last but not least, the creation of the passthrough layer is now
done in TogglePassthrough where it does make much more sense than
in StartFrame().