### PR TITLE
Remove a recursive call to skipAd()

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/Media.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/Media.java
@@ -131,8 +131,8 @@ public class Media implements WMediaSession.Delegate {
     }
 
     public void skipAd() {
-        if (canSkipAd()) {
-            skipAd();
+        if (canSkipAd() && mMediaSession != null) {
+            mMediaSession.skipAd();
         }
     }
 


### PR DESCRIPTION
The implementation of skipAdd was recursively calling itself causing crashes due to
a StackOverflowException. It should call the WMediaSession.skipAd() method instead.

Fixes #771 