### PR TITLE
Add implementation statement for openwnn

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -522,6 +522,7 @@ dependencies {
     implementation deps.lifecycle.viewmodel
     implementation deps.lifecycle.java8
     implementation deps.lifecycle.process
+    implementation deps.openwnn
     implementation deps.support.annotations
     implementation deps.support.app_compat
     implementation deps.support.recyclerview

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -522,7 +522,7 @@ dependencies {
     implementation deps.lifecycle.viewmodel
     implementation deps.lifecycle.java8
     implementation deps.lifecycle.process
-    implementation deps.openwnn
+    implementation 'jp.co.omronsoft.openwnn:openwnn:1.3.7'
     implementation deps.support.annotations
     implementation deps.support.app_compat
     implementation deps.support.recyclerview


### PR DESCRIPTION
CI fails with the following error
```
Could not determine the dependencies of task ':app:lintVitalPicoxrArm64GeckoGenericRelease'.
> Could not resolve all artifacts for configuration ':app:oculusvrArm64GeckoGenericDebugCompileClasspath'.
   > Could not find jp.co.omronsoft.openwnn:openwnn:1.3.7.
     Required by:
         project :app
```