### PR TITLE
[OpenXR] Query&select environment blend modes from the runtime

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -104,6 +104,8 @@ struct DeviceDelegateOpenXR::State {
   bool reorientRequested { false };
   OpenXRLayerPassthroughPtr passthroughLayer { nullptr };
   PassthroughStrategyPtr passthroughStrategy;
+  XrEnvironmentBlendMode defaultBlendMode { XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM };
+  XrEnvironmentBlendMode passthroughBlendMode { XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM };
 
   bool IsPositionTrackingSupported() {
       CHECK(system != XR_NULL_SYSTEM_ID);
@@ -203,6 +205,8 @@ struct DeviceDelegateOpenXR::State {
     CHECK_XRCMD(xrGetSystem(instance, &systemInfo, &system));
     CHECK_MSG(system != XR_NULL_SYSTEM_ID, "Failed to initialize XRSystem");
 
+    deviceType = DeviceUtils::GetDeviceTypeFromSystem(IsPositionTrackingSupported());
+
     // If hand tracking extension is present, query whether the runtime actually supports it
     XrSystemHandTrackingPropertiesEXT handTrackingProperties{XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_EXT};
     handTrackingProperties.supportsHandTracking = XR_FALSE;
@@ -230,22 +234,16 @@ struct DeviceDelegateOpenXR::State {
     VRB_LOG("OpenXR runtime %s hand tracking", mHandTrackingSupported ? "does support" : "doesn't support");
     VRB_LOG("OpenXR runtime %s FB passthrough extension", passthroughProperties.supportsPassthrough ? "does support" : "doesn't support");
 
+    InitializeBlendModes();
     if (passthroughProperties.supportsPassthrough) {
         passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyFBExtension>();
     } else {
-#if defined(LYNX)
-        passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyBlendMode>();
-#elif defined(SPACES)
-        if (deviceType == device::LenovoA3)
-            passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyNoSkybox>();
-        else
+        CHECK(passthroughBlendMode != XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM);
+        if (passthroughBlendMode == XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND)
             passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyBlendMode>();
-#else
-        passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyUnsupported>();
-#endif
+        else
+            passthroughStrategy = std::make_unique<OpenXRPassthroughStrategyUnsupported>();
     }
-
-    deviceType = DeviceUtils::GetDeviceTypeFromSystem(IsPositionTrackingSupported());
   }
 
   // xrGet*GraphicsRequirementsKHR check must be called prior to xrCreateSession
@@ -305,6 +303,35 @@ struct DeviceDelegateOpenXR::State {
       eyeSwapChains.push_back(swapChain);
     }
     VRB_DEBUG("OpenXR available views: %d", (int)eyeSwapChains.size());
+  }
+
+  void InitializeBlendModes() {
+      CHECK(instance != XR_NULL_HANDLE);
+      CHECK(system != 0);
+
+      uint32_t count;
+      XrViewConfigurationType viewConfigurationType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+      CHECK_XRCMD(xrEnumerateEnvironmentBlendModes(instance, system, viewConfigurationType, 0, &count, nullptr));
+      CHECK(count > 0);
+
+      std::vector<XrEnvironmentBlendMode> blendModes(count);
+      CHECK_XRCMD(xrEnumerateEnvironmentBlendModes(instance, system, viewConfigurationType, count, &count, blendModes.data()));
+      VRB_LOG("OpenXR: %d supported blend mode%c", count, count > 1 ? 's' : ' ');
+      for (const auto& blendMode : blendModes)
+          VRB_LOG("\t%s", to_string(blendMode));
+
+      auto blendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+      const auto supportsOpaqueBlendMode = std::find(blendModes.begin(), blendModes.end(), blendMode) != blendModes.end();
+      blendMode = XR_ENVIRONMENT_BLEND_MODE_ADDITIVE;
+      const auto supportsAdditiveBlendMode = std::find(blendModes.begin(), blendModes.end(), blendMode) != blendModes.end();
+      blendMode = XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND;
+      const auto supportsAlphaBlendMode = std::find(blendModes.begin(), blendModes.end(), blendMode) != blendModes.end();
+      CHECK(supportsOpaqueBlendMode || supportsAdditiveBlendMode || supportsAlphaBlendMode);
+
+      passthroughBlendMode = supportsAdditiveBlendMode ? XR_ENVIRONMENT_BLEND_MODE_ADDITIVE : (supportsAlphaBlendMode ? XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND : XR_ENVIRONMENT_BLEND_MODE_OPAQUE);
+      defaultBlendMode = supportsOpaqueBlendMode ? XR_ENVIRONMENT_BLEND_MODE_OPAQUE : passthroughBlendMode;
+      VRB_LOG("OpenXR: selected default blend mode %s", to_string(defaultBlendMode));
+      VRB_LOG("OpenXR: selected passthrough blend mode %s", to_string(passthroughBlendMode));
   }
 
   void InitializeImmersiveDisplay() {
@@ -1083,11 +1110,11 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
   layers.clear();
 
   // This limit is valid at least for Pico and Meta.
-  auto submitEndFrame = [&layers, displayTime, session = m.session, isPassthroughEnabled = mIsPassthroughEnabled, passthroughStrategy = m.passthroughStrategy.get()]() {
+  auto submitEndFrame = [&layers, displayTime, session = m.session, blendMode = mIsPassthroughEnabled ? m.passthroughBlendMode : m.defaultBlendMode]() {
       static int i = 0;
       XrFrameEndInfo frameEndInfo{XR_TYPE_FRAME_END_INFO};
       frameEndInfo.displayTime = displayTime;
-      frameEndInfo.environmentBlendMode = isPassthroughEnabled ? passthroughStrategy->environmentBlendModeForPassthrough() : XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+      frameEndInfo.environmentBlendMode = blendMode;
       frameEndInfo.layerCount = (uint32_t) layers.size();
       frameEndInfo.layers = layers.data();
       CHECK_XRCMD(xrEndFrame(session, &frameEndInfo));

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
@@ -69,11 +69,4 @@ OpenXRPassthroughStrategyFBExtension::createLayerIfSupported(VRLayerPassthroughP
     return OpenXRLayerPassthrough::Create(vrLayer, passthroughHandle);
 }
 
-XrEnvironmentBlendMode
-OpenXRPassthroughStrategyUnsupported::environmentBlendModeForPassthrough() const {
-    VRB_ERROR("should not be called when passthrough is not available");
-    return XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
-};
-
-
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
@@ -15,7 +15,6 @@ public:
 enum class HandleEventResult { NoError, NonRecoverableError, NeedsReinit };
 virtual void initializePassthrough(XrSession) {}
 virtual bool usesCompositorLayer() const { return false; }
-virtual XrEnvironmentBlendMode environmentBlendModeForPassthrough() const = 0;
 virtual HandleEventResult handleEvent(const XrEventDataBaseHeader&) { return HandleEventResult::NoError; };
 virtual ~OpenXRPassthroughStrategy() = default;
 virtual bool isReady() const { return mIsInErrorState; };
@@ -25,8 +24,6 @@ bool mIsInErrorState { false };
 };
 
 class OpenXRPassthroughStrategyUnsupported : public OpenXRPassthroughStrategy {
-private:
-XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override;
 };
 
 class OpenXRPassthroughStrategyFBExtension : public OpenXRPassthroughStrategy {
@@ -35,7 +32,6 @@ public:
 private:
 void initializePassthrough(XrSession) override;
 bool usesCompositorLayer() const override { return true; }
-XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_OPAQUE; };
 HandleEventResult handleEvent(const XrEventDataBaseHeader&) override;
 bool isReady() const override;
 OpenXRLayerPassthroughPtr createLayerIfSupported(VRLayerPassthroughPtr) const override;
@@ -44,14 +40,6 @@ XrPassthroughFB passthroughHandle { XR_NULL_HANDLE };
 };
 
 class OpenXRPassthroughStrategyBlendMode : public OpenXRPassthroughStrategy {
-private:
-XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND; };
-};
-
-// This strategy is intended for runtimes that show a transparent environment when the skybox layer is not rendered.
-class OpenXRPassthroughStrategyNoSkybox : public OpenXRPassthroughStrategy {
-private:
-XrEnvironmentBlendMode environmentBlendModeForPassthrough() const override { return XR_ENVIRONMENT_BLEND_MODE_OPAQUE; };
 };
 
 } // namespace crow


### PR DESCRIPTION
Enumerate the available environment blend modes in the runtime and select the
proper ones for both default operation and passthrough modes. The preferred 
selections for the default mode are: OPAQUE -> ADDITIVE -> ALPHA

For passthrough mode we do ADDITIVE -> ALPHA -> OPAQUE. If OPAQUE then
passthrough might still be supported, for example via an OpenXR extension
(as it happens with Meta devices).

Now that blend modes are automatically selected from the supported blend 
modes retrieved from the runtime, we can get rid of the code that returned
the blend mode in the passthrough strategies as it is no longer needed.

This allows us also to remove the NoSkybox strategy which was actually not
needed (if passthrough is enabled and there is no passthrough layer then we
simply don't draw the skybox).