### PR TITLE
Reenable WebVR support

### DIFF
--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -8,7 +8,7 @@
 #  - "/path/to/gecko-profile"
 #
 prefs:
-  dom.vr.enabled: false
+  dom.vr.enabled: true
   dom.gamepad.extensions.enabled: true
   dom.vr.external.enable: true
   dom.vr.webxr.enabled: true


### PR DESCRIPTION
We have been traditionally disabling WebVR support because we don't want to support an already deprecated spec. We do actually thought about that as a way to "force" people to migrate to WebXR.

At the same time there is a lot of WebVR content still out there and people have to switch to other browsers that are still supporting them. The web have traditionally been backwards compatible so that's another point in favour.

We don't plan to offer WebVR support but at least we want to support already existing content.

Fixes #611, #263, #224, #221