### PR TITLE
[CI] Upgrade some action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Wolvic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: 'true'
 
@@ -32,7 +32,7 @@ jobs:
         run: echo "third_party_sha=$(cat third_party_hash)" >> $GITHUB_ENV
 
       - name: Checkout third parties
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.third_party_sha }}
           repository: Igalia/wolvic-third-parties
@@ -40,7 +40,7 @@ jobs:
           path: 'third_party'
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'


### PR DESCRIPTION
CI complains about the usage of some actions that are using node.js version 12 which
 is deprecated. In particular checkout and setup-java actions. We should upgrade 
them to v3 which uses node.js version 16.

For more details
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/