### PR TITLE
[SPACES] Disable hand mesh rendering

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -529,7 +529,7 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
 
     // We don't use hand models for Pico because the runtime is giving us
     // incorrect data on some joints; instead, a sphere is drawn for each joint.
-#if !defined(PICOXR)
+#if !defined(PICOXR) && !defined(SPACES)
     // Lazy-load hand models
     if (controller.mode == ControllerMode::Hand && !controller.handMesh) {
       if (controllers->LoadHandMeshFromAssets(controller)) {

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -235,7 +235,7 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
     // Due to unstable or inaccurate hand-tracking data, hand mesh models
     // are not enabled on Pico devices. We are drawing a sphere for each joint
     // instead.
-#if defined(PICOXR)
+#if defined(PICOXR) || defined(SPACES)
     // Initialize hand joints if needed
     if (controller.handJointTransforms.size() == 0) {
         controller.handJointTransforms.resize(jointTransforms.size());

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -604,7 +604,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     // Scale joints according to their radius (for rendering). This is only
     // relevant for devices where we are using spheres to render the hands
     // instead of a proper hand model.
-#if defined(PICOXR)
+#if defined(PICOXR) || defined(SPACES)
     for (int i = 0; i < mHandJoints.size(); i++) {
         if (IsHandJointPositionValid((XrHandJointEXT) i)) {
             float radius = mHandJoints[i].radius;


### PR DESCRIPTION
The data we get from hand joints is not properly aligned. This makes the mesh look horrible,
so better use the alternate rendering path with spheres.