### PR TITLE
Revert "Reenable WebVR support"

### DIFF
--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -8,7 +8,7 @@
 #  - "/path/to/gecko-profile"
 #
 prefs:
-  dom.vr.enabled: true
+  dom.vr.enabled: false
   dom.gamepad.extensions.enabled: true
   dom.vr.external.enable: true
   dom.vr.webxr.enabled: true


### PR DESCRIPTION
Reverts Igalia/wolvic#636

We were never really happy to reenable WebVR. We just did it in order not to limit users to access old VR content. But two things happened that made us reconsider us that position
1. Meta Browser does not offer support for WebVR, so users won't expect WebVR content to run just because "it runs in the Meta browser"
2. Several sites that started to work with WebVR enabled, do actually work with WebXR **if** we pretend to be the Meta browser. So again we've hit the wall of UA filtering.