### PR TITLE
Add the right WebXR input profiles for Pico4 and Pico4E

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -245,7 +245,7 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
       result = mozilla::gfx::VRControllerType::PicoNeo2;
       break;
     case device::PicoXR:
-      result = mozilla::gfx::VRControllerType::PicoNeo2;
+      result = mozilla::gfx::VRControllerType::Pico4;
       break;
     case device::UnknownType:
     default:

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -151,6 +151,7 @@ enum class VRControllerType : uint8_t {
   PicoGaze,
   PicoG2,
   PicoNeo2,
+  Pico4,
   _end
 };
 

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -227,7 +227,7 @@ namespace crow {
             "vr_controller_pico4_left.obj",
             "vr_controller_pico4_right.obj",
             device::PicoXR,
-            std::vector<OpenXRInputProfile> { "generic-trigger-squeeze-thumbstick" },
+            std::vector<OpenXRInputProfile> { "pico-4", "generic-trigger-squeeze-thumbstick" },
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
                     { OpenXRButtonType::Squeeze, kPathSqueeze, OpenXRButtonFlags::Value, OpenXRHandFlags::Both },
@@ -253,7 +253,7 @@ namespace crow {
             "vr_controller_pico4_left.obj",
             "vr_controller_pico4_right.obj",
             device::PicoXR,
-            std::vector<OpenXRInputProfile> { "generic-trigger-squeeze-thumbstick" },
+            std::vector<OpenXRInputProfile> { "pico-4", "generic-trigger-squeeze-thumbstick" },
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
                     { OpenXRButtonType::Squeeze, kPathSqueeze, OpenXRButtonFlags::Value, OpenXRHandFlags::Both },


### PR DESCRIPTION
They have been added to the WebXR repo here
https://github.com/immersive-web/webxr-input-profiles/blob/main/packages/registry/profiles/pico/pico-4.json

Gecko didn't have support for them, so we had to add them to our Gecko branch too
https://github.com/Igalia/gecko-dev/commit/13155ba80b0afb3b6dd8e7ed8dcbede2decde8bb.