### PR TITLE
Reenable Quest 1 support

### DIFF
--- a/app/src/main/cpp/DeviceUtils.cpp
+++ b/app/src/main/cpp/DeviceUtils.cpp
@@ -118,6 +118,7 @@ device::DeviceType DeviceUtils::GetDeviceTypeFromSystem(bool is6DoF) {
     int length = PopulateDeviceModelString(model);
 
     if (deviceNamesMap.empty()) {
+        deviceNamesMap.emplace("Quest", device::OculusQuest);
         deviceNamesMap.emplace("Quest 2", device::OculusQuest2);
         // So far no need to differentiate between Pico4 and Pico4E
         deviceNamesMap.emplace("A8110", device::PicoXR);


### PR DESCRIPTION
With the new filtering based on Android properties the Quest 1 was removed
accidentally because we were not adding it to the list of supported devices.
It was never really officially supported but we knew that Wolvic was still working there.

Fixes #738 