### PR TITLE
[PicoXR] Enable WAKE_LOCK permission to allow app resuming

### DIFF
--- a/app/src/picoxr/AndroidManifest.xml
+++ b/app/src/picoxr/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.igalia.wolvic" xmlns:tools="http://schemas.android.com/tools">
     <uses-feature android:glEsVersion="0x00030001"/>
     <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" />
+    <!-- Required in Pico platform to avoid a crash during app resuming -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="replace"/>
 
     <application>
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">


### PR DESCRIPTION
Otherwise application will crash due to the lack of that permission whenever the application has to be resumed (for example after being paused because the user removed the headset. This permission was removed in the past because it was a requirement from the Meta Store. We thought we could remove it for all the platforms but apparently this is a real problem only for Pico.

This is the exception for reference
  2023-05-11 12:24:57.396 31860-31860 E/AndroidRuntime: FATAL EXCEPTION: main
      Process: com.igalia.wolvic.dev, PID: 31860
      java.lang.RuntimeException: Unable to resume activity {com.igalia.wolvic.dev/com.igalia.wolvic.VRBrowserActivity}:
      java.lang.SecurityException: Neither user 10191 nor current process has android.permission.WAKE_LOCK.
          at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4413)
          at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4445)
          at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
          at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
          at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
          at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2151)
          at android.os.Handler.dispatchMessage(Handler.java:107)
          at android.os.Looper.loop(Looper.java:220)
          at android.app.ActivityThread.main(ActivityThread.java:7655)
          at java.lang.reflect.Method.invoke(Native Method)
          at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
          at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)