### PR TITLE
Fix zoom in desktop mode

### DIFF
--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -21,5 +21,8 @@ prefs:
   media.webspeech.synth.enabled: false
   # GPU process in Android broke WebXR. https://bugzilla.mozilla.org/show_bug.cgi?id=1771854
   layers.gpu-process.enabled: false
-  # disable zoom gestures
-  apz.one_touch_pinch: false
+  # disable pinch gestures
+  browser.gesture.pinch.out: ''
+  browser.gesture.pinch.in: ''
+  browser.gesture.pinch.out.shift: ''
+  browser.gesture.pinch.in.shift: ''

--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -26,3 +26,4 @@ prefs:
   browser.gesture.pinch.in: ''
   browser.gesture.pinch.out.shift: ''
   browser.gesture.pinch.in.shift: ''
+  apz.one_touch_pinch: false

--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -22,4 +22,4 @@ prefs:
   # GPU process in Android broke WebXR. https://bugzilla.mozilla.org/show_bug.cgi?id=1771854
   layers.gpu-process.enabled: false
   # disable zoom gestures
-  apz.allow_zooming: false
+  apz.one_touch_pinch: false


### PR DESCRIPTION
We need to enable zooming so pages in desktop mode can fill their window.

To prevent accidental zooming, we disable the "one touch pinch" feature instead.