### PR TITLE
Hand tracking aim without XR_FB_hand_tracking_aim

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -664,10 +664,12 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     // different for each hand in the case of Quest. So here correct the transformation matrix
     // by an angle that was obtained empirically.
 #if defined(OCULUSVR)
-    float correctionAngle = (mHandeness == OpenXRHandFlags::Left) ? M_PI_2 : M_PI_4 * 3/2;
-    auto correctionMatrix = vrb::Matrix::Rotation(vrb::Vector(0.0, 0.0, 1.0),
-                                                  correctionAngle);
-    pointerTransform = pointerTransform.PostMultiply(correctionMatrix);
+    if (mSupportsFBHandTrackingAim) {
+        float correctionAngle = (mHandeness == OpenXRHandFlags::Left) ? M_PI_2 : M_PI_4 * 3 / 2;
+        auto correctionMatrix = vrb::Matrix::Rotation(vrb::Vector(0.0, 0.0, 1.0),
+                                                      correctionAngle);
+        pointerTransform = pointerTransform.PostMultiply(correctionMatrix);
+    }
 #elif defined(PICOXR)
     float correctionAngle = -M_PI_2;
     pointerTransform

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -706,9 +706,6 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     pointerTransform
         .PostMultiplyInPlace(vrb::Matrix::Rotation(vrb::Vector(0.0, 1.0, 0.0),correctionAngle)
         .PostMultiply(vrb::Matrix::Rotation(vrb::Vector(0.0, 0.0, 1.0), correctionAngle)));
-#elif defined(LYNX)
-    auto vector = mHandeness == OpenXRHandFlags::Left ? vrb::Vector(0.0, 0.5, 1.0) : vrb::Vector(-0.5, 0.0, 1.0);
-    pointerTransform.PostMultiplyInPlace(vrb::Matrix::Rotation(vector, M_PI_2));
 #endif
 
     if (renderMode == device::RenderMode::StandAlone)

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -40,7 +40,7 @@ private:
     XrResult applyHapticFeedback(XrAction, XrDuration, float = XR_FREQUENCY_UNSPECIFIED, float = 0.0) const;
     XrResult stopHapticFeedback(XrAction) const;
     void UpdateHaptics(ControllerDelegate&);
-    bool GetHandTrackingInfo(const XrFrameState&, XrSpace);
+    bool GetHandTrackingInfo(const XrFrameState&, XrSpace, const vrb::Matrix& head);
     float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
     bool IsHandJointPositionValid(const enum XrHandJointEXT aJoint);
 


### PR DESCRIPTION
Implements the aim ray used in hand tracking for systems not supporting `XR_FB_hand_tracking_aim`