### PR TITLE
Restrict context menus in kiosk mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1634,6 +1634,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             return;
         }
 
+        // We don't show the menu in kiosk mode
+        if (isKioskMode()) {
+            return;
+        }
+
         mContextMenu = new ContextMenuWidget(getContext());
         mContextMenu.mWidgetPlacement.parentHandle = getHandle();
         mContextMenu.setDismissCallback(this::hideContextMenus);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/SelectionActionWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/SelectionActionWidget.java
@@ -152,7 +152,9 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
                     WSession.SelectionActionDelegate.ACTION_SELECT_ALL, this::handleAction));
         }
 
-        if (mSelectionText != null && !mSelectionText.trim().isEmpty()) {
+        // Contextual search is disabled in kiosk mode.
+        if (!mWidgetManager.getWindows().getFocusedWindow().isKioskMode() &&
+                mSelectionText != null && !mSelectionText.trim().isEmpty()) {
             buttons.add(createButton(
                     getContext().getString(
                             R.string.context_menu_web_search,


### PR DESCRIPTION
Disable menus with functionality that does not make sense in kiosk mode:

- search selected text
- link menu (download link, open in new tab/window, etc.)