### PR TITLE
[OpenXR] Invert the logic of detecting hand tracking detection

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -748,17 +748,23 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
       CHECK_XRCMD(CreateActionSpace(mPointerAction, mPointerSpace));
     }
 
-    // If hand tracking is active, use it to emulate the controller.
-    if (GetHandTrackingInfo(frameState, localSpace, head)) {
-        EmulateControllerFromHand(renderMode, head, delegate);
-        return;
-    }
-
     // Pose transforms.
     bool isPoseActive { false };
     XrSpaceLocation poseLocation { XR_TYPE_SPACE_LOCATION };
     if (XR_FAILED(GetPoseState(mPointerAction,  mPointerSpace, localSpace, frameState, isPoseActive, poseLocation))) {
         delegate.SetEnabled(mIndex, false);
+        return;
+    }
+
+#if defined(PICOXR)
+    // Pico does continuously track the controllers even when left alone. That's why we return
+    // always true so that we always check hand tracking just in case.
+    bool isControllerUnavailable = true;
+#else
+    bool isControllerUnavailable = (poseLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) == 0;
+#endif
+    if (isControllerUnavailable && GetHandTrackingInfo(frameState, localSpace, head)) {
+        EmulateControllerFromHand(renderMode, head, delegate);
         return;
     }
 


### PR DESCRIPTION
So far the current code was checking whether hand tracking was active, and if that's 
the case, then hand tracking was used as input. Otherwise we fell back to using controllers.

That approach has been working fine so far because the devices we ported Wolvic to,
do activate hand tracking only when the controllers are not used. However there are 
some other systems that do continuosly track the hands (even when using the controllers,
as the MagicLeap2). For the latter ones, the above approach does not work because hand 
tracking will be always active even when the controllers are being used.

That's why we should invert the check condition. From now on, we first check if the
controller pose is valid (by looking for its orientation valid bit (it does not make sense
to check for position because there are 3DoF controllers as well). If it's valid then we
use the controller. Otherwise we check whether hand tracking is enabled.

There is one exception, Pico runtime does continuously track the controllers even when
hand tracking is used. That's why for the case of Pico we always have to check whether
hand tracking is active.