### PR TITLE
Show the size of the download file in the confirmation dialog

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
@@ -34,6 +34,14 @@ public class DownloadJob {
         return job;
     }
 
+    private static long guessFileSize(@Nullable String contentLength) {
+        try {
+            return Long.parseLong(contentLength);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
     public static DownloadJob fromUri(@NonNull String uri, Map<String, String> headers) {
         DownloadJob job = new DownloadJob();
         job.mUri = uri;
@@ -42,6 +50,7 @@ public class DownloadJob {
             // TODO: We may want to create our own Content-Disposition parser, instead of relying on Android.
             String contentDisposition = Uri.decode(headers.get("content-disposition"));
             job.mFilename = URLUtil.guessFileName(uri, contentDisposition, headers.get("content/type"));
+            job.mContentLength = guessFileSize(headers.get("content-length"));
         } else {
             job.mFilename = URLUtil.guessFileName(uri, null, null);
         }


### PR DESCRIPTION
We can use the WebResponse headers to estimate the size of the file associated to the Download job that is going to be processed.

Fixes #775