### PR TITLE
Use the multilingual URL for the Welcome page

### DIFF
--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -217,7 +217,7 @@
 
     <!-- Phone UI links -->
     <string name="hvr_learn_more_url" translatable="false">https://consumer.huawei.com/cn/wearables/vr-glass/</string>
-    <string name="landing_page_url" translatable="false">https://wolvic.com/en/welcome/</string>
+    <string name="landing_page_url" translatable="false">https://wolvic.com/welcome/</string>
 
     <!-- Shared preferences key to store the list of installed Web apps (JSON string) -->
     <string name="settings_key_web_apps_data" translatable="false">settings_key_web_apps_data</string>


### PR DESCRIPTION
Use `https://wolvic.com/welcome/` as the URL for the Welcome page instead of hardcoding a particular language.

The above URL will follow the user's preferred language, if possible.