### PR TITLE
Use the ModuleVersionSelector's name field to narrow down the dependency group

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -660,8 +660,9 @@ dependencies {
         // are the culprit and define their dependencies so that we can let gradle to resolve them automatically.
         // See https://docs.gradle.org/current/userguide/dependency_resolution.html for details.
          resolutionStrategy.eachDependency { details ->
-            if (details.requested.group == 'org.jetbrains.kotlin') {
-                details.useVersion '1.4.10'
+            if (details.requested.group == 'org.jetbrains.kotlin'
+                    && details.requested.name.contains('kotlin-stdlib')) {
+                details.useVersion '1.4.10';
             } else if (details.requested.group == 'org.jetbrains.kotlinx'
                     && details.requested.name.contains('coroutines')) {
                 details.useVersion '1.4.2'


### PR DESCRIPTION
in the PR#621 we have defined some dependency conflict resolution rules to address the problems we have with the release builds. However, we defined a rule to substitute the versions of the modules in conflict that belong to the 'org.jetbrains.kotlin' group. This rule included dependencies that we shouldn't resolve that way.

This PR narrows down the dependency selection so that the rules applies only to the 'kotlin-stdlib' and 'kotlin-stdlib-jdk8' modules.