### PR TITLE
Make passthrough work on release builds in Meta devices

### DIFF
--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -260,17 +260,29 @@ OpenXRLayerPassthrough::Init(JNIEnv *aEnv, XrSession session, vrb::RenderContext
     .flags = XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
     .purpose = XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB
   };
-  CHECK_XRCMD(OpenXRExtensions::sXrCreatePassthroughLayerFB(session, &layerCreateInfo, &xrLayer));
+  CHECK_XRCMD(OpenXRExtensions::sXrCreatePassthroughLayerFB(session, &layerCreateInfo, &mPassthroughLayerHandle));
   OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Init(aEnv, session, aContext);
 }
 
 void
+OpenXRLayerPassthrough::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) {
+  xrCompositionLayer = {
+          .type = XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB,
+          .next = XR_NULL_HANDLE,
+          .flags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT,
+          .space = XR_NULL_HANDLE,
+          .layerHandle = mPassthroughLayerHandle,
+  };
+  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Update(aSpace, aPose, aClearSwapChain);
+}
+
+void
 OpenXRLayerPassthrough::Destroy() {
-  if (xrLayer == XR_NULL_HANDLE)
+  if (mPassthroughLayerHandle == XR_NULL_HANDLE)
     return;
 
-  CHECK_XRCMD(OpenXRExtensions::sXrDestroyPassthroughLayerFB (xrLayer));
-  xrLayer = XR_NULL_HANDLE;
+  CHECK_XRCMD(OpenXRExtensions::sXrDestroyPassthroughLayerFB(mPassthroughLayerHandle));
+  mPassthroughLayerHandle = XR_NULL_HANDLE;
   OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Destroy();
 }
 

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -420,16 +420,19 @@ typedef std::shared_ptr<OpenXRLayerPassthrough> OpenXRLayerPassthroughPtr;
 
 class OpenXRLayerPassthrough : public OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB> {
   public:
-    XrPassthroughLayerFB xrLayer;
+    XrCompositionLayerPassthroughFB xrCompositionLayer;
 
     static OpenXRLayerPassthroughPtr
     Create(const VRLayerPassthroughPtr& aLayer, XrPassthroughFB);
     void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
+    void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
     void Destroy() override;
     bool IsDrawRequested() const override { return layer->IsDrawRequested(); };
+    bool IsValid() const { return mPassthroughLayerHandle != XR_NULL_HANDLE; }
 
 private:
     XrPassthroughFB mPassthroughInstance;
+    XrPassthroughLayerFB mPassthroughLayerHandle;
 };
 
 }


### PR DESCRIPTION
Passthrough support was added to meta some time ago using a FB extension. That extension required the creation of a XrCompositionLayerPassthroughFB that was passed to the compositor. That was working for debug builds but not for release ones. The reason why is because we were storing that object in a local variable that was freed after exiting its scope. It was not enough adding them to a vector because we're using a typecast for the compositor layer generic header.

Instead we now store that composition layer in the OpenXRLayerPassthrough. That requires us to implement the Update() method to initialize it properly before passing it to the compositor. That makes our passthrough layer identical to the other ones (as we were not using/overriding Update()).

Fixes #703