### PR TITLE
Correct key to disable one-touch pinch

### DIFF
--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -26,4 +26,4 @@ prefs:
   browser.gesture.pinch.in: ''
   browser.gesture.pinch.out.shift: ''
   browser.gesture.pinch.in.shift: ''
-  apz.one_touch_pinch: false
+  apz.one_touch_pinch.enabled: false


### PR DESCRIPTION
The correct key is `apz.one_touch_pinch.enabled`

See [AsyncPanZoomController.cpp in gecko-dev](https://github.com/Igalia/gecko-dev/blob/46676276469f58252b99a504edaa7fa7249fe9c8/gfx/layers/apz/src/AsyncPanZoomController.cpp#L363)