### PR TITLE
Smoothing filter for hand clicks

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -36,6 +36,10 @@ const float kPinchRange = kPinchStart - kPinchThreshold;
 // 0.7 is generally accepted as good for objects facing each other.
 const float kPalmHeadThreshold = 0.7;
 
+// We apply a exponential smoothing filter to the measured distance between index and thumb so we
+// avoid erroneous click and release events. This constant is the smoothing factor of said filter.
+const double kSmoothFactor = 0.5;
+
 OpenXRInputSourcePtr OpenXRInputSource::Create(XrInstance instance, XrSession session, OpenXRActionSet& actionSet, const XrSystemProperties& properties, OpenXRHandFlags handeness, int index)
 {
     OpenXRInputSourcePtr input(new OpenXRInputSource(instance, session, actionSet, properties, handeness, index));
@@ -628,8 +632,17 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
         IsHandJointPositionValid(XR_HAND_JOINT_INDEX_TIP_EXT)) {
         const double indexThumbDistance = GetDistanceBetweenJoints(XR_HAND_JOINT_THUMB_TIP_EXT,
                                                                    XR_HAND_JOINT_INDEX_TIP_EXT);
-        pinchFactor = 1.0 - std::clamp((indexThumbDistance - kPinchThreshold) / kPinchRange, 0.0, 1.0);
-        indexPinching = indexThumbDistance < kPinchThreshold;
+
+        // Apply a smoothing filter to reduce the number of phantom events.
+        auto smoothingFilter = [](double value) {
+            static double smoothValue = 0;
+            smoothValue = kSmoothFactor * value + (1 - kSmoothFactor) * smoothValue;
+            return smoothValue;
+        };
+        double smoothIndexThumbDistance = smoothingFilter(indexThumbDistance);
+
+        pinchFactor = 1.0 - std::clamp((smoothIndexThumbDistance - kPinchThreshold) / kPinchRange, 0.0, 1.0);
+        indexPinching = smoothIndexThumbDistance < kPinchThreshold;
     }
     delegate.SetPinchFactor(mIndex, pinchFactor);
     bool triggerButtonPressed = indexPinching && !leftPalmFacesHead && mHasAimState;


### PR DESCRIPTION
Apply a exponential smoothing filter to the measured distance between index and thumb so we can avoid erroneous click and release events in hand tracking.

 The smoothing factor of said filter is 0.5, which means that the output of the filter on each frame will be

    0.5 * current data point + 0.5 * accumulated smooth value