### PR TITLE
Add a "_srgb_ suffix to the Environments payload's URL for Oculus devices

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
@@ -215,6 +215,21 @@ public class EnvironmentUtils {
     }
 
     /**
+     * Returns the URL to the environment's payload, with the SRGB suffix for the devices requiring this
+     * compressed texture format.
+     * @param env An Environment data structure
+     * @return The appropriated URL to the environment's payload .
+     */
+    @Nullable
+    public static String getEnvironmentPayload(Environment env) {
+        String payload = env.getPayload();
+        if (!DeviceType.isOculusBuild())
+            return payload;
+        int at = payload.lastIndexOf(".");
+        return payload.substring(0, at) + "_srgb" + payload.substring(at);
+    }
+
+    /**
      * Retuns the external environment based for a given environment id. It returns the environment
      * for the current version if the environment exists, otherwise it returns the environment with that id
      * for the most recent previous version.
@@ -289,7 +304,7 @@ public class EnvironmentUtils {
                 RemoteProperties versionProperties = properties.get(versionName);
                 if (versionProperties != null && versionProperties.getEnvironments() != null) {
                     return Arrays.stream(versionProperties.getEnvironments())
-                            .filter(environment -> payloadUrl.equals(environment.getPayload()))
+                            .filter(environment -> payloadUrl.equals(getEnvironmentPayload(environment)))
                             .findFirst()
                             .orElse(null);
                 }
@@ -303,7 +318,7 @@ public class EnvironmentUtils {
                 RemoteProperties props = properties.get(key);
                 if (props != null && props.getEnvironments() != null) {
                     return Arrays.stream(props.getEnvironments())
-                            .filter(environment -> payloadUrl.equals(environment.getPayload()))
+                            .filter(environment -> payloadUrl.equals(getEnvironmentPayload(environment)))
                             .findFirst()
                             .orElse(null);
                 }

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
@@ -114,6 +114,7 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
 
     private void downloadEnvironment(@NonNull String envId) {
         final Environment environment = EnvironmentUtils.getExternalEnvironmentById(mContext, envId);
+        final String payload = EnvironmentUtils.getEnvironmentPayload(environment);
         if (environment != null) {
             // Check if the env is being downloaded
             boolean isDownloading = mDownloadManager.getDownloads().stream()
@@ -121,12 +122,12 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
                             item.getStatus() == DownloadManager.STATUS_RUNNING &&
                                     item.getStatus() == DownloadManager.STATUS_PAUSED &&
                                     item.getStatus() == DownloadManager.STATUS_PENDING &&
-                                    item.getUri().equals(environment.getPayload()))
+                                    item.getUri().equals(payload))
                     .findFirst().orElse(null) != null;
 
             if (!isDownloading) {
                 // If the env is not being downloaded, start downloading it
-                DownloadJob job = DownloadJob.create(environment.getPayload());
+                DownloadJob job = DownloadJob.create(payload);
                 mDownloadManager.startDownload(job);
             }
         }


### PR DESCRIPTION
The Oculus devices require the textures to be in the sRGB color space. Hence we would require the Environments payload's URL to include a _srgb_ suffix in the ZIP's filename. We want this to download just the files required for each device.

The functionality this PR provides depends on PR#633 (to be applied to the gh-pages branch), although there is no problem at all to merge them in any order.