### PR TITLE
Declare QuestPro as supported in the manifest

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
-        <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>
+        <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
             <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:supportsPictureInPicture="false"
         >
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
-        <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>
+        <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>
         <activity
             android:name=".VRBrowserActivity"
             android:launchMode="singleTask"


### PR DESCRIPTION
As advised here
https://developer.oculus.com/documentation/native/android/mobile-native-manifest/

There is the option of using "cambria" to support systems down to v42 but we really don't target such old versions.