### PR TITLE
Build fix for java version > 11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,7 @@ android.injected.testOnly=false
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+# Fixes "Unable to make field private final java.lang.String java.io.File.path accessible" when
+# building using Java version > 11
+org.gradle.jvmargs=--add-opens java.base/java.io=ALL-UNNAMED


### PR DESCRIPTION
Building with Java > 11 triggers the following error:

"Unable to make field private final java.lang.String java.io.File.path accessible"

which can be solved by passing an additional argument to the JVM.