### PR TITLE
Basic navigation UI in kiosk mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -668,11 +668,11 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
     public void onKioskMode(WindowWidget aWindow, boolean isKioskMode) {
         if (isKioskMode) {
             mTrayViewModel.setShouldBeVisible(false);
-            hide(KEEP_WIDGET);
         } else {
             mTrayViewModel.setShouldBeVisible(true);
-            show(KEEP_FOCUS);
         }
+        updateUI();
+        mSettingsViewModel.refresh();
     }
 
     @Override
@@ -823,7 +823,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         }
         AnimationHelper.fadeOut(mBinding.navigationBarMenu.resizeModeContainer, 0, () -> onWidgetUpdate(mAttachedWindow));
         mWidgetManager.popBackHandler(mResizeBackHandler);
-        mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isFullScreen() || !mAttachedWindow.isKioskMode());
+        mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isFullScreen() && !mAttachedWindow.isKioskMode());
         closeFloatingMenus();
 
         if (aResizeAction == ResizeAction.KEEP_SIZE) {

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -54,7 +54,8 @@
             android:layout_weight="1"
             android:src="@drawable/ic_icon_home"
             android:tooltipText="@string/home_tooltip"
-            app:privateMode="@{viewmodel.isPrivateSession}"/>
+            app:privateMode="@{viewmodel.isPrivateSession}"
+            app:visibleGone="@{!viewmodel.isKioskMode}" />
 
         <com.igalia.wolvic.ui.views.NavigationURLBar
             android:id="@+id/urlBar"
@@ -63,7 +64,16 @@
             android:layout_gravity="center_vertical"
             android:layout_marginStart="10dp"
             android:layout_weight="100"
-            android:orientation="horizontal"/>
+            android:orientation="horizontal"
+            app:visibleGone="@{!viewmodel.isKioskMode}" />
+
+        <Space
+            android:id="@+id/urlBarPlaceholder"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:layout_marginStart="10dp"
+            android:layout_weight="100"
+            app:visibleGone="@{viewmodel.isKioskMode}" />
 
         <com.igalia.wolvic.ui.views.UIButton
             android:id="@+id/desktopModeButton"
@@ -74,7 +84,7 @@
             android:src="@drawable/ic_icon_ua_desktop"
             android:tooltipText="@string/hamburger_menu_switch_to_desktop"
             app:privateMode="@{viewmodel.isPrivateSession}"
-            app:visibleGone="@{viewmodel.isDesktopMode}" />
+            app:visibleGone="@{viewmodel.isDesktopMode &amp;&amp; !viewmodel.isKioskMode}" />
 
         <RelativeLayout
             android:layout_width="40dp"
@@ -83,13 +93,15 @@
             android:layout_marginStart="10dp"
             android:scaleType="fitCenter"
             android:layout_gravity="center_vertical"
-            app:visibleGone="@{settingsmodel.isWhatsNewVisible &amp;&amp; viewmodel.width > 640}">
+            app:visibleGone="@{settingsmodel.isWhatsNewVisible &amp;&amp; viewmodel.width > 640 &amp;&amp; !viewmodel.isKioskMode}">
+
             <com.igalia.wolvic.ui.views.UIButton
                 android:id="@+id/whatsNew"
                 style="?attr/navigationBarButtonStyle"
                 android:src="@drawable/ic_whats_new"
                 android:tooltipText="@string/whats_new_tooltip"
-                app:privateMode="@{viewmodel.isPrivateSession}"/>
+                app:privateMode="@{viewmodel.isPrivateSession}" />
+
             <com.google.android.material.textview.MaterialTextView
                 android:layout_width="6dp"
                 android:layout_height="6dp"


### PR DESCRIPTION
Enable basic navigation controls in kiosk mode:
Back, Forward, and Reload.

Also enable a simpler menu, which in kiosk mode
only contains Resize and Passthrough.