### PR TITLE
[l10n] Update translations to Spanish

### DIFF
--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1763,5 +1763,5 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="deprecated_version_dialog_info_button">Más información…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>
     <string name="security_options_permission_fine_location_warning">Wolvic sólo puede obtener tu ubicación aproximada. Esto se puede cambiar en la configuración del sistema.</string>
-    <string name="hamburger_menu_toggle_passthrough">A través de</string>
+    <string name="hamburger_menu_toggle_passthrough">Passthrough</string>
 </resources>


### PR DESCRIPTION
Currently translated at 100.0% (641 of 641 strings)

This corrects the translation of *Passthrough*, which for the moment is better to keep as-is, since the literal translation is not sufficiently popular or understood.