### PR TITLE
Close on back

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -926,22 +926,19 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             return;
         }
         if (!mWindows.handleBack()) {
-            if (DeviceType.isHVRBuild()) {
-                mWindows.getFocusedWindow().showConfirmPrompt(
-                        getString(R.string.app_name),
-                        getString(R.string.exit_confirm_dialog_body, getString(R.string.app_name)),
-                        new String[]{
-                                getString(R.string.exit_confirm_dialog_button_cancel),
-                                getString(R.string.exit_confirm_dialog_button_quit),
-                        }, (index, isChecked) -> {
-                            if (index == PromptDialogWidget.POSITIVE) {
-                                VRBrowserActivity.super.onBackPressed();
-                            }
-                        });
+            mWindows.getFocusedWindow().showConfirmPrompt(
+                    getString(R.string.app_name),
+                    getString(R.string.exit_confirm_dialog_body, getString(R.string.app_name)),
+                    new String[]{
+                            getString(R.string.exit_confirm_dialog_button_cancel),
+                            getString(R.string.exit_confirm_dialog_button_quit),
+                    }, (index, isChecked) -> {
+                        if (index == PromptDialogWidget.POSITIVE) {
+                            VRBrowserActivity.super.onBackPressed();
+                            finishAndRemoveTask();
+                        }
+                    });
 
-            } else {
-                super.onBackPressed();
-            }
         }
     }
 

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1133,10 +1133,12 @@ BrowserWorld::StartFrame() {
     }
   }
 
-#if defined(OCULUSVR) && defined(STORE_BUILD)
+#if defined(OCULUSVR)
+#if defined(STORE_BUILD)
   ProcessOVRPlatformEvents();
 #endif
   m.device->ProcessEvents();
+#endif
   m.context->Update();
   m.externalVR->PullBrowserState();
   m.externalVR->SetHapticState(m.controllers);

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1490,6 +1490,7 @@ DeviceDelegateOpenXR::IsInVRMode() const {
 
 bool
 DeviceDelegateOpenXR::ExitApp() {
+  xrRequestExitSession(m.session);
   return true;
 }
 


### PR DESCRIPTION
These PR involves 3 changes
1. Show a confirmation dialog when trying to exit wolvic by triggering the back action 
with no browser history. This has been only done in HVR but we actually want it for 
all the platforms
1. Improve the OpenXR render loop. I've made it more similar to the hello_xr example 
from Khronos. These changes allow us to unify the handling of several conditions that
could end up forcing us to exit the render loop. It does also make our finalization process
smoother, ensuring that we properly free and shutdown the OpenXR entities we use.
This makes Wolvic a better citizen in an environment with apps using the OpenXR runtime.
1. Removes an unneeded call that could cause invalid behaviours due to reentrancy.