### PR TITLE
Declare Wolvic as a browser application in Android

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,12 +38,20 @@
             android:exported="true"
             android:configChanges="density|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
             android:windowSoftInputMode="stateAlwaysHidden">
+            <!-- Declares Wolvic as a browser app -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+            </intent-filter>
+            <!-- Used for the special wolvic:// links -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
                 <data
                     android:scheme="wolvic"
                     android:host="com.igalia.wolvic" />


### PR DESCRIPTION
This allows Wolvic to be listed in the Android's
"Settings->Apps->Default Apps->Browser app" menu. Once there users can select it
to be the default browser of the system to handle http and https schemas.

This has been broken for a while since we started to handle the special wolvic:// URLs.