### PR TITLE
Restore drawing the beam for hand tracking

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -526,7 +526,8 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
       controller.handMeshToggle->ToggleAll(controller.mode == ControllerMode::Hand);
 
     if (controller.beamToggle)
-      controller.beamToggle->ToggleAll(controller.mode == ControllerMode::Device && controller.hasAim);
+      controller.beamToggle->ToggleAll(controller.hasAim);
+
 
     if (controller.modelToggle)
       controller.modelToggle->ToggleAll(controller.mode == ControllerMode::Device);


### PR DESCRIPTION
We initially decided to remove it for hand tracking because we considered that it was a bit a nuisance. However testing with many different users demonstrate that it helps a lot because people usually have issues locating the pointers because they are only rendered when hitting a widget.