### PR TITLE
New device detection

### DIFF
--- a/app/src/main/cpp/Device.h
+++ b/app/src/main/cpp/Device.h
@@ -6,7 +6,9 @@
 #ifndef VRBROWSER_DEVICE_H
 #define VRBROWSER_DEVICE_H
 
+#include <map>
 #include <stdint.h>
+#include "SystemUtils.h"
 
 namespace crow {
 namespace device {

--- a/app/src/main/cpp/DeviceUtils.cpp
+++ b/app/src/main/cpp/DeviceUtils.cpp
@@ -12,6 +12,8 @@
 
 namespace crow {
 
+std::unordered_map<std::string, device::DeviceType> DeviceUtils::deviceNamesMap;
+
 vrb::Matrix
 DeviceUtils::CalculateReorientationMatrix(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition) {
   const float kPitchUpThreshold = 0.2f;
@@ -109,6 +111,28 @@ vrb::GeometryPtr DeviceUtils::GetSphereGeometry(vrb::CreationContextPtr& context
     }
 
     return std::move(geometry);
+}
+
+device::DeviceType DeviceUtils::GetDeviceTypeFromSystem(bool is6DoF) {
+    char model[128];
+    int length = PopulateDeviceModelString(model);
+
+    if (deviceNamesMap.empty()) {
+        deviceNamesMap.emplace("Quest 2", device::OculusQuest2);
+        // So far no need to differentiate between Pico4 and Pico4E
+        deviceNamesMap.emplace("A8110", device::PicoXR);
+        deviceNamesMap.emplace("Lynx-R1", device::LynxR1);
+        deviceNamesMap.emplace("kirin9000", is6DoF ? device::HVR6DoF : device::HVR3DoF);
+        deviceNamesMap.emplace("motorola edge 30 pro", device::LenovoA3);
+        deviceNamesMap.emplace("Quest Pro", device::MetaQuestPro);
+    }
+
+    auto device = deviceNamesMap.find(model);
+    if (device == deviceNamesMap.end()) {
+        VRB_WARN("Device %s is not supported", model);
+        return device::UnknownType;
+    }
+    return device->second;
 }
 
 }

--- a/app/src/main/cpp/DeviceUtils.h
+++ b/app/src/main/cpp/DeviceUtils.h
@@ -9,6 +9,9 @@
 #include "vrb/MacroUtils.h"
 #include "vrb/Forward.h"
 #include "vrb/Geometry.h"
+#include "Device.h"
+
+#include <unordered_map>
 
 namespace crow {
 
@@ -26,7 +29,10 @@ public:
                                      const uint32_t aMaxWidth, const uint32_t aMaxHeight,
                                      uint32_t& aTargetWidth, uint32_t& aTargetHeight);
   static vrb::GeometryPtr GetSphereGeometry(vrb::CreationContextPtr& context, uint32_t resolution, float radius);
+  static device::DeviceType GetDeviceTypeFromSystem(bool is6DoF);
+
 private:
+  static std::unordered_map<std::string, device::DeviceType> deviceNamesMap;
   VRB_NO_DEFAULTS(DeviceUtils)
 };
 

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -226,6 +226,8 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
       // FIXME: GeckoView does not support Quest Pro yet. Pretend to be the Quest2
       result = mozilla::gfx::VRControllerType::OculusTouch3;
           break;
+    case device::HVR3DoF:
+    case device::HVR6DoF:
     case device::ViveFocus:
       result = mozilla::gfx::VRControllerType::HTCViveFocus;
       break;

--- a/app/src/main/cpp/SystemUtils.h
+++ b/app/src/main/cpp/SystemUtils.h
@@ -7,11 +7,17 @@
 namespace crow {
 
 #define ANDROID_OS_BUILD_ID "ro.build.id"
+#define ANDROID_OS_MODEL_ID "ro.product.vendor.model"
 
 // Get the Build ID of the current Android system.
 inline const char* GetBuildIdString(char* out) {
   __system_property_get(ANDROID_OS_BUILD_ID, out);
   return out;
+}
+
+// Retrieves the model name from Android OS. Returns the amount of chars of the model.
+inline int PopulateDeviceModelString(char* model) {
+  return __system_property_get(ANDROID_OS_MODEL_ID, model);
 }
 
 // Parse a version string into an array of integers of size resultSize.

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -120,7 +120,6 @@ namespace crow {
 
     struct OpenXRInputMapping {
         const char* const path { nullptr };
-        const char* const systemFilter {nullptr };
         DoF systemDoF;
         const char* const leftControllerModel { nullptr };
         const char* const rightControllerModel { nullptr };
@@ -138,7 +137,6 @@ namespace crow {
     // Oculus Touch v2:  https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/oculus/oculus-touch-v2.json
     const OpenXRInputMapping OculusTouch {
         "/interaction_profiles/oculus/touch_controller",
-        "Oculus Quest",
         IS_6DOF,
         "vr_controller_oculusquest_left.obj",
         "vr_controller_oculusquest_right.obj",
@@ -166,7 +164,6 @@ namespace crow {
     // Oculus Touch v3:  https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/oculus/oculus-touch-v3.json
     const OpenXRInputMapping OculusTouch2 {
             "/interaction_profiles/oculus/touch_controller",
-            "Oculus Quest2",
             IS_6DOF,
             "vr_controller_oculusquest2_left.obj",
             "vr_controller_oculusquest2_right.obj",
@@ -194,11 +191,10 @@ namespace crow {
     // Meta Quest Touch Pro: https://github.com/immersive-web/webxr-input-profiles/blob/main/packages/registry/profiles/meta/meta-quest-touch-pro.json
     const OpenXRInputMapping MetaQuestTouchPro {
             "/interaction_profiles/oculus/touch_controller",
-            "Meta Quest Pro",
             IS_6DOF,
             "vr_controller_metaquestpro_left.obj",
             "vr_controller_metaquestpro_right.obj",
-            device::OculusQuest2,
+            device::MetaQuestPro,
             std::vector<OpenXRInputProfile> { "meta-quest-touch-pro", "oculus-touch-v2", "oculus-touch", "generic-trigger-squeeze-thumbstick" },
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
@@ -222,7 +218,6 @@ namespace crow {
     // Pico controller: this definition was created for the Pico 4, but the Neo 3 will likely also be compatible
     const OpenXRInputMapping Pico4 {
             "/interaction_profiles/pico/neo3_controller",
-            "PICO 4",
             IS_6DOF,
             "vr_controller_pico4_left.obj",
             "vr_controller_pico4_right.obj",
@@ -248,7 +243,6 @@ namespace crow {
 
     const OpenXRInputMapping Pico4E {
             "/interaction_profiles/pico/neo3_controller",
-            "PICO 4 Enterprise",
             IS_6DOF,
             "vr_controller_pico4_left.obj",
             "vr_controller_pico4_right.obj",
@@ -275,11 +269,10 @@ namespace crow {
     // HVR 3DOF: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-trigger-touchpad.json
     const OpenXRInputMapping Hvr3DOF {
             "/interaction_profiles/huawei/controller",
-            "Haliday: G3HMD by Huawei",
             IS_3DOF,
             nullptr,
             "vr_controller_focus.obj",
-            device::ViveFocus,
+            device::HVR3DoF,
             std::vector<OpenXRInputProfile> { "generic-trigger-touchpad" },
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
@@ -296,11 +289,10 @@ namespace crow {
 
   const OpenXRInputMapping Hvr6DOF {
       "/interaction_profiles/huawei/6dof_controller",
-      "Haliday: G3HMD by Huawei",
       IS_6DOF,
       "hvr_6dof_left.obj",
       "hvr_6dof_right.obj",
-      device::OculusQuest,
+      device::HVR6DoF,
       std::vector<OpenXRInputProfile> { "oculus-touch-v3", "oculus-touch-v2", "oculus-touch", "generic-trigger-squeeze-thumbstick" },
       std::vector<OpenXRButton> {
           { OpenXRButtonType::ButtonX, kPathButtonX, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left },
@@ -328,7 +320,6 @@ namespace crow {
 
   const OpenXRInputMapping LynxR1 {
       "/interaction_profiles/khr/simple_controller",
-      "Monado: ",
       IS_6DOF,
       "vr_controller_oculusgo.obj",
       "vr_controller_oculusgo.obj",
@@ -342,11 +333,10 @@ namespace crow {
     // Default fallback: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-button.json
     const OpenXRInputMapping KHRSimple {
             "/interaction_profiles/khr/simple_controller",
-            nullptr,
             IS_3DOF,
             "vr_controller_oculusgo.obj",
             "vr_controller_oculusgo.obj",
-            device::OculusGo,
+            device::UnknownType,
             std::vector<OpenXRInputProfile> { "generic-button" },
             std::vector<OpenXRButton> {
                     { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::Click, OpenXRHandFlags::Both },

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -2,6 +2,7 @@
 #include "OpenXRExtensions.h"
 #include <assert.h>
 #include <unordered_set>
+#include "DeviceUtils.h"
 #include "SystemUtils.h"
 
 #if defined(PICOXR)


### PR DESCRIPTION
Use Android OS calls to properly retrieve the device types instead of the unreliable OpenXR's systemName