### PR TITLE
Update non_L10n.xml

### DIFF
--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -213,7 +213,7 @@
 
     <!-- Settings Survey link -->
     <string name="survey_link" translatable="false">https://github.com/Igalia/wolvic/issues/</string>
-    <string name="feedback_link" translatable="false">https://wolvic.com/en/report_an_issue.html</string>
+    <string name="feedback_link" translatable="false">https://wolvic.com/en/feedback.html</string>
 
     <!-- Phone UI links -->
     <string name="hvr_learn_more_url" translatable="false">https://consumer.huawei.com/cn/wearables/vr-glass/</string>


### PR DESCRIPTION
Changes the url of the feedback form so that it works (it changed and is now broken entirely).  I think this should probably lack the /en/ part but that currently doesn't actually work either so maybe we can at least merge it into parity with where it was working as of earlier today.