### PR TITLE
Fix build with JDK 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,10 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+# Also fix build error with JDK 17: https://stackoverflow.com/a/69179997
+## Unable to make field private final java.lang.String java.io.File.path accessible:
+## module java.base does not "opens java.io" to unnamed module
+org.gradle.jvmargs=-Xmx1536m --add-opens java.base/java.io=ALL-UNNAMED
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Starting from Flamingo, the Android Studio IDE is bundled with JDK 17.

This PR fixes the build error `Unable to make field private final java.lang.String java.io.File.path accessible: module java.base does not "opens java.io" to unnamed module` I encountered when I tried to build it with JDK 17. I fixed it by referring to https://stackoverflow.com/a/69179997, and I found that only `--add-opens=java.base/java.io=ALL-UNNAMED` is needed here.

