### PR TITLE
Add missing face of beam geometry

### DIFF
--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -187,6 +187,13 @@ ControllerContainer::InitializeBeam() {
   index.push_back(5);
   geometry->AddFace(index, uvIndex, index);
 
+  index.clear();
+  index.push_back(1);
+  index.push_back(2);
+  index.push_back(3);
+  index.push_back(4);
+  geometry->AddFace(index, uvIndex, index);
+
   m.beamModel = std::move(geometry);
   for (Controller& controller: m.list) {
     if (controller.beamParent) {


### PR DESCRIPTION
The handtracking beam is basically a very long and thin pyramid, with its base facing the user.

However, we were not drawing that pyramid's base, so the beam looked strange.

 This PR adds that missing face to the beam's geometry.