### PR TITLE
Automate application name change for hvr flavor in mainland China

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,6 +123,7 @@ android {
         buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "false"
         buildConfigField "Boolean", "KIOSK_MODE_ALWAYS", "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        resValue "string", "app_name_value", "Wolvic VR Browser"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14 -fexceptions -frtti -Werror" +
@@ -674,6 +675,12 @@ if (gradle.hasProperty('geckoViewLocalArm') || gradle.hasProperty('geckoViewLoca
 if(gradle.hasProperty("userProperties.openxr") && !gradle.startParameter.taskNames.isEmpty()){
     if (!(gradle.startParameter.taskNames.any { it.contains("Generic") }) && gradle."userProperties.openxr" == "false") {
         throw new GradleException('Cannot build a store flavor with openxr=false ')
+    }
+}
+
+if(!gradle.startParameter.taskNames.isEmpty()){
+    if (gradle.startParameter.taskNames.any { it.contains("Hvr") } && gradle.startParameter.taskNames.any { it.contains("Cn") }) {
+        android.defaultConfig.resValue "string", "app_name_value", "Wolvic"
     }
 }
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name" translatable="false">Wolvic VR Browser</string>
+    <string name="app_name" translatable="false">@string/app_name_value</string>
     <string name="bug_report_url" translatable="false">github.com/Igalia/wolvic/issues</string>
     <!-- You can test a local file using: "resource://android/assets/webvr/index.html" -->
     <string name="homepage_url" translatable="false">https://wolvic.com/start</string>


### PR DESCRIPTION
This pr fixes #653.This PR automates the application name change for the hvr flavor in mainland China. It adds a new resource value and modifies the build script to set the application name to "Wolvic" for the hvr flavor in mainland China, eliminating the need for manual replacements before generating packages.