### PR TITLE
Disable zooming

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
@@ -43,6 +43,7 @@ object EngineProvider {
             builder.screenSizeOverride(settingsStore.maxWindowWidth, settingsStore.maxWindowHeight)
             builder.inputAutoZoomEnabled(false)
             builder.doubleTapZoomingEnabled(false)
+            builder.forceUserScalableEnabled(false)
             builder.debugLogging(settingsStore.isDebugLoggingEnabled)
             builder.consoleOutput(settingsStore.isDebugLoggingEnabled)
             builder.loginAutofillEnabled(settingsStore.isAutoFillEnabled)

--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -21,3 +21,5 @@ prefs:
   media.webspeech.synth.enabled: false
   # GPU process in Android broke WebXR. https://bugzilla.mozilla.org/show_bug.cgi?id=1771854
   layers.gpu-process.enabled: false
+  # disable zoom gestures
+  apz.allow_zooming: false


### PR DESCRIPTION
Even though we don't support changing the zoom level of a page, sometimes we get accidental zooms because of the way Gecko interprets motion events.

This change disables zooming by setting the apz.allow_zooming property to false.

Furthermore, we also set forceUserScalableEnabled to false.

Fixes https://github.com/Igalia/wolvic/issues/681