### PR TITLE
Revert "Remove WAKE_LOCK and FOREGROUND_SERVICE permissions"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="com.igalia.wolvic">
     <uses-feature android:glEsVersion="0x00030000"/>
 
@@ -14,10 +13,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
-
-    <!-- Requested by GeckoView but not needed in VR -->
-    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
 
     <permission android:name="${applicationId}.CRASH_RECEIVER_PERMISSION"
                 android:protectionLevel="signature"/>

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -14,6 +14,10 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
 
+    <!-- Requested by GeckoView but not needed in VR -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
+
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -16,6 +16,10 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
 
+    <!-- Requested by GeckoView but not needed in VR -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
+
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 


### PR DESCRIPTION
Reverts Igalia/wolvic#490

This causes crashes in some platforms when the screen goes off (for example after unwearying the glasses for some time) because the application has not the `WAKE_LOCK` permissions. Does not happen in Meta so we can keep the previous version of the code that removed them just for Meta platform