### PR TITLE
New 'user feedback' icon in the navigation bar

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -281,6 +281,11 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             }
         });
 
+        mBinding.navigationBarNavigation.userFeedbackButton.setOnClickListener(v -> {
+            v.requestFocusFromTouch();
+            mWidgetManager.openNewTabForeground(getResources().getString(R.string.feedback_link));
+        });
+
         mBinding.navigationBarNavigation.desktopModeButton.setOnClickListener(view -> {
             final int defaultUaMode = SettingsStore.getInstance(mAppContext).getUaMode();
             if (mHamburgerMenu != null) {

--- a/app/src/main/res/drawable/baseline_contact_support_24.xml
+++ b/app/src/main/res/drawable/baseline_contact_support_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11.5,2C6.81,2 3,5.81 3,10.5S6.81,19 11.5,19h0.5v3c4.86,-2.34 8,-7 8,-11.5C20,5.81 16.19,2 11.5,2zM12.5,16.5h-2v-2h2v2zM12.5,13h-2c0,-3.25 3,-3 3,-5 0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2h-2c0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,2.5 -3,2.75 -3,5z"/>
+</vector>

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -76,6 +76,17 @@
             app:visibleGone="@{viewmodel.isKioskMode}" />
 
         <com.igalia.wolvic.ui.views.UIButton
+            android:id="@+id/userFeedbackButton"
+            style="?attr/navigationBarButtonStyle"
+            android:layout_marginStart="10dp"
+            android:layout_weight="0"
+            android:checked="true"
+            android:src="@drawable/baseline_contact_support_24"
+            android:tooltipText="@string/user_feedback_tooltip"
+            app:privateMode="@{viewmodel.isPrivateSession}"
+            app:visibleGone="@{!viewmodel.isKioskMode}" />
+
+        <com.igalia.wolvic.ui.views.UIButton
             android:id="@+id/desktopModeButton"
             style="?attr/accentedNavigationBarButtonStyle"
             android:layout_marginStart="10dp"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -213,6 +213,7 @@
 
     <!-- Settings Survey link -->
     <string name="survey_link" translatable="false">https://github.com/Igalia/wolvic/issues/</string>
+    <string name="feedback_link" translatable="false">https://wolvic.com/en/report_an_issue.html</string>
 
     <!-- Phone UI links -->
     <string name="hvr_learn_more_url" translatable="false">https://consumer.huawei.com/cn/wearables/vr-glass/</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,6 +445,10 @@
         opens the Release Notes web site for the current app version. -->
     <string name="settings_whats_new">What’s New</string>
 
+    <!-- This string is for the tooltip that appears when the user hovers over the User Feedback' icon in the
+         Navigation Bar. The button it labels, when pressed, open the release notes page. -->
+    <string name="user_feedback_tooltip">Share ideas and feedback</string>
+
     <!-- This string is the title of a dialog box shown to the user when a settings
          change requires the application to restart. -->
     <string name="restart_dialog_restart">Restart Required</string>


### PR DESCRIPTION
We have created a site where the Wolvic's users may provide general feedback about the application, questions doubts or even complaints and request for new features or enhancements.

There will be a new permanent icon in the navigation bar, right after the url placeholder. Click events of this buttons will be handled by launching a new foreground tab where the above mentioned feedback site will be loaded.