### PR TITLE
Define remote environments in the props.json file 

### DIFF
--- a/props.json
+++ b/props.json
@@ -1,4 +1,15 @@
 {
+  "1.5.1": {
+    "whatsNewUrl": "https://wolvic.com/blog/release_1.5.1"
+    "environments": [
+      {
+        "value": "spring",
+        "title": "Spring",
+        "thumbnail": "https://igalia.github.io/wolvic-3D-environments/spring/spring.png",
+        "payload": "https://igalia.github.io/wolvic-3D-environments/spring/spring.zip"
+      }
+    ]
+  },
   "1.5": {
     "whatsNewUrl": "https://wolvic.com/blog/release_1.5"
   },


### PR DESCRIPTION
In FirefoxReality there was the possibility of retrieving environments from the github page of a repository. We use the props.json file we can now define for each Wolvic's version a structure with the following information of the environments we offer to the user:

  {
        "value": "spring",
        "title": "Spring",
        "thumbnail": "https://igalia.github.io/wolvic-3D-environments/spring/spring.png",
        "payload": "https://igalia.github.io/wolvic-3D-environments/spring/spring.zip"
  }

The dialog we have in the Wolvic's settings will show all options for all the entries defined in the corresponding version, downloading just the thumbnail. Once the user select an option, a download tasks is queued and only once it finished, the new env will be loaded.
