### PR TITLE
Fix auto-enable passthrough for the Lenovo A3

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -537,10 +537,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         } else {
             mTray.start(this);
         }
-        // TODO: Too early for runtimes using the passthrough layer.
-        if (DeviceType.getType() == DeviceType.LenovoA3) {
-            togglePassthrough();
-        }
     }
 
     @Override
@@ -1357,7 +1353,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Keep
     @SuppressWarnings("unused")
     private void setDeviceType(int aType) {
-        runOnUiThread(() -> DeviceType.setType(aType));
+        runOnUiThread(() -> {
+            DeviceType.setType(aType);
+            if (aType == DeviceType.LenovoA3) {
+                togglePassthrough();
+            }
+        });
     }
 
     @Keep


### PR DESCRIPTION
The Lenovo A3 should use passthrough mode by default as it's a see-through device.
We tried to toggle passthrough on app start but that's in general too early because 
the device type might not have been set. It's better to do it just after getting the 
proper device type from native code.