### PR TITLE
Fix ability to trigger a pressed event during hand-tracking when no aim is enabled

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -661,12 +661,13 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
         indexPinching = indexThumbDistance < kPinchThreshold;
     }
     delegate.SetPinchFactor(mIndex, pinchFactor);
+    bool triggerButtonPressed = indexPinching && !leftPalmFacesHead && mHasAimState;
     delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_TRIGGER,
-                            device::kImmersiveButtonTrigger, indexPinching && !leftPalmFacesHead,
-                            indexPinching && !leftPalmFacesHead, 1.0);
+                            device::kImmersiveButtonTrigger, triggerButtonPressed,
+                            triggerButtonPressed, 1.0);
     if (leftPalmFacesHead) {
         delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_APP, -1, indexPinching, indexPinching, 1.0);
-    } else {
+    } else if (mHasAimState) {
         if (renderMode == device::RenderMode::Immersive && indexPinching != selectActionStarted) {
             selectActionStarted = indexPinching;
             if (selectActionStarted) {


### PR DESCRIPTION
This is a bug that was introduced recently while trying to fix a different issue (see https://github.com/Igalia/wolvic/pull/670).

The problem is that we are not considering the aim state when deciding when a pinch gesture should trigger or not a button press or a select action.