### PR TITLE
Fix and Check warnings / deprecation notes in the current build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,6 +149,12 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -571,6 +571,7 @@ dependencies {
     implementation deps.android_components.feature_webcompat_reporter
     implementation deps.android_components.feature_addons
     implementation deps.android_components.glean
+    implementation deps.android_components.preference
     implementation deps.app_services.rustlog
 
     // Kotlin dependency

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/ContentBlockingDelegateImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/ContentBlockingDelegateImpl.java
@@ -220,6 +220,7 @@ class ContentBlockingDelegateImpl implements ContentBlocking.Delegate {
     }
 
     static int toGeckoCookieLifetime(@WContentBlocking.CBCookieLifetime int flags) {
+        // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
         switch (flags) {
             case WContentBlocking.CookieLifetime.DAYS:
                 return ContentBlocking.CookieLifetime.DAYS;
@@ -233,6 +234,7 @@ class ContentBlockingDelegateImpl implements ContentBlocking.Delegate {
     }
 
     static int fromGeckoCookieLifetime( int flags) {
+        // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
         switch (flags) {
             case ContentBlocking.CookieLifetime.DAYS:
                 return WContentBlocking.CookieLifetime.DAYS;

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/ContentBlockingDelegateImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/ContentBlockingDelegateImpl.java
@@ -218,32 +218,4 @@ class ContentBlockingDelegateImpl implements ContentBlocking.Delegate {
 
         throw new RuntimeException("Unreachable code");
     }
-
-    static int toGeckoCookieLifetime(@WContentBlocking.CBCookieLifetime int flags) {
-        // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
-        switch (flags) {
-            case WContentBlocking.CookieLifetime.DAYS:
-                return ContentBlocking.CookieLifetime.DAYS;
-            case WContentBlocking.CookieLifetime.NORMAL:
-                return ContentBlocking.CookieLifetime.NORMAL;
-            case WContentBlocking.CookieLifetime.RUNTIME:
-                return ContentBlocking.CookieLifetime.RUNTIME;
-        }
-
-        throw new RuntimeException("Unreachable code");
-    }
-
-    static int fromGeckoCookieLifetime( int flags) {
-        // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
-        switch (flags) {
-            case ContentBlocking.CookieLifetime.DAYS:
-                return WContentBlocking.CookieLifetime.DAYS;
-            case ContentBlocking.CookieLifetime.NORMAL:
-                return WContentBlocking.CookieLifetime.NORMAL;
-            case ContentBlocking.CookieLifetime.RUNTIME:
-                return WContentBlocking.CookieLifetime.RUNTIME;
-        }
-
-        throw new RuntimeException("Unreachable code");
-    }
 }

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoViewFetchClient.kt
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoViewFetchClient.kt
@@ -23,8 +23,7 @@ import java.util.concurrent.TimeoutException
  * GeckoView ([GeckoWebExecutor]) based implementation of [Client].
  */
 class GeckoViewFetchClient(
-    context: Context,
-    private val maxReadTimeOut: Pair<Long, TimeUnit> = Pair(MAX_READ_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+        private val maxReadTimeOut: Pair<Long, TimeUnit> = Pair(MAX_READ_TIMEOUT_MINUTES, TimeUnit.MINUTES)
 ) : Client() {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -64,8 +63,8 @@ class GeckoViewFetchClient(
         const val MAX_READ_TIMEOUT_MINUTES = 5L
 
         @JvmStatic
-        fun create(context: Context, executor: GeckoWebExecutor): GeckoViewFetchClient {
-            val client = GeckoViewFetchClient(context)
+        fun create(executor: GeckoWebExecutor): GeckoViewFetchClient {
+            val client = GeckoViewFetchClient()
             client.executor = executor
             return client
         }

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoWebExtension.kt
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/GeckoWebExtension.kt
@@ -269,7 +269,7 @@ class GeckoWebExtension(
                 session.setParentSession(activeSession)
                 session.setUaMode(GeckoSessionSettings.USER_AGENT_MODE_DESKTOP, true)
                 val geckoEngineSession = WolvicEngineSession(session)
-                ext.metaData?.optionsPageUrl?.let { optionsPageUrl ->
+                ext.metaData.optionsPageUrl?.let { optionsPageUrl ->
                     tabHandler.onNewTab(
                             this@GeckoWebExtension,
                             geckoEngineSession,

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -105,7 +105,7 @@ public class RuntimeImpl implements WRuntime {
     @NonNull
     @Override
     public Client createFetchClient(Context context) {
-        return GeckoViewFetchClient.create(context, mExecutor);
+        return GeckoViewFetchClient.create(mExecutor);
     }
 
     @Override

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -49,8 +49,6 @@ public class RuntimeImpl implements WRuntime {
                         .enhancedTrackingProtectionLevel(ContentBlockingDelegateImpl.toGeckoEtpLevel(settings.getContentBlocking().getEnhancedTrackingProtectionLevel()))
                         .cookieBehavior(ContentBlockingDelegateImpl.toGeckoCookieBehavior(settings.getContentBlocking().getCookieBehavior()))
                         .cookieBehaviorPrivateMode(ContentBlockingDelegateImpl.toGeckoCookieBehavior(settings.getContentBlocking().getCookieBehaviorPrivate()))
-                        // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
-                        .cookieLifetime(ContentBlockingDelegateImpl.toGeckoCookieLifetime(settings.getContentBlocking().getCookieLifetime()))
                         .safeBrowsing(ContentBlockingDelegateImpl.toGeckoSafeBrowsing(settings.getContentBlocking().getSafeBrowsing()))
                         .build())
                 .displayDensityOverride(settings.getDisplayDensityOverride())

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -49,6 +49,7 @@ public class RuntimeImpl implements WRuntime {
                         .enhancedTrackingProtectionLevel(ContentBlockingDelegateImpl.toGeckoEtpLevel(settings.getContentBlocking().getEnhancedTrackingProtectionLevel()))
                         .cookieBehavior(ContentBlockingDelegateImpl.toGeckoCookieBehavior(settings.getContentBlocking().getCookieBehavior()))
                         .cookieBehaviorPrivateMode(ContentBlockingDelegateImpl.toGeckoCookieBehavior(settings.getContentBlocking().getCookieBehaviorPrivate()))
+                        // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
                         .cookieLifetime(ContentBlockingDelegateImpl.toGeckoCookieLifetime(settings.getContentBlocking().getCookieLifetime()))
                         .safeBrowsing(ContentBlockingDelegateImpl.toGeckoSafeBrowsing(settings.getContentBlocking().getSafeBrowsing()))
                         .build())

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeSettingsImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeSettingsImpl.java
@@ -242,17 +242,6 @@ class RuntimeSettingsImpl extends WRuntimeSettings {
             mRuntime.getSettings().getContentBlocking().setCookieBehaviorPrivateMode(ContentBlockingDelegateImpl.toGeckoCookieBehavior(cookieBehaviorPrivate));
         }
 
-        @Override
-        public int getCookieLifetime() {
-            // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
-            return ContentBlockingDelegateImpl.fromGeckoCookieLifetime(mRuntime.getSettings().getContentBlocking().getCookieLifetime());
-        }
-
-        @Override
-        public void setCookieLifetime(int cookieLifetime) {
-            // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
-            mRuntime.getSettings().getContentBlocking().setCookieLifetime(ContentBlockingDelegateImpl.toGeckoCookieLifetime(cookieLifetime));
-        }
 
         @Override
         public int getEnhancedTrackingProtectionLevel() {

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeSettingsImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/RuntimeSettingsImpl.java
@@ -244,11 +244,13 @@ class RuntimeSettingsImpl extends WRuntimeSettings {
 
         @Override
         public int getCookieLifetime() {
+            // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
             return ContentBlockingDelegateImpl.fromGeckoCookieLifetime(mRuntime.getSettings().getContentBlocking().getCookieLifetime());
         }
 
         @Override
         public void setCookieLifetime(int cookieLifetime) {
+            // TODO: Deprecated cookieLifetime, see: https://github.com/Igalia/wolvic/issues/810
             mRuntime.getSettings().getContentBlocking().setCookieLifetime(ContentBlockingDelegateImpl.toGeckoCookieLifetime(cookieLifetime));
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/FragmentControllerCallbacks.java
+++ b/app/src/common/shared/com/igalia/wolvic/FragmentControllerCallbacks.java
@@ -61,16 +61,6 @@ public class FragmentControllerCallbacks extends FragmentHostCallback {
     }
 
     @Override
-    public void onStartIntentSenderFromFragment(@NonNull Fragment fragment, IntentSender intent, int requestCode, @Nullable Intent fillInIntent, int flagsMask, int flagsValues, int extraFlags, @Nullable Bundle options) throws IntentSender.SendIntentException {
-        super.onStartIntentSenderFromFragment(fragment, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags, options);
-    }
-
-    @Override
-    public void onRequestPermissionsFromFragment(@NonNull Fragment fragment, @NonNull String[] permissions, int requestCode) {
-        super.onRequestPermissionsFromFragment(fragment, permissions, requestCode);
-    }
-
-    @Override
     public boolean onShouldShowRequestPermissionRationale(@NonNull String permission) {
         return super.onShouldShowRequestPermissionRationale(permission);
     }

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -176,7 +176,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     FrameLayout mWidgetContainer;
     int mLastGesture;
     SwipeRunnable mLastRunnable;
-    Handler mHandler = new Handler();
+    Handler mHandler = new Handler(Looper.getMainLooper());
     Runnable mAudioUpdateRunnable;
     Windows mWindows;
     RootWidget mRootWidget;
@@ -246,7 +246,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        mFragmentController = FragmentController.createController(new FragmentControllerCallbacks(this, new Handler(), 0));
+        mFragmentController = FragmentController.createController(new FragmentControllerCallbacks(this, new Handler(Looper.getMainLooper()), 0));
         mFragmentController.attachHost(null);
         mFragmentController.dispatchActivityCreated();
 
@@ -677,6 +677,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     public void onConfigurationChanged(Configuration newConfig) {
         Language language = LocaleUtils.getDisplayLanguage(this);
         newConfig.setLocale(language.getLocale());
+        // TODO: Deprecated updateConfiguration(Configuration,DisplayMetrics),
+        //  see https://github.com/Igalia/wolvic/issues/797
         getBaseContext().getResources().updateConfiguration(newConfig, getBaseContext().getResources().getDisplayMetrics());
 
         LocaleUtils.update(this, language);

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -28,7 +28,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Process;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Pair;
 import android.view.KeyEvent;

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
@@ -85,6 +85,8 @@ public class VRBrowserApplication extends Application implements AppServicesProv
         Context context = LocaleUtils.init(this);
         Language language = LocaleUtils.getDisplayLanguage(context);
         newConfig.setLocale(language.getLocale());
+        // TODO: Deprecated updateConfiguration(Configuration,DisplayMetrics),
+        //  see https://github.com/Igalia/wolvic/issues/797
         getApplicationContext().getResources().updateConfiguration(newConfig, getBaseContext().getResources().getDisplayMetrics());
         super.onConfigurationChanged(newConfig);
     }

--- a/app/src/common/shared/com/igalia/wolvic/addons/views/AddonOptionsPermissionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/addons/views/AddonOptionsPermissionsView.java
@@ -2,6 +2,7 @@ package com.igalia.wolvic.addons.views;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 import android.view.View;
 
@@ -54,8 +55,11 @@ public class AddonOptionsPermissionsView extends RecyclerView.ViewHolder impleme
         mBinding.permissionsList.addOnScrollListener(mScrollListener);
         mBinding.permissionsList.setHasFixedSize(true);
         mBinding.permissionsList.setItemViewCacheSize(20);
-        mBinding.permissionsList.setDrawingCacheEnabled(true);
-        mBinding.permissionsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            mBinding.permissionsList.setDrawingCacheEnabled(true);
+            mBinding.permissionsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
         mBinding.learnMoreLink.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             mWidgetManager.openNewTabForeground(mContext.getString(R.string.sumo_addons_permissions));

--- a/app/src/common/shared/com/igalia/wolvic/addons/views/AddonsListView.java
+++ b/app/src/common/shared/com/igalia/wolvic/addons/views/AddonsListView.java
@@ -3,6 +3,7 @@ package com.igalia.wolvic.addons.views;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
@@ -77,8 +78,11 @@ public class AddonsListView extends RecyclerView.ViewHolder implements AddonsMan
         mBinding.addonsList.addOnScrollListener(mScrollListener);
         mBinding.addonsList.setHasFixedSize(true);
         mBinding.addonsList.setItemViewCacheSize(20);
-        mBinding.addonsList.setDrawingCacheEnabled(true);
-        mBinding.addonsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache().
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            mBinding.addonsList.setDrawingCacheEnabled(true);
+            mBinding.addonsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
 
         mViewModel.setIsLoading(true);
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -5,7 +5,7 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.StrictMode;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 
 import androidx.annotation.IntDef;

--- a/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 
 import androidx.annotation.NonNull;

--- a/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
@@ -124,6 +124,7 @@ public class WebAppsStore implements SharedPreferences.OnSharedPreferenceChangeL
     }
 
     private void notifyListeners() {
+        @SuppressWarnings("unchecked")
         List<WebAppsListener> listenersCopy = new ArrayList(mListeners);
         List<WebApp> webAppsCopy = new ArrayList<>(mWebApps.values());
         Handler handler = new Handler(Looper.getMainLooper());

--- a/app/src/common/shared/com/igalia/wolvic/browser/adapter/ComponentsAdapter.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/adapter/ComponentsAdapter.kt
@@ -3,10 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.igalia.wolvic.browser.adapter
 
 import com.igalia.wolvic.browser.components.WolvicEngineSession
 import com.igalia.wolvic.browser.engine.Session
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
@@ -96,7 +99,7 @@ class ComponentsAdapter private constructor(
     }
 
     fun getSessionStateForSession(session: Session?): SessionState? {
-        return store.state.tabs.firstOrNull() {
+        return store.state.tabs.firstOrNull {
             it.id == session?.id
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/content/TrackingProtectionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/content/TrackingProtectionStore.java
@@ -3,7 +3,7 @@ package com.igalia.wolvic.browser.content;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -11,7 +11,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Surface;
 import android.view.inputmethod.CursorAnchorInfo;

--- a/app/src/common/shared/com/igalia/wolvic/crashreporting/CrashReporterService.java
+++ b/app/src/common/shared/com/igalia/wolvic/crashreporting/CrashReporterService.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+// TODO: Deprecated JobIntentService, see https://github.com/Igalia/wolvic/issues/805
 import androidx.core.app.JobIntentService;
 
 import com.igalia.wolvic.BuildConfig;

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -9,6 +9,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
+import android.graphics.BlendMode;
+import android.graphics.BlendModeColorFilter;
+import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -129,7 +132,9 @@ public class DownloadsManager {
         request.setDescription(job.getDescription());
         request.setMimeType(job.getContentType());
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
-        request.setVisibleInDownloadsUi(false);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            request.setVisibleInDownloadsUi(false);
+        }
 
         if (job.getOutputPath() == null) {
             try {
@@ -213,6 +218,7 @@ public class DownloadsManager {
         }
         Log.i(LOGTAG, "Saved " + job.getUri() + " to " + file.getName() + " (" + readBytes + " bytes)");
 
+        // TODO: Deprecated addCompletedDownload(...), see https://github.com/Igalia/wolvic/issues/798
         mDownloadManager.addCompletedDownload(file.getName(), file.getName(),
                 true, UrlUtils.getMimeTypeFromUrl(file.getPath()), file.getPath(), readBytes, true,
                 Uri.parse(job.getUri().replaceFirst("^blob:","")), null);

--- a/app/src/common/shared/com/igalia/wolvic/input/CustomKeyboard.java
+++ b/app/src/common/shared/com/igalia/wolvic/input/CustomKeyboard.java
@@ -91,6 +91,7 @@ public class CustomKeyboard extends Keyboard {
             getKeys().add(key);
             Object keysObj = getFieldObject(mRows[rowIndex], "mKeys");
             if (keysObj != null && getFieldObject(mRows[rowIndex], "mKeys") instanceof ArrayList) {
+                @SuppressWarnings("unchecked")
                 ArrayList<Key> mKeys = (ArrayList<Key>) keysObj;
                 if (mKeys != null) {
                     mKeys.add(key);

--- a/app/src/common/shared/com/igalia/wolvic/search/SearchEngineWrapper.java
+++ b/app/src/common/shared/com/igalia/wolvic/search/SearchEngineWrapper.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 
 import androidx.annotation.NonNull;

--- a/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
@@ -85,6 +85,7 @@ public class OffscreenDisplay {
             Display defaultDisplay = manager.getDisplay(Display.DEFAULT_DISPLAY);
 
             int flags = DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY;
+            // TODO: Deprecated getMetrics(DisplayMetrics), see https://github.com/Igalia/wolvic/issues/799
             defaultDisplay.getMetrics(mDefaultMetrics);
 
             mVirtualDisplay = manager.createVirtualDisplay("OffscreenViews Overlay", mWidth, mHeight,
@@ -124,6 +125,8 @@ public class OffscreenDisplay {
             try {
                 getWindow()
                         .getDecorView()
+                        // TODO: Deprecated setSystemUiVisibility(int) and related flags,
+                        //  see https://github.com/Igalia/wolvic/issues/800
                         .setSystemUiVisibility(
                                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                                         | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/DownloadsAdapter.java
@@ -169,6 +169,7 @@ public class DownloadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                                     binding.thumbnail.setImageBitmap(bitmap);
                             }
                     );
+                    // TODO: Deprecated AsyncTask, see https://github.com/Igalia/wolvic/issues/801
                     task.execute();
                 }
                 break;

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/FileUploadAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/FileUploadAdapter.java
@@ -131,6 +131,7 @@ public class FileUploadAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         binding.thumbnail.setImageBitmap(bitmap);
                 }
         );
+        // TODO: Deprecated AsyncTask, see https://github.com/Igalia/wolvic/issues/801
         task.execute();
 
         boolean isSelected = mSelectedItems.contains(item);

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/ThumbnailAsyncTask.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/ThumbnailAsyncTask.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
+// TODO: Deprecated AsyncTask, see https://github.com/Igalia/wolvic/issues/801
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.CancellationSignal;

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/CustomKeyboardView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/CustomKeyboardView.java
@@ -18,6 +18,8 @@ package com.igalia.wolvic.ui.views;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.BlendMode;
+import android.graphics.BlendModeColorFilter;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
@@ -28,6 +30,7 @@ import android.graphics.drawable.Drawable;
 import android.inputmethodservice.Keyboard;
 import android.inputmethodservice.Keyboard.Key;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
 import android.util.AttributeSet;
@@ -286,7 +289,7 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     private static class MessageHandler extends Handler {
         private WeakReference<CustomKeyboardView> mView;
 
-
+        @Deprecated
         public MessageHandler(@NonNull CustomKeyboardView view) {
             mView = new WeakReference<>(view);
         }
@@ -851,7 +854,11 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 final float drawableY = (key.height - padding.top - padding.bottom - key.icon.getIntrinsicHeight()) / 2.0f
                         + padding.top + statePadding;
                 canvas.translate(drawableX, drawableY);
-                key.icon.setColorFilter(targetColor, PorterDuff.Mode.MULTIPLY);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    key.icon.setColorFilter(new BlendModeColorFilter(targetColor, BlendMode.MULTIPLY));
+                } else {
+                    key.icon.setColorFilter(targetColor, PorterDuff.Mode.MULTIPLY);
+                }
                 key.icon.setBounds(0, 0, key.icon.getIntrinsicWidth(), key.icon.getIntrinsicHeight());
                 key.icon.draw(canvas);
                 canvas.translate(-drawableX, -drawableY);
@@ -1169,8 +1176,7 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         mDirtyRect.union(key.x + getPaddingLeft(), key.y + getPaddingTop(),
                 key.x + key.width + getPaddingLeft(), key.y + key.height + getPaddingTop());
         onBufferDraw();
-        invalidate(key.x + getPaddingLeft(), key.y + getPaddingTop(),
-                key.x + key.width + getPaddingLeft(), key.y + key.height + getPaddingTop());
+        invalidate();
     }
 
     private boolean openPopupIfRequired(MotionEvent me) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/FadingFrameLayout.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/FadingFrameLayout.java
@@ -79,7 +79,7 @@ public class FadingFrameLayout extends FrameLayout {
             mPaint.setShader(gradient);
         }
 
-        int count = canvas.saveLayer(0.0f, 0.0f, (float) getWidth(), (float) getHeight(), null, Canvas.ALL_SAVE_FLAG);
+        int count = canvas.saveLayer(0.0f, 0.0f, (float) getWidth(), (float) getHeight(), null);
         super.dispatchDraw(canvas);
 
         if (isHorizontalFadingEdgeEnabled() && getHorizontalFadingEdgeLength() > 0) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/MediaSeekBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/MediaSeekBar.java
@@ -2,6 +2,7 @@ package com.igalia.wolvic.ui.views;
 
 import android.content.Context;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -58,7 +59,7 @@ public class MediaSeekBar extends LinearLayout implements SeekBar.OnSeekBarChang
 
     private void initialize() {
         inflate(getContext(), R.layout.media_controls_seek_bar, this);
-        mHandler = new Handler();
+        mHandler = new Handler(Looper.getMainLooper());
         mSeekBar = findViewById(R.id.mediaSeekBar);
         mLeftText = findViewById(R.id.mediaSeekLeftLabel);
         mRightText = findViewById(R.id.mediaSeekRightLabel);

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/BookmarksView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/BookmarksView.java
@@ -9,6 +9,7 @@ import static com.igalia.wolvic.ui.widgets.settings.SettingsView.SettingViewType
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -115,8 +116,11 @@ public class BookmarksView extends LibraryView implements BookmarksStore.Bookmar
         mBinding.bookmarksList.addOnScrollListener(mScrollListener);
         mBinding.bookmarksList.setHasFixedSize(true);
         mBinding.bookmarksList.setItemViewCacheSize(20);
-        mBinding.bookmarksList.setDrawingCacheEnabled(true);
-        mBinding.bookmarksList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache().
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            mBinding.bookmarksList.setDrawingCacheEnabled(true);
+            mBinding.bookmarksList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
 
         mLayoutManager = (CustomLinearLayoutManager) mBinding.bookmarksList.getLayoutManager();
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
@@ -102,8 +102,11 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         mBinding.downloadsList.addOnScrollListener(mScrollListener);
         mBinding.downloadsList.setHasFixedSize(true);
         mBinding.downloadsList.setItemViewCacheSize(20);
-        mBinding.downloadsList.setDrawingCacheEnabled(true);
-        mBinding.downloadsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache().
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            mBinding.downloadsList.setDrawingCacheEnabled(true);
+            mBinding.downloadsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
 
         mViewModel.setIsEmpty(true);
         mViewModel.setIsLoading(true);

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/HistoryView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/HistoryView.java
@@ -9,6 +9,7 @@ import static com.igalia.wolvic.ui.widgets.settings.SettingsView.SettingViewType
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -122,8 +123,11 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
         mBinding.historyList.addOnScrollListener(mScrollListener);
         mBinding.historyList.setHasFixedSize(true);
         mBinding.historyList.setItemViewCacheSize(20);
-        mBinding.historyList.setDrawingCacheEnabled(true);
-        mBinding.historyList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache().
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            mBinding.historyList.setDrawingCacheEnabled(true);
+            mBinding.historyList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
 
         mViewModel.setIsLoading(true);
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/WebAppsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/WebAppsView.java
@@ -7,6 +7,7 @@ package com.igalia.wolvic.ui.views.library;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.LayoutInflater;
@@ -80,8 +81,11 @@ public class WebAppsView extends LibraryView implements WebAppsStore.WebAppsList
         mBinding.webAppsList.addOnScrollListener(mScrollListener);
         mBinding.webAppsList.setHasFixedSize(true);
         mBinding.webAppsList.setItemViewCacheSize(20);
-        mBinding.webAppsList.setDrawingCacheEnabled(true);
-        mBinding.webAppsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache().
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            mBinding.webAppsList.setDrawingCacheEnabled(true);
+            mBinding.webAppsList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
 
         mViewModel.setIsNarrow(false);
         mViewModel.setIsLoading(true);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -36,7 +37,7 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
     private Rect mOffsetViewBounds;
     private VideoProjectionMenuWidget mProjectionMenu;
     static long VOLUME_SLIDER_CHECK_DELAY = 1000;
-    private Handler mVolumeCtrlHandler = new Handler();
+    private Handler mVolumeCtrlHandler = new Handler(Looper.getMainLooper());
     private boolean mHideVolumeSlider = false;
     private Runnable mVolumeCtrlRunnable;
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -16,7 +16,7 @@ import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.net.Uri;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.Pair;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
@@ -264,8 +264,8 @@ public class TabsWidget extends UIDialog {
                             aSender.attachToSession(latestTabs.get(0), mBitmapCache);
                             return;
                         }
-                        mTabs.remove(holder.getAdapterPosition() - 1);
-                        mAdapter.notifyItemRemoved(holder.getAdapterPosition());
+                        mTabs.remove(holder.getBindingAdapterPosition() - 1);
+                        mAdapter.notifyItemRemoved(holder.getBindingAdapterPosition());
                         updateTabCounter();
 
                     } else {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -818,10 +818,12 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
     }
 
     private void updateWifi() {
+        // TODO: Deprecated getConnectionInfo(), see https://github.com/Igalia/wolvic/issues/802
         if ((mTrayViewModel.getWifiConnected().getValue() != null) && mTrayViewModel.getWifiConnected().getValue().get()) {
             WifiManager wifiManager = (WifiManager) getContext().getSystemService(Context.WIFI_SERVICE);
             if (wifiManager != null) {
                 WifiInfo wifiInfo = wifiManager.getConnectionInfo();
+                // TODO: Deprecated calculateSignalLevel(int, int), see https://github.com/Igalia/wolvic/issues/802
                 int level = WifiManager.calculateSignalLevel(wifiInfo.getRssi(), 4);
                 if (level != mLastWifiLevel) {
                     if (updateWifiIcon(level)) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/UIWidget.java
@@ -424,6 +424,7 @@ public abstract class UIWidget extends FrameLayout implements Widget {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     protected <T extends UIWidget> T getChild(int aChildId) {
         return (T) mChildren.get(aChildId);
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -17,7 +17,7 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.SurfaceTexture;
 import android.net.Uri;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.text.format.Formatter;
 import android.util.Log;
 import android.util.Pair;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
@@ -3,6 +3,7 @@ package com.igalia.wolvic.ui.widgets.menus;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.webkit.URLUtil;
@@ -87,8 +88,11 @@ public class HamburgerMenuWidget extends UIWidget implements
         binding.list.addOnScrollListener(mScrollListener);
         binding.list.setHasFixedSize(true);
         binding.list.setItemViewCacheSize(20);
-        binding.list.setDrawingCacheEnabled(true);
-        binding.list.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache().
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            binding.list.setDrawingCacheEnabled(true);
+            binding.list.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
 
         updateItems();
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/FilePromptWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/FilePromptWidget.java
@@ -2,6 +2,7 @@ package com.igalia.wolvic.ui.widgets.prompts;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -65,8 +66,11 @@ public class FilePromptWidget extends PromptWidget implements DownloadsManager.D
         mBinding.filesList.setAdapter(mFileUploadAdapter);
         mBinding.filesList.setHasFixedSize(true);
         mBinding.filesList.setItemViewCacheSize(20);
-        mBinding.filesList.setDrawingCacheEnabled(true);
-        mBinding.filesList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        // Drawing Cache is deprecated in API level 28: https://developer.android.com/reference/android/view/View#getDrawingCache().
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            mBinding.filesList.setDrawingCacheEnabled(true);
+            mBinding.filesList.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        }
 
         onDownloadsUpdate(mDownloadsManager.getDownloads());
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LanguageOptionsView.java
@@ -9,7 +9,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Point;
 import android.graphics.Typeface;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.style.StyleSpan;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
@@ -3,7 +3,7 @@ package com.igalia.wolvic.ui.widgets.settings;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Point;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.view.LayoutInflater;
 
 import androidx.databinding.DataBindingUtil;

--- a/app/src/common/shared/com/igalia/wolvic/utils/ConnectivityReceiver.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/ConnectivityReceiver.java
@@ -7,7 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 
 import androidx.annotation.NonNull;
 
@@ -29,6 +30,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
     }
 
     public void init() {
+        // TODO: Deprecated CONNECTIVITY_ACTION, see https://github.com/Igalia/wolvic/issues/803
         mContext.registerReceiver(this, new IntentFilter(CONNECTIVITY_ACTION));
     }
 
@@ -50,8 +52,10 @@ public class ConnectivityReceiver extends BroadcastReceiver {
     }
 
     public static boolean isNetworkAvailable(Context aContext) {
-        ConnectivityManager manager = (ConnectivityManager) aContext.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetworkInfo = manager.getActiveNetworkInfo();
-        return activeNetworkInfo != null && activeNetworkInfo.isConnected();
+        ConnectivityManager connectivityManager = (ConnectivityManager) aContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        Network network = connectivityManager.getActiveNetwork();
+        NetworkCapabilities networkCapabilities = connectivityManager.getNetworkCapabilities(network);
+
+        return networkCapabilities != null && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
@@ -3,7 +3,7 @@ package com.igalia.wolvic.utils;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/app/src/hvr/java/com/igalia/wolvic/ContentHolderFragment.java
+++ b/app/src/hvr/java/com/igalia/wolvic/ContentHolderFragment.java
@@ -4,7 +4,7 @@ import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -15,7 +15,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.hardware.display.DisplayManager;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Surface;

--- a/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
@@ -199,6 +199,8 @@ public class PlatformActivity extends Activity {
     }
 
     void setImmersiveSticky() {
+        // TODO: Deprecated setSystemUiVisibility(int) and related flags,
+        //  see https://github.com/Igalia/wolvic/issues/800
         getWindow()
                 .getDecorView()
                 .setSystemUiVisibility(

--- a/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -80,13 +80,14 @@ public class PlatformActivity extends NativeActivity {
     }
 
     protected void setFullScreen() {
+        // TODO: Deprecated setSystemUiVisibility(int) and related flags,
+        //  see https://github.com/Igalia/wolvic/issues/800
         int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                 | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
-
 
         getWindow().getDecorView().setSystemUiVisibility(flags);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ buildscript {
 
 allprojects {
     addRepos(repositories)
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        }
+    }
 }
 
 task clean(type: Delete) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,5 @@ android.injected.testOnly=false
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+org.gradle.warning.mode=all

--- a/versions.gradle
+++ b/versions.gradle
@@ -92,6 +92,7 @@ android_components.feature_webcompat_reporter = "org.mozilla.components:feature-
 android_components.feature_addons = "org.mozilla.components:feature-addons:$versions.android_components"
 android_components.support_test = "org.mozilla.components:support-test:$versions.android_components"
 android_components.support_test_appservices = "org.mozilla.components:support-test-appservices:$versions.android_components"
+android_components.preference = "androidx.preference:preference:1.2.0"
 deps.android_components = android_components
 
 def app_services = [:]


### PR DESCRIPTION
- Enable showing all build warnings
- Fix build and deprecation warnings and add some TODO comments for deprecation (Because they may not be feasible at the moment or need refactoring. e.g. AsyncTask, JobIntentService).

There are also some warnings that may be fixed by upgrading the dependency versions, and they are not fixed in this PR:

```bash
> Task :app:gleanGenerateMetricsSourceForAospArm64GeckoGenericDebug
Glean SDK - generating API from /wolvic/app/metrics.yaml
Glean SDK - generating API from /wolvic/app/pings.yaml
The AbstractExecTask.execResult property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the executionResult property instead. See https://docs.gradle.org/7.3.2/dsl/org.gradle.api.tasks.AbstractExecTask.html#org.gradle.api.tasks.AbstractExecTask:execResult for more details.
```

```bash
> Task :app:compressAospArm64GeckoGenericDebugAssets
warn: removing resource com.igalia.wolvic:string/mozac_browser_errorpages_page_go_back without required default value.
warn: removing resource com.igalia.wolvic:string/mozac_browser_errorpages_page_title without required default value.
warn: removing resource com.igalia.wolvic:string/mozac_feature_addons_user_rating_count without required default value.
```

```bash
> Task :app:stripAospArm64GeckoGenericDebugDebugSymbols
Unable to strip the following libraries, packaging them as they are: libjnidispatch.so.
```

```bash
> Task :app:compileAospArm64GeckoGenericDebugJavaWithJavac
ANTLR Tool version 4.5.3 used for code generation does not match the current runtime version 4.7.1
```

WARNING: Since I still haven't got my testing device, the code in bundled JDK 17 using Android Studio Flamingo.