### PR TITLE
Set the correct trigger and squeeze button states when hands disappear

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -591,7 +591,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     jointTransforms.resize(mHandJoints.size());
     for (int i = 0; i < mHandJoints.size(); i++) {
         vrb::Matrix transform = XrPoseToMatrix(mHandJoints[i].pose);
-        bool positionIsValid = mHandJoints[i].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT;
+        bool positionIsValid = IsHandJointPositionValid((XrHandJointEXT) i);
 #if defined(SPACES)
         positionIsValid = shouldConsiderPoseAsValid(mHandJoints[i].pose);
 #endif
@@ -610,15 +610,15 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     bool leftPalmFacesHead = false;
     if (mHandeness == OpenXRHandFlags::Left) {
 #if defined(OCULUSVR)
-        if (mHandJoints[XR_HAND_JOINT_PALM_EXT].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT)
+        if (IsHandJointPositionValid(XR_HAND_JOINT_PALM_EXT))
             leftPalmFacesHead = !mHasAimState;
 #else
-        int palmJointIndex = XR_HAND_JOINT_PALM_EXT;
+        XrHandJointEXT palmJointIndex = XR_HAND_JOINT_PALM_EXT;
 #if defined(PICOXR)
         // Pico runtime doesn't provide palm joint info, so we use the wrist instead.
         palmJointIndex = XR_HAND_JOINT_WRIST_EXT;
 #endif
-        if (mHandJoints[palmJointIndex].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) {
+        if (IsHandJointPositionValid(palmJointIndex)) {
             vrb::Vector vector = vrb::Vector(0.0f, 0.0f, 1.0f);
             vrb::Matrix palmMatrix = jointTransforms[palmJointIndex];
             vrb::Matrix headPalmMatrix = head.Inverse().PostMultiply(palmMatrix);
@@ -630,7 +630,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
 
     // Scale joints according to their radius (for rendering)
     for (int i = 0; i < mHandJoints.size(); i++) {
-        if (mHandJoints[i].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) {
+        if (IsHandJointPositionValid((XrHandJointEXT) i)) {
             float radius = mHandJoints[i].radius;
             vrb::Matrix scale = vrb::Matrix::Identity().ScaleInPlace(
                     vrb::Vector(radius, radius, radius));

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -60,6 +60,7 @@ private:
     void UpdateHaptics(ControllerDelegate&);
     bool GetHandTrackingInfo(const XrFrameState&, XrSpace);
     float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
+    bool IsHandJointPositionValid(const enum XrHandJointEXT aJoint);
 
     XrInstance mInstance { XR_NULL_HANDLE };
     XrSession mSession { XR_NULL_HANDLE };


### PR DESCRIPTION
Since we introduce the ability to emulate controllers using the hands, with thumb+index pinch as trigger and thumb+middle pinch as squeeze, we never checked that these hand joints had valid position data, to properly calculate the distance between them.

This is causing that when hands are occluded or completely disappear, the joint data becomes invalid and we may incorrectly detect a pinch gesture. This results in a hand that is not active or visible, could lock the trigger or squeeze buttons in a pressed state, preventing the other hand or the controllers from getting the focus.

This patch makes sure that we detect a pinch gesture when the actual joints have valid positions, and always set the trigger and squeeze button states.

Fixes #655.