### PR TITLE
Add Wolvic Version and Device Type info as URL parameters

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -277,7 +277,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
         mBinding.navigationBarNavigation.userFeedbackButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
-            mWidgetManager.openNewTabForeground(getResources().getString(R.string.feedback_link));
+            mWidgetManager.openNewTabForeground(getResources().getString(R.string.feedback_link, BuildConfig.VERSION_NAME, DeviceType.getType()));
         });
 
         mBinding.navigationBarNavigation.desktopModeButton.setOnClickListener(view -> {

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -213,7 +213,7 @@
 
     <!-- Settings Survey link -->
     <string name="survey_link" translatable="false">https://github.com/Igalia/wolvic/issues/</string>
-    <string name="feedback_link" translatable="false">https://wolvic.com/en/feedback/</string>
+    <string name="feedback_link" translatable="false">https://wolvic.com/en/feedback/index.html?version=%1$s&amp;device=%2$d</string>
 
     <!-- Phone UI links -->
     <string name="hvr_learn_more_url" translatable="false">https://consumer.huawei.com/cn/wearables/vr-glass/</string>


### PR DESCRIPTION
The feedback form is quite useful for many of our users to report us problems or new features they wish. However, frequently we struggle to address their requests due to the lack of context of the feedback received. 

This PR adds the Wolvic Version and the Device Type as parameters of the feedback form's URL. 