### PR TITLE
Workaround a bug in Lynx stage space

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -976,6 +976,9 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
           m.immersiveDisplay->SetSittingToStandingTransform(
                   vrb::Matrix::Translation(kAverageHeight));
       }
+#elif LYNX
+      // Stage space coordinates are wrong. As an example the returned Y value is 0.008.
+      m.immersiveDisplay->SetSittingToStandingTransform(vrb::Matrix::Translation(kAverageHeight * 0.7));
 #endif
     }
 


### PR DESCRIPTION
The stage space transform pose is buggy in Lynx. As an example these are the position values returned by Lynx runtime:
    -0.078508 -0.008649 0.234955
compared to the values returned by Meta Quest2:
    -0.150562 1.199420 -0.134182

The fact that the Y value is -0.008649 makes the view inside WebXR experiences appear slightly bellow the floor level.