### PR TITLE
Avoid creating hand models renderer object when not used

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -240,7 +240,6 @@ struct BrowserWorld::State {
     blitter = ExternalBlitter::Create(create);
     fadeAnimation = FadeAnimation::Create(create);
     splashAnimation = SplashAnimation::Create(create);
-    handModelsRenderer = HandModels::Create(create);
     monitor = PerformanceMonitor::Create(create);
     monitor->AddPerformanceMonitorObserver(std::make_shared<PerformanceObserver>());
     wasInGazeMode = false;
@@ -532,9 +531,7 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
 #if !defined(PICOXR) && !defined(SPACES)
     // Lazy-load hand models
     if (controller.mode == ControllerMode::Hand && !controller.handMesh) {
-      if (controllers->LoadHandMeshFromAssets(controller)) {
-        handModelsRenderer->UpdateHandModel(controller);
-      }
+      controllers->LoadHandMeshFromAssets(controller);
     }
 #else
     if (controller.handMeshToggle)
@@ -1726,8 +1723,11 @@ BrowserWorld::DrawWorld(device::Eye aEye) {
 
   // Draw hand models
   for (Controller& controller: m.controllers->GetControllers()) {
-    if (controller.enabled && controller.mode == ControllerMode::Hand && controller.handMesh)
+    if (controller.enabled && controller.mode == ControllerMode::Hand && controller.handMesh) {
+      if (!m.handModelsRenderer)
+        m.handModelsRenderer = HandModels::Create(m.create);
       m.handModelsRenderer->Draw(*camera, controller);
+    }
   }
 
   // Draw controllers

--- a/app/src/main/cpp/HandModels.h
+++ b/app/src/main/cpp/HandModels.h
@@ -5,29 +5,27 @@
 
 #pragma once
 
-#include "vrb/ResourceGL.h"
-#include "ExternalVR.h"
+#include "Controller.h"
+#include "vrb/Camera.h"
 
 namespace crow {
 
 class HandModels;
 typedef std::shared_ptr<HandModels> HandModelsPtr;
 
-class HandModels : protected vrb::ResourceGL {
+class HandModels {
+protected:
+    struct State;
 public:
   static HandModelsPtr Create(vrb::CreationContextPtr& aContext);
   void Draw(const vrb::Camera& aCamera, const Controller& aController);
-  void UpdateHandModel(const Controller& aController);
-protected:
-  struct State;
   HandModels(State& aState, vrb::CreationContextPtr& aContext);
-  ~HandModels() = default;
-  void InitializeGL() override;
-  void ShutdownGL() override;
+  ~HandModels();
 private:
   State& m;
-  HandModels() = delete;
-  VRB_NO_DEFAULTS(HandModels)
+  void InitializeGL();
+  void ShutdownGL();
+  void UpdateHandModel(const Controller& aController);
 };
 
 } // namespace crow


### PR DESCRIPTION
Right now we are creating the *HandModelsRenderer* instance in all cases, even on devices that don't support hand-tracking at all, or where we are rendering joint spheres instead.

This patch makes *HandModelsRenderer* object be created lazily, right before rendering the hand models. At this point we already know that the device supports hand-tracking, and a hand mesh is enabled and already loaded for it.

The patch also removes *HandModelRenderer* class' inheritance from *vrb::ResourceGL*. The reason is that on ResourceGL objects, the OpenGL state is not initialized immediately, so it doesn't play well with us creating HandModelsRenderer lazily right before rendering.

Fixes #701.