### PR TITLE
Fallback to KHR simple controller if none is found

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -88,7 +88,7 @@ XrResult OpenXRInputSource::Initialize()
     auto systemDoF = systemIs6DoF ? DoF::IS_6DOF : DoF::IS_3DOF;
     auto deviceType = DeviceUtils::GetDeviceTypeFromSystem(systemIs6DoF);
     for (auto& mapping: OpenXRInputMappings) {
-      if (deviceType != mapping.controllerType)
+      if (deviceType != mapping.controllerType && mapping.controllerType != device::UnknownType)
         continue;
 
       if (systemDoF != mapping.systemDoF)


### PR DESCRIPTION
We have recently changed the code that filters the available interaction profiles depending on the device type. The problem is that we regressed the case in which none matches. In that case we need to default to Khronos' simple controller profile.