### PR TITLE
Enable passthrough for the Snapdragon spaces runtime

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1855,7 +1855,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public boolean isPassthroughSupported() {
-        return DeviceType.isOculusBuild() || DeviceType.isLynx();
+        return DeviceType.isOculusBuild() || DeviceType.isLynx() || DeviceType.isSnapdragonSpaces();
     }
 
     @Override

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -256,8 +256,10 @@ struct DeviceDelegateOpenXR::State {
     if (passthroughProperties.supportsPassthrough) {
         passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyFBExtension>();
     } else {
-#if defined(LYNX) || defined(SPACES)
+#if defined(LYNX)
         passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyBlendMode>();
+#elif defined(SPACES)
+        passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyNoSkybox>();
 #else
         passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyUnsupported>();
 #endif

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
@@ -48,4 +48,10 @@ private:
 XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND; };
 };
 
+// This strategy is intended for runtimes that show a transparent environment when the skybox layer is not rendered.
+class OpenXRPassthroughStrategyNoSkybox : public OpenXRPassthroughStrategy {
+private:
+XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_OPAQUE; };
+};
+
 } // namespace crow


### PR DESCRIPTION
This PR adds the Snapdragon devices to the list of the ones with Passthrough support. This will make the appropriated menu item to be visible in the hamburger menu. 

The Snapdragon devices were using the OpenXRPassthroughStrategyBlendMode strategy, which uses the  XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND flag in the XrFrameEndInfo data structure. Unfortunately, the runtime doesn't support this flag. 

A new  OpenXRPassthroughStrategyNoSkybox class for the strategy pattern is defined for this case, which assigns a XR_ENVIRONMENT_BLEND_MODE_OPAQUE flag (the default) instead.  

In order to activate the passthrough is enough to avoid rendering the cube layer with the skybox, so that the runtime draws a transparent background. 