### PR TITLE
Allow dialog titles to have two lines if needed

### DIFF
--- a/app/src/main/res/layout/deprecated_version_dialog.xml
+++ b/app/src/main/res/layout/deprecated_version_dialog.xml
@@ -53,7 +53,6 @@
                 android:layout_gravity="center_horizontal"
                 android:ellipsize="end"
                 android:gravity="center_horizontal"
-                android:lines="1"
                 android:maxLines="2"
                 android:minLines="1"
                 android:text="@string/deprecated_version_dialog_title"

--- a/app/src/main/res/layout/prompt_alert.xml
+++ b/app/src/main/res/layout/prompt_alert.xml
@@ -27,7 +27,6 @@
             android:layout_weight="7"
             android:ellipsize="end"
             android:gravity="center_horizontal"
-            android:lines="1"
             android:maxLines="2"
             android:minLines="1"
             android:textColor="@color/fog"

--- a/app/src/main/res/layout/prompt_auth.xml
+++ b/app/src/main/res/layout/prompt_auth.xml
@@ -20,7 +20,6 @@
             android:layout_marginEnd="20dp"
             android:ellipsize="end"
             android:gravity="center_horizontal"
-            android:lines="1"
             android:maxLines="2"
             android:minLines="1"
             android:textColor="@color/fog"

--- a/app/src/main/res/layout/prompt_choice.xml
+++ b/app/src/main/res/layout/prompt_choice.xml
@@ -18,7 +18,6 @@
         android:layout_marginBottom="10dp"
         android:ellipsize="end"
         android:gravity="center_horizontal"
-        android:lines="1"
         android:maxLines="2"
         android:minLines="1"
         android:textColor="@color/fog"

--- a/app/src/main/res/layout/prompt_confirm.xml
+++ b/app/src/main/res/layout/prompt_confirm.xml
@@ -20,7 +20,6 @@
             android:layout_marginEnd="20dp"
             android:ellipsize="end"
             android:gravity="center_horizontal"
-            android:lines="1"
             android:maxLines="2"
             android:minLines="1"
             android:textColor="@color/fog"

--- a/app/src/main/res/layout/prompt_dialog.xml
+++ b/app/src/main/res/layout/prompt_dialog.xml
@@ -41,7 +41,6 @@
                 android:layout_gravity="center_horizontal"
                 android:ellipsize="end"
                 android:gravity="center_horizontal"
-                android:lines="1"
                 android:maxLines="2"
                 android:minLines="1"
                 android:textColor="@color/fog"

--- a/app/src/main/res/layout/prompt_file.xml
+++ b/app/src/main/res/layout/prompt_file.xml
@@ -27,7 +27,6 @@
             android:layout_marginBottom="10dp"
             android:ellipsize="end"
             android:gravity="center_horizontal"
-            android:lines="1"
             android:maxLines="2"
             android:minLines="1"
             android:textColor="@color/fog"

--- a/app/src/main/res/layout/prompt_text.xml
+++ b/app/src/main/res/layout/prompt_text.xml
@@ -22,7 +22,6 @@
             android:layout_marginEnd="20dp"
             android:ellipsize="end"
             android:gravity="center_horizontal"
-            android:lines="1"
             android:maxLines="2"
             android:minLines="1"
             android:textColor="@color/fog"


### PR DESCRIPTION
We want dialog titles to use two lines of text if needed, so we set `android:maxLines="2"`.

However, that attribute was not having an effect because we were also forcing them to have exactly one line (`android:lines="1"`).