### PR TITLE
Change app_name to Wolvic

### DIFF
--- a/app/src/debug/res/values/non_L10n.xml
+++ b/app/src/debug/res/values/non_L10n.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name" translatable="false">Wolvic VR Browser(Dev)</string>
+    <string name="app_name" translatable="false">Wolvic (Dev)</string>
 </resources>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name" translatable="false">Wolvic VR Browser</string>
+    <string name="app_name" translatable="false">Wolvic</string>
     <string name="bug_report_url" translatable="false">github.com/Igalia/wolvic/issues</string>
     <!-- You can test a local file using: "resource://android/assets/webvr/index.html" -->
     <string name="homepage_url" translatable="false">https://wolvic.com/start</string>


### PR DESCRIPTION
It used to be Wolvic VR Browser but that looks like unnecessary long as it usually gets truncated.
We should use only Wolvic and then add the proper metadata to ensure that searches for browser
do show Wolvic as an option.