### PR TITLE
Fix assert() on Mac compilation

### DIFF
--- a/app/src/main/cpp/HandModels.cpp
+++ b/app/src/main/cpp/HandModels.cpp
@@ -11,6 +11,7 @@
 #include "vrb/GLError.h"
 #include "vrb/Logger.h"
 #include "vrb/ShaderUtil.h"
+#include <assert.h>
 
 #define XR_EXT_HAND_TRACKING_NUM_JOINTS 26
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <array>
 #include <algorithm>
+#include <assert.h>
 #include <cstdlib>
 #include <unistd.h>
 #include <sstream>

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
@@ -3,6 +3,7 @@
 #include <vrb/Logger.h>
 #include "OpenXRExtensions.h"
 #include "OpenXRHelpers.h"
+#include <assert.h>
 
 namespace crow {
 


### PR DESCRIPTION
Compiling on Mac requires us to explicitly include the standard cassert header.