### PR TITLE
[Regression] Fix background dimming on fullscreen videos

### DIFF
--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -102,7 +102,7 @@ public:
       xrLayer->next = XR_NULL_HANDLE;
 
       if (mCompositionLayerColorScaleBias != XR_NULL_HANDLE)
-        PushNextXrStructureInChain((XrBaseInStructure&)xrLayer, (XrBaseInStructure&)*mCompositionLayerColorScaleBias);
+        PushNextXrStructureInChain((XrBaseInStructure&)*xrLayer, (XrBaseInStructure&)*mCompositionLayerColorScaleBias);
     }
   }
 


### PR DESCRIPTION
In 0ef55bc7 we added a new method called PushNextXrStructureInChain to easily append structures to the "next" pointer on an structure chain. This kind of structures are tipically used to setup extensions.

We did that, among other things, to support the CompositionLayerColorScaleBias extension that allowed us to do background diming on videos in OpenXR as we used to do with OculusVR backend. The problem is that we didn't pass the right pointer to that method so that the structure was not really added to where it should.

Fixes #646 