### PR TITLE
Add an extension-less method to compute the aim for hand tracking

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library( # Sets the name of the library.
              src/main/cpp/ExternalVR.cpp
              src/main/cpp/GestureDelegate.cpp
              src/main/cpp/JNIUtil.cpp
+             src/main/cpp/OneEuroFilter.cpp
              src/main/cpp/Pointer.cpp
              src/main/cpp/Skybox.cpp
              src/main/cpp/SplashAnimation.cpp

--- a/app/src/main/cpp/OneEuroFilter.cpp
+++ b/app/src/main/cpp/OneEuroFilter.cpp
@@ -1,0 +1,82 @@
+#include <cstring>
+#include <vrb/Quaternion.h>
+#include "OneEuroFilter.h"
+
+namespace crow {
+
+float* LowPassFilterQuaternion::filter(const float x[4], float alpha) {
+    if (firstTime) {
+        firstTime = false;
+        memcpy(mHatxprev, x, sizeof(float) * 4);
+    }
+
+    auto q = vrb::Quaternion::Slerp({mHatxprev[0],mHatxprev[1],mHatxprev[2],mHatxprev[3]}, {x[0],x[1],x[2],x[3]}, alpha).Normalize();
+    memcpy(mHatxprev, q.Data(), sizeof(float) * 4);
+    return mHatxprev;
+}
+
+float* LowPassFilterVector::filter(const float x[3], float alpha) {
+    if (firstTime) {
+        firstTime = false;
+        memcpy(mHatxprev, x, sizeof(float) * 3);
+    }
+
+    float hatx[3];
+    for (int i = 0; i < 3; ++i)
+        hatx[i] = alpha * x[i] + (1 - alpha) * mHatxprev[i];
+
+    memcpy(mHatxprev, hatx, sizeof(float) * 3);
+    return mHatxprev;
+}
+
+void
+VectorFilterable::setDxIdentity(float dx[3]) {
+    dx[0] = dx[1] = dx[2] = 0;
+}
+
+void
+VectorFilterable::computeDerivate(float dx[3], const float prev[3], const float current[3], float dt)
+{
+    for (int i = 0; i < 3; ++i)
+        dx[i] = (current[i] - prev[i]) / dt;
+}
+
+float
+VectorFilterable::computeDerivateMagnitude(const float dx[3]) {
+    float sqnorm = 0;
+    for (int i = 0; i < 3; ++i)
+        sqnorm += dx[i] * dx[i];
+    return sqrt(sqnorm);
+}
+
+void
+QuaternionFilterable::setDxIdentity(float dx[4]) {
+    dx[0] = dx[1] = dx[2] = 0;
+    dx[3] = 1;
+}
+
+void
+QuaternionFilterable::computeDerivate(float dx[4], const float prev[4], const float current[4], float dt) {
+    vrb::Quaternion qPrev(prev);
+    vrb::Quaternion qCurrent(current);
+    auto qdx = qCurrent * qPrev.Inverse();
+
+    // nlerp instead of slerp
+    float rate = 1.0 / dt;
+    qdx.x() *= rate;
+    qdx.y() *= rate;
+    qdx.z() *= rate;
+    qdx.w() = qdx.w() * rate + (1.0 - rate);
+    qdx = qdx.Normalize();
+
+    memcpy(dx, qdx.Data(), sizeof(float) * 4);
+}
+
+float
+QuaternionFilterable::computeDerivateMagnitude(const float dx[4]) {
+    /// Should be safe since the quaternion we're given has been normalized.
+    return 2.0 * acos(static_cast<float>(dx[3]));
+}
+
+
+} // namespace crow

--- a/app/src/main/cpp/OneEuroFilter.h
+++ b/app/src/main/cpp/OneEuroFilter.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <cstdint>
+
+namespace crow {
+
+// This is an implementation of the 1€ filter https://gery.casiez.net/1euro/ by Géry Casiez, Nicolas
+// Roussel, and Daniel Vogel. The 1€ filter is a simple algorithm to filter noisy signals for high
+// precision and responsiveness. It uses a first order low-pass filter with an adaptive cutoff
+// frequency: at low speeds, a low cutoff stabilizes the signal by reducing jitter, but as speed
+// increases, the cutoff is increased to reduce lag. The algorithm is easy to implement, uses very
+// few resources, and with two easily understood parameters, it is easy to tune. In a comparison
+// with other filters, the 1 € filter has less lag using a reference amount of jitter reduction.
+
+// This code was inspired by the template implementation https://gery.casiez.net/1euro/1efilter.cc
+// and specific code for quaternions https://github.com/vrpn/vrpn/blob/master/vrpn_OneEuroFilter.h
+
+template<typename Filterable, int SIZE>
+class OneEuroFilter {
+public:
+
+OneEuroFilter(float mincutoff, float beta, float dcutoff)
+    : mincutoff(mincutoff)
+    , dcutoff(dcutoff)
+    , beta(beta) {};
+
+OneEuroFilter()
+    : mincutoff(1)
+    , dcutoff(1)
+    , beta(0.5) {};
+
+float* filter(int64_t timestamp, const float x[SIZE]) {
+    float dx[SIZE];
+
+    // Timestamp is expressed in nanoseconds in OpenXR, the algorithm expects seconds.
+    float dt = float(timestamp - mPreviousDt) / float(1000000000);
+    mPreviousDt = timestamp;
+
+    if (firstTime) {
+        firstTime = false;
+        Filterable::setDxIdentity(dx);
+        dt = 0.000000001;
+    } else {
+        Filterable::computeDerivate(dx, xfilt.hatxprev(), x, dt);
+    }
+
+    auto computeAlpha = [](float dt, float cutoff) {
+        float tau = 1.0 / (2.0 * M_PI * cutoff);
+        return 1.0 / (1.0 + tau / dt);
+    };
+
+    float derivateMagnitude = Filterable::computeDerivateMagnitude(
+            dxfilt.filter(dx, computeAlpha(dt, dcutoff)));
+    float cutoff = mincutoff + beta * derivateMagnitude;
+
+    return xfilt.filter(x, computeAlpha(dt, cutoff));
+}
+
+private:
+int64_t mPreviousDt { 0 };
+bool firstTime {true };
+float mincutoff;
+float dcutoff;
+float beta;
+typename Filterable::Filter xfilt;
+typename Filterable::Filter dxfilt;
+};
+
+// This is not the low pass filter defined in the paper, but a different version suitable for
+// quaternions in which low pass filtering is reframed in terms of interpolation using SLERP
+// https://github.com/vrpn/vrpn/blob/master/vrpn_OneEuroFilter.h
+class LowPassFilterQuaternion {
+public:
+float* filter(const float x[4], float alpha);
+float* hatxprev() { return mHatxprev; }
+
+private:
+bool firstTime {true };
+float mHatxprev[4];
+};
+
+class LowPassFilterVector {
+public:
+float* filter(const float x[3], float alpha);
+float* hatxprev() { return mHatxprev; }
+
+private:
+bool firstTime {true };
+float mHatxprev[3];
+};
+
+class VectorFilterable {
+public:
+typedef LowPassFilterVector Filter;
+
+static void setDxIdentity(float dx[3]);
+static void computeDerivate(float dx[3], const float prev[3], const float current[3], float dt);
+static float computeDerivateMagnitude(const float dx[3]);
+
+};
+typedef OneEuroFilter<VectorFilterable, 3> OneEuroFilterVector;
+
+class QuaternionFilterable {
+public:
+typedef LowPassFilterQuaternion Filter;
+
+static void setDxIdentity(float dx[4]);
+static void computeDerivate(float dx[4], const float prev[4], const float current[4], float dt);
+static float computeDerivateMagnitude(const float dx[4]);
+
+};
+typedef OneEuroFilter<QuaternionFilterable, 4> OneEuroFilterQuaternion;
+
+} // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -5,6 +5,7 @@
 #include "OpenXRHelpers.h"
 #include "OpenXRActionSet.h"
 #include "ElbowModel.h"
+#include "OneEuroFilter.h"
 #include <optional>
 #include <unordered_map>
 
@@ -72,6 +73,7 @@ private:
     bool mHasAimState { false };
     vrb::Matrix mHandAimTransform;
     bool mSupportsFBHandTrackingAim { false };
+    std::unique_ptr<OneEuroFilterVector> mOneEuroFilterPosition;
 
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -40,7 +40,7 @@ private:
     XrResult applyHapticFeedback(XrAction, XrDuration, float = XR_FREQUENCY_UNSPECIFIED, float = 0.0) const;
     XrResult stopHapticFeedback(XrAction) const;
     void UpdateHaptics(ControllerDelegate&);
-    bool GetHandTrackingInfo(const XrFrameState&, XrSpace);
+    bool GetHandTrackingInfo(const XrFrameState&, XrSpace, const vrb::Matrix& head);
     float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
     bool IsHandJointPositionValid(const enum XrHandJointEXT aJoint);
 

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -70,7 +70,7 @@ private:
     std::array<XrHandJointLocationEXT, XR_HAND_JOINT_COUNT_EXT> mHandJoints;
     bool mHasHandJoints { false };
     bool mHasAimState { false };
-    XrPosef mHandAimPose;
+    vrb::Matrix mHandAimTransform;
     bool mSupportsFBHandTrackingAim { false };
 
 public:


### PR DESCRIPTION
So far we have two methods to compute the aim when using hand tracking:
* a Facebook extension: works pretty well but only supported in Meta and Pico so far
* the aim is computed from the orientation of a hand joint

The latter works but it isn't very good because a single joint has a lot of noise
(so the aim is very unstable) and also because is extremely sensitive to small
displacements.

Instead we provide a new method to compute the aim based on an ray that
goes from each shoulder (estimated) to the wrist of each hand. This makes the
aim ray way more stable. On top of that we're also adding the 1€ filter that helps
to reduce jitter.