### PR TITLE
[OpenXR] Blend mode passthrough

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -147,6 +147,7 @@ if(OPENXR)
             src/openxr/cpp/OpenXRInputSource.cpp
             src/openxr/cpp/OpenXRActionSet.cpp
             src/openxr/cpp/OpenXRExtensions.cpp
+            src/openxr/cpp/OpenXRPassthroughStrategy.cpp
     )
 
 elseif(OCULUSVR)

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1855,7 +1855,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public boolean isPassthroughSupported() {
-        return DeviceType.isOculusBuild();
+        return DeviceType.isOculusBuild() || DeviceType.isLynx();
     }
 
     @Override

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -107,6 +107,9 @@ public:
     virtual ~ReorientClient() {};
   };
   void SetReorientClient(ReorientClient* client) { mReorientClient = client; }
+  bool IsPassthroughEnabled() const { return mIsPassthroughEnabled; }
+  void TogglePassthroughEnabled() { mIsPassthroughEnabled = !mIsPassthroughEnabled; }
+  virtual bool usesPassthroughCompositorLayer() const { return false; }
 
 protected:
   DeviceDelegate() {}
@@ -115,6 +118,7 @@ protected:
 
   bool mShouldRender { false };
   ReorientClient* mReorientClient { nullptr };
+  bool mIsPassthroughEnabled { false };
 private:
   VRB_NO_DEFAULTS(DeviceDelegate)
 };

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -57,6 +57,7 @@ public:
   VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) override;
   VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) override;
   VRLayerPassthroughPtr CreateLayerPassthrough() override;
+  bool usesPassthroughCompositorLayer() const override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
@@ -1,0 +1,13 @@
+#include <vrb/Logger.h>
+#include "OpenXRPassthroughStrategy.h"
+
+namespace crow {
+
+XrEnvironmentBlendMode
+OpenXRPassthroughStrategyUnsupported::environmentBlendModeForPassthrough() const {
+    VRB_ERROR("should not be called when passthrough is not available");
+    return XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+};
+
+
+} // namespace crow

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
@@ -1,7 +1,73 @@
-#include <vrb/Logger.h>
 #include "OpenXRPassthroughStrategy.h"
 
+#include <vrb/Logger.h>
+#include "OpenXRExtensions.h"
+#include "OpenXRHelpers.h"
+
 namespace crow {
+
+OpenXRLayerPassthroughPtr
+OpenXRPassthroughStrategy::createLayerIfSupported(VRLayerPassthroughPtr) const {
+    VRB_ERROR("asking to create a layer for passthrough when it isn't actually supported");
+    return nullptr;
+};
+
+OpenXRPassthroughStrategyFBExtension::~OpenXRPassthroughStrategyFBExtension() {
+    if (passthroughHandle != XR_NULL_HANDLE) {
+        CHECK_XRCMD(OpenXRExtensions::sXrDestroyPassthroughFB (passthroughHandle));
+        passthroughHandle = XR_NULL_HANDLE;
+    }
+}
+
+void
+OpenXRPassthroughStrategyFBExtension::initializePassthrough(XrSession session) {
+    if (session == XR_NULL_HANDLE)
+        return;
+
+    assert(OpenXRExtensions::sXrCreatePassthroughFB != nullptr && passthroughHandle == XR_NULL_HANDLE);
+
+    XrPassthroughCreateInfoFB passthroughCreateInfo = {
+            .type = XR_TYPE_PASSTHROUGH_CREATE_INFO_FB,
+            .flags = XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
+    };
+    CHECK_XRCMD(OpenXRExtensions::sXrCreatePassthroughFB(session, &passthroughCreateInfo, &passthroughHandle));
+}
+
+OpenXRPassthroughStrategy::HandleEventResult
+OpenXRPassthroughStrategyFBExtension::handleEvent(const XrEventDataBaseHeader& event) {
+    XrPassthroughStateChangedFlagsFB passthroughState = reinterpret_cast<const XrEventDataPassthroughStateChangedFB&>(event).flags;
+    HandleEventResult result = HandleEventResult::NoError;
+
+    if ((passthroughState & XR_PASSTHROUGH_STATE_CHANGED_REINIT_REQUIRED_BIT_FB) ||
+        (passthroughState & XR_PASSTHROUGH_STATE_CHANGED_NON_RECOVERABLE_ERROR_BIT_FB)) {
+        result = HandleEventResult::NonRecoverableError;
+        mIsInErrorState = true;
+        if (passthroughHandle != XR_NULL_HANDLE) {
+            CHECK_XRCMD(OpenXRExtensions::sXrDestroyPassthroughFB (passthroughHandle));
+            passthroughHandle = XR_NULL_HANDLE;
+        }
+    }
+    if (passthroughState & XR_PASSTHROUGH_STATE_CHANGED_REINIT_REQUIRED_BIT_FB) {
+        result = HandleEventResult::NeedsReinit;
+        mIsInErrorState = false;
+    } else if ((passthroughState & XR_PASSTHROUGH_STATE_CHANGED_RESTORED_ERROR_BIT_FB)) {
+        mIsInErrorState = false;
+    } else {
+        // XR_PASSTHROUGH_STATE_CHANGED_RECOVERABLE_ERROR_BIT_FB
+        mIsInErrorState = true;
+    }
+    return result;
+}
+
+bool
+OpenXRPassthroughStrategyFBExtension::isReady() const {
+    return !mIsInErrorState && passthroughHandle != XR_NULL_HANDLE;
+}
+
+OpenXRLayerPassthroughPtr
+OpenXRPassthroughStrategyFBExtension::createLayerIfSupported(VRLayerPassthroughPtr vrLayer) const {
+    return OpenXRLayerPassthrough::Create(vrLayer, passthroughHandle);
+}
 
 XrEnvironmentBlendMode
 OpenXRPassthroughStrategyUnsupported::environmentBlendModeForPassthrough() const {

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include <openxr/openxr.h>
+#include "OpenXRLayers.h"
 
 namespace crow {
 
@@ -11,9 +12,16 @@ typedef std::unique_ptr<OpenXRPassthroughStrategy> PassthroughStrategyPtr;
 
 class OpenXRPassthroughStrategy {
 public:
+enum class HandleEventResult { NoError, NonRecoverableError, NeedsReinit };
+virtual void initializePassthrough(XrSession) {}
 virtual bool usesCompositorLayer() const { return false; }
 virtual XrEnvironmentBlendMode environmentBlendModeForPassthrough() const = 0;
+virtual HandleEventResult handleEvent(const XrEventDataBaseHeader&) { return HandleEventResult::NoError; };
 virtual ~OpenXRPassthroughStrategy() = default;
+virtual bool isReady() const { return mIsInErrorState; };
+virtual OpenXRLayerPassthroughPtr createLayerIfSupported(VRLayerPassthroughPtr) const;
+protected:
+bool mIsInErrorState { false };
 };
 
 class OpenXRPassthroughStrategyUnsupported : public OpenXRPassthroughStrategy {
@@ -22,9 +30,17 @@ XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override;
 };
 
 class OpenXRPassthroughStrategyFBExtension : public OpenXRPassthroughStrategy {
+public:
+~OpenXRPassthroughStrategyFBExtension();
 private:
+void initializePassthrough(XrSession) override;
 bool usesCompositorLayer() const override { return true; }
 XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_OPAQUE; };
+HandleEventResult handleEvent(const XrEventDataBaseHeader&) override;
+bool isReady() const override;
+OpenXRLayerPassthroughPtr createLayerIfSupported(VRLayerPassthroughPtr) const override;
+
+XrPassthroughFB passthroughHandle { XR_NULL_HANDLE };
 };
 
 class OpenXRPassthroughStrategyBlendMode : public OpenXRPassthroughStrategy {

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+
+#include <openxr/openxr.h>
+
+namespace crow {
+
+class OpenXRPassthroughStrategy;
+typedef std::unique_ptr<OpenXRPassthroughStrategy> PassthroughStrategyPtr;
+
+class OpenXRPassthroughStrategy {
+public:
+virtual bool usesCompositorLayer() const { return false; }
+virtual XrEnvironmentBlendMode environmentBlendModeForPassthrough() const = 0;
+virtual ~OpenXRPassthroughStrategy() = default;
+};
+
+class OpenXRPassthroughStrategyUnsupported : public OpenXRPassthroughStrategy {
+private:
+XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override;
+};
+
+class OpenXRPassthroughStrategyFBExtension : public OpenXRPassthroughStrategy {
+private:
+bool usesCompositorLayer() const override { return true; }
+XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_OPAQUE; };
+};
+
+class OpenXRPassthroughStrategyBlendMode : public OpenXRPassthroughStrategy {
+private:
+XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND; };
+};
+
+} // namespace crow


### PR DESCRIPTION
This PR generalizes the passthrough code by means of an strategy pattern. The different strategies allow us to do:
1. no passthrough
1. passthrough via FB extension
1. passthrough via `XrFrameEndInfo.environmentBlendMode`

Some others could be added in the future too. The first step was to migrate the current code (option 2.) to the strategy pattern. Then we added option 3. It basically adds support for doing passthrough by setting the `XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND` to the `environmentBlendMode` attribute of the `XrFrameEndInfo` structure. That works fine for Lynx so this PR is also enabling passthrough for Lynx as well via this new strategy.