### PR TITLE
Fix deprecated android.inputmethodservice.Keyboard and keyboardView

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/input/CustomKeyboard.java
+++ b/app/src/common/shared/com/igalia/wolvic/input/CustomKeyboard.java
@@ -8,7 +8,7 @@ package com.igalia.wolvic.input;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.XmlResourceParser;
-import android.inputmethodservice.Keyboard;
+import com.igalia.wolvic.input.Keyboard;
 import android.view.KeyEvent;
 
 import java.lang.reflect.Field;

--- a/app/src/common/shared/com/igalia/wolvic/input/Keyboard.java
+++ b/app/src/common/shared/com/igalia/wolvic/input/Keyboard.java
@@ -1,0 +1,854 @@
+/*
+ * Copyright (C) 2008-2009 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.igalia.wolvic.input;
+import com.igalia.wolvic.R;
+import androidx.annotation.XmlRes;
+import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.content.res.XmlResourceParser;
+import android.graphics.drawable.Drawable;
+import android.text.TextUtils;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.util.TypedValue;
+import android.util.Xml;
+import org.xmlpull.v1.XmlPullParserException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+/**
+ * Loads an XML description of a keyboard and stores the attributes of the keys. A keyboard
+ * consists of rows of keys.
+ * <p>The layout file for a keyboard contains XML that looks like the following snippet:</p>
+ * <pre>
+ * &lt;Keyboard
+ *         android:keyWidth="%10p"
+ *         android:keyHeight="50px"
+ *         android:horizontalGap="2px"
+ *         android:verticalGap="2px" &gt;
+ *     &lt;Row android:keyWidth="32px" &gt;
+ *         &lt;Key android:keyLabel="A" /&gt;
+ *         ...
+ *     &lt;/Row&gt;
+ *     ...
+ * &lt;/Keyboard&gt;
+ * </pre>
+ * @attr ref R.styleable#Keyboard_keyWidth
+ * @attr ref R.styleable#Keyboard_keyHeight
+ * @attr ref R.styleable#Keyboard_horizontalGap
+ * @attr ref R.styleable#Keyboard_verticalGap
+ * This class is copied from AOSP as instructed.
+ */
+public class Keyboard {
+    static final String TAG = "Keyboard";
+    
+    // Keyboard XML Tags
+    private static final String TAG_KEYBOARD = "Keyboard";
+    private static final String TAG_ROW = "Row";
+    private static final String TAG_KEY = "Key";
+    public static final int EDGE_LEFT = 0x01;
+    public static final int EDGE_RIGHT = 0x02;
+    public static final int EDGE_TOP = 0x04;
+    public static final int EDGE_BOTTOM = 0x08;
+    public static final int KEYCODE_SHIFT = -1;
+    public static final int KEYCODE_MODE_CHANGE = -2;
+    public static final int KEYCODE_CANCEL = -3;
+    public static final int KEYCODE_DONE = -4;
+    public static final int KEYCODE_DELETE = -5;
+    public static final int KEYCODE_ALT = -6;
+    
+    /** Keyboard label **/
+    private CharSequence mLabel;
+    /** Horizontal gap default for all rows */
+    private int mDefaultHorizontalGap;
+    
+    /** Default key width */
+    private int mDefaultWidth;
+    /** Default key height */
+    private int mDefaultHeight;
+    /** Default gap between rows */
+    private int mDefaultVerticalGap;
+    /** Is the keyboard in the shifted state */
+    private boolean mShifted;
+    
+    /** Key instance for the shift key, if present */
+    private Key[] mShiftKeys = { null, null };
+    /** Key index for the shift key, if present */
+    private int[] mShiftKeyIndices = {-1, -1};
+    /** Current key width, while loading the keyboard */
+    private int mKeyWidth;
+    
+    /** Current key height, while loading the keyboard */
+    private int mKeyHeight;
+    
+    /** Total height of the keyboard, including the padding and keys */
+    private int mTotalHeight;
+    
+    /** 
+     * Total width of the keyboard, including left side gaps and keys, but not any gaps on the
+     * right side.
+     */
+    private int mTotalWidth;
+    
+    /** List of keys in this keyboard */
+    private List<Key> mKeys;
+    
+    /** List of modifier keys such as Shift & Alt, if any */
+    private List<Key> mModifierKeys;
+    
+    /** Width of the screen available to fit the keyboard */
+    private int mDisplayWidth;
+    /** Height of the screen */
+    private int mDisplayHeight;
+    /** Keyboard mode, or zero, if none.  */
+    private int mKeyboardMode;
+    // Variables for pre-computing nearest keys.
+    
+    private static final int GRID_WIDTH = 10;
+    private static final int GRID_HEIGHT = 5;
+    private static final int GRID_SIZE = GRID_WIDTH * GRID_HEIGHT;
+    private int mCellWidth;
+    private int mCellHeight;
+    private int[][] mGridNeighbors;
+    private int mProximityThreshold;
+    /** Number of key widths from current touch point to search for nearest keys. */
+    private static float SEARCH_DISTANCE = 1.8f;
+    private ArrayList<Row> rows = new ArrayList<Row>();
+    /**
+     * Container for keys in the keyboard. All keys in a row are at the same Y-coordinate. 
+     * Some of the key size defaults can be overridden per row from what the {@link Keyboard}
+     * defines. 
+     * @attr ref R.styleable#Keyboard_keyWidth
+     * @attr ref R.styleable#Keyboard_keyHeight
+     * @attr ref R.styleable#Keyboard_horizontalGap
+     * @attr ref R.styleable#Keyboard_verticalGap
+     * @attr ref R.styleable#Keyboard_Row_rowEdgeFlags
+     * @attr ref R.styleable#Keyboard_Row_keyboardMode
+     */
+    public static class Row {
+        /** Default width of a key in this row. */
+        public int defaultWidth;
+        /** Default height of a key in this row. */
+        public int defaultHeight;
+        /** Default horizontal gap between keys in this row. */
+        public int defaultHorizontalGap;
+        /** Vertical gap following this row. */
+        public int verticalGap;
+        ArrayList<Key> mKeys = new ArrayList<Key>();
+        /**
+         * Edge flags for this row of keys. Possible values that can be assigned are
+         * {@link Keyboard#EDGE_TOP EDGE_TOP} and {@link Keyboard#EDGE_BOTTOM EDGE_BOTTOM}  
+         */
+        public int rowEdgeFlags;
+        
+        /** The keyboard mode for this row */
+        public int mode;
+        
+        private Keyboard parent;
+        public Row(Keyboard parent) {
+            this.parent = parent;
+        }
+        
+        public Row(Resources res, Keyboard parent, XmlResourceParser parser) {
+            this.parent = parent;
+            TypedArray a = res.obtainAttributes(Xml.asAttributeSet(parser), 
+                    R.styleable.Keyboard);
+            defaultWidth = getDimensionOrFraction(a, 
+                    R.styleable.Keyboard_keyWidth, 
+                    parent.mDisplayWidth, parent.mDefaultWidth);
+            defaultHeight = getDimensionOrFraction(a, 
+                    R.styleable.Keyboard_keyHeight, 
+                    parent.mDisplayHeight, parent.mDefaultHeight);
+            defaultHorizontalGap = getDimensionOrFraction(a,
+                    R.styleable.Keyboard_horizontalGap, 
+                    parent.mDisplayWidth, parent.mDefaultHorizontalGap);
+            verticalGap = getDimensionOrFraction(a, 
+                    R.styleable.Keyboard_verticalGap, 
+                    parent.mDisplayHeight, parent.mDefaultVerticalGap);
+            a.recycle();
+            a = res.obtainAttributes(Xml.asAttributeSet(parser),
+                    R.styleable.Keyboard_Row);
+            rowEdgeFlags = a.getInt(R.styleable.Keyboard_Row_rowEdgeFlags, 0);
+            mode = a.getResourceId(R.styleable.Keyboard_Row_keyboardMode,
+                    0);
+            a.recycle();
+        }
+    }
+    /**
+     * Class for describing the position and characteristics of a single key in the keyboard.
+     * 
+     * @attr ref R.styleable#Keyboard_keyWidth
+     * @attr ref R.styleable#Keyboard_keyHeight
+     * @attr ref R.styleable#Keyboard_horizontalGap
+     * @attr ref R.styleable#Keyboard_Key_codes
+     * @attr ref R.styleable#Keyboard_Key_keyIcon
+     * @attr ref R.styleable#Keyboard_Key_keyLabel
+     * @attr ref R.styleable#Keyboard_Key_iconPreview
+     * @attr ref R.styleable#Keyboard_Key_isSticky
+     * @attr ref R.styleable#Keyboard_Key_isRepeatable
+     * @attr ref R.styleable#Keyboard_Key_isModifier
+     * @attr ref R.styleable#Keyboard_Key_popupKeyboard
+     * @attr ref R.styleable#Keyboard_Key_popupCharacters
+     * @attr ref R.styleable#Keyboard_Key_keyOutputText
+     * @attr ref R.styleable#Keyboard_Key_keyEdgeFlags
+     */
+    public static class Key {
+        /** 
+         * All the key codes (unicode or custom code) that this key could generate, zero'th 
+         * being the most important.
+         */
+        public int[] codes;
+        
+        /** Label to display */
+        public CharSequence label;
+        
+        /** Icon to display instead of a label. Icon takes precedence over a label */
+        public Drawable icon;
+        /** Preview version of the icon, for the preview popup */
+        public Drawable iconPreview;
+        /** Width of the key, not including the gap */
+        public int width;
+        /** Height of the key, not including the gap */
+        public int height;
+        /** The horizontal gap before this key */
+        public int gap;
+        /** Whether this key is sticky, i.e., a toggle key */
+        public boolean sticky;
+        /** X coordinate of the key in the keyboard layout */
+        public int x;
+        /** Y coordinate of the key in the keyboard layout */
+        public int y;
+        /** The current pressed state of this key */
+        public boolean pressed;
+        /** If this is a sticky key, is it on? */
+        public boolean on;
+        /** Text to output when pressed. This can be multiple characters, like ".com" */
+        public CharSequence text;
+        /** Popup characters */
+        public CharSequence popupCharacters;
+        /** 
+         * Flags that specify the anchoring to edges of the keyboard for detecting touch events
+         * that are just out of the boundary of the key. This is a bit mask of 
+         * {@link Keyboard#EDGE_LEFT}, {@link Keyboard#EDGE_RIGHT}, {@link Keyboard#EDGE_TOP} and
+         * {@link Keyboard#EDGE_BOTTOM}.
+         */
+        public int edgeFlags;
+        /** Whether this is a modifier key, such as Shift or Alt */
+        public boolean modifier;
+        /** The keyboard that this key belongs to */
+        private Keyboard keyboard;
+        /** 
+         * If this key pops up a mini keyboard, this is the resource id for the XML layout for that
+         * keyboard.
+         */
+        public int popupResId;
+        /** Whether this key repeats itself when held down */
+        public boolean repeatable;
+        
+        private final static int[] KEY_STATE_NORMAL_ON = { 
+            android.R.attr.state_checkable, 
+            android.R.attr.state_checked
+        };
+        
+        private final static int[] KEY_STATE_PRESSED_ON = { 
+            android.R.attr.state_pressed, 
+            android.R.attr.state_checkable, 
+            android.R.attr.state_checked 
+        };
+        
+        private final static int[] KEY_STATE_NORMAL_OFF = { 
+            android.R.attr.state_checkable 
+        };
+        
+        private final static int[] KEY_STATE_PRESSED_OFF = { 
+            android.R.attr.state_pressed, 
+            android.R.attr.state_checkable 
+        };
+        
+        private final static int[] KEY_STATE_NORMAL = {
+        };
+        
+        private final static int[] KEY_STATE_PRESSED = {
+            android.R.attr.state_pressed
+        };
+        /** Create an empty key with no attributes. */
+        public Key(Row parent) {
+            keyboard = parent.parent;
+            height = parent.defaultHeight;
+            width = parent.defaultWidth;
+            gap = parent.defaultHorizontalGap;
+            edgeFlags = parent.rowEdgeFlags;
+        }
+        
+        /** Create a key with the given top-left coordinate and extract its attributes from
+         * the XML parser.
+         * @param res resources associated with the caller's context
+         * @param parent the row that this key belongs to. The row must already be attached to
+         * a {@link Keyboard}.
+         * @param x the x coordinate of the top-left
+         * @param y the y coordinate of the top-left
+         * @param parser the XML parser containing the attributes for this key
+         */
+        public Key(Resources res, Row parent, int x, int y, XmlResourceParser parser) {
+            this(parent);
+            this.x = x;
+            this.y = y;
+            
+            TypedArray a = res.obtainAttributes(Xml.asAttributeSet(parser), 
+                    R.styleable.Keyboard);
+            width = getDimensionOrFraction(a, 
+                    R.styleable.Keyboard_keyWidth,
+                    keyboard.mDisplayWidth, parent.defaultWidth);
+            height = getDimensionOrFraction(a, 
+                    R.styleable.Keyboard_keyHeight,
+                    keyboard.mDisplayHeight, parent.defaultHeight);
+            gap = getDimensionOrFraction(a, 
+                    R.styleable.Keyboard_horizontalGap,
+                    keyboard.mDisplayWidth, parent.defaultHorizontalGap);
+            a.recycle();
+            a = res.obtainAttributes(Xml.asAttributeSet(parser),
+                    R.styleable.Keyboard_Key);
+            this.x += gap;
+            TypedValue codesValue = new TypedValue();
+            a.getValue(R.styleable.Keyboard_Key_codes, 
+                    codesValue);
+            if (codesValue.type == TypedValue.TYPE_INT_DEC 
+                    || codesValue.type == TypedValue.TYPE_INT_HEX) {
+                codes = new int[] { codesValue.data };
+            } else if (codesValue.type == TypedValue.TYPE_STRING) {
+                codes = parseCSV(codesValue.string.toString());
+            }
+            
+            iconPreview = a.getDrawable(R.styleable.Keyboard_Key_iconPreview);
+            if (iconPreview != null) {
+                iconPreview.setBounds(0, 0, iconPreview.getIntrinsicWidth(), 
+                        iconPreview.getIntrinsicHeight());
+            }
+            popupCharacters = a.getText(
+                    R.styleable.Keyboard_Key_popupCharacters);
+            popupResId = a.getResourceId(
+                    R.styleable.Keyboard_Key_popupKeyboard, 0);
+            repeatable = a.getBoolean(
+                    R.styleable.Keyboard_Key_isRepeatable, false);
+            modifier = a.getBoolean(
+                    R.styleable.Keyboard_Key_isModifier, false);
+            sticky = a.getBoolean(
+                    R.styleable.Keyboard_Key_isSticky, false);
+            edgeFlags = a.getInt(R.styleable.Keyboard_Key_keyEdgeFlags, 0);
+            edgeFlags |= parent.rowEdgeFlags;
+            icon = a.getDrawable(
+                    R.styleable.Keyboard_Key_keyIcon);
+            if (icon != null) {
+                icon.setBounds(0, 0, icon.getIntrinsicWidth(), icon.getIntrinsicHeight());
+            }
+            label = a.getText(R.styleable.Keyboard_Key_keyLabel);
+            text = a.getText(R.styleable.Keyboard_Key_keyOutputText);
+            
+            if (codes == null && !TextUtils.isEmpty(label)) {
+                codes = new int[] { label.charAt(0) };
+            }
+            a.recycle();
+        }
+        
+        /**
+         * Informs the key that it has been pressed, in case it needs to change its appearance or
+         * state.
+         * @see #onReleased(boolean)
+         */
+        public void onPressed() {
+            pressed = !pressed;
+        }
+        /**
+         * Changes the pressed state of the key.
+         *
+         * <p>Toggled state of the key will be flipped when all the following conditions are
+         * fulfilled:</p>
+         *
+         * <ul>
+         *     <li>This is a sticky key, that is, {@link #sticky} is {@code true}.
+         *     <li>The parameter {@code inside} is {@code true}.
+         *     <li>{@link android.os.Build.VERSION#SDK_INT} is greater than
+         *         {@link android.os.Build.VERSION_CODES#LOLLIPOP_MR1}.
+         * </ul>
+         *
+         * @param inside whether the finger was released inside the key. Works only on Android M and
+         * later. See the method document for details.
+         * @see #onPressed()
+         */
+        public void onReleased(boolean inside) {
+            pressed = !pressed;
+            if (sticky && inside) {
+                on = !on;
+            }
+        }
+        int[] parseCSV(String value) {
+            int count = 0;
+            int lastIndex = 0;
+            if (value.length() > 0) {
+                count++;
+                while ((lastIndex = value.indexOf(",", lastIndex + 1)) > 0) {
+                    count++;
+                }
+            }
+            int[] values = new int[count];
+            count = 0;
+            StringTokenizer st = new StringTokenizer(value, ",");
+            while (st.hasMoreTokens()) {
+                try {
+                    values[count++] = Integer.parseInt(st.nextToken());
+                } catch (NumberFormatException nfe) {
+                    Log.e(TAG, "Error parsing keycodes " + value);
+                }
+            }
+            return values;
+        }
+        /**
+         * Detects if a point falls inside this key.
+         * @param x the x-coordinate of the point 
+         * @param y the y-coordinate of the point
+         * @return whether or not the point falls inside the key. If the key is attached to an edge,
+         * it will assume that all points between the key and the edge are considered to be inside
+         * the key.
+         */
+        public boolean isInside(int x, int y) {
+            boolean leftEdge = (edgeFlags & EDGE_LEFT) > 0;
+            boolean rightEdge = (edgeFlags & EDGE_RIGHT) > 0;
+            boolean topEdge = (edgeFlags & EDGE_TOP) > 0;
+            boolean bottomEdge = (edgeFlags & EDGE_BOTTOM) > 0;
+            if ((x >= this.x || (leftEdge && x <= this.x + this.width)) 
+                    && (x < this.x + this.width || (rightEdge && x >= this.x)) 
+                    && (y >= this.y || (topEdge && y <= this.y + this.height))
+                    && (y < this.y + this.height || (bottomEdge && y >= this.y))) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        /**
+         * Returns the square of the distance between the center of the key and the given point.
+         * @param x the x-coordinate of the point
+         * @param y the y-coordinate of the point
+         * @return the square of the distance of the point from the center of the key
+         */
+        public int squaredDistanceFrom(int x, int y) {
+            int xDist = this.x + width / 2 - x;
+            int yDist = this.y + height / 2 - y;
+            return xDist * xDist + yDist * yDist;
+        }
+        
+        /**
+         * Returns the drawable state for the key, based on the current state and type of the key.
+         * @return the drawable state of the key.
+         * @see android.graphics.drawable.StateListDrawable#setState(int[])
+         */
+        public int[] getCurrentDrawableState() {
+            int[] states = KEY_STATE_NORMAL;
+            if (on) {
+                if (pressed) {
+                    states = KEY_STATE_PRESSED_ON;
+                } else {
+                    states = KEY_STATE_NORMAL_ON;
+                }
+            } else {
+                if (sticky) {
+                    if (pressed) {
+                        states = KEY_STATE_PRESSED_OFF;
+                    } else {
+                        states = KEY_STATE_NORMAL_OFF;
+                    }
+                } else {
+                    if (pressed) {
+                        states = KEY_STATE_PRESSED;
+                    }
+                }
+            }
+            return states;
+        }
+    }
+    /**
+     * Creates a keyboard from the given xml key layout file.
+     * @param context the application or service context
+     * @param xmlLayoutResId the resource file that contains the keyboard layout and keys.
+     */
+    public Keyboard(Context context, int xmlLayoutResId) {
+        this(context, xmlLayoutResId, 0);
+    }
+    /**
+     * Creates a keyboard from the given xml key layout file. Weeds out rows
+     * that have a keyboard mode defined but don't match the specified mode.
+     * @param context the application or service context
+     * @param xmlLayoutResId the resource file that contains the keyboard layout and keys.
+     * @param modeId keyboard mode identifier
+     * @param width sets width of keyboard
+     * @param height sets height of keyboard
+     */
+    public Keyboard(Context context, @XmlRes int xmlLayoutResId, int modeId, int width,
+            int height) {
+        mDisplayWidth = width;
+        mDisplayHeight = height;
+        mDefaultHorizontalGap = 0;
+        mDefaultWidth = mDisplayWidth / 10;
+        mDefaultVerticalGap = 0;
+        mDefaultHeight = mDefaultWidth;
+        mKeys = new ArrayList<Key>();
+        mModifierKeys = new ArrayList<Key>();
+        mKeyboardMode = modeId;
+        loadKeyboard(context, context.getResources().getXml(xmlLayoutResId));
+    }
+    /**
+     * Creates a keyboard from the given xml key layout file. Weeds out rows
+     * that have a keyboard mode defined but don't match the specified mode. 
+     * @param context the application or service context
+     * @param xmlLayoutResId the resource file that contains the keyboard layout and keys.
+     * @param modeId keyboard mode identifier
+     */
+    public Keyboard(Context context, @XmlRes int xmlLayoutResId, int modeId) {
+        DisplayMetrics dm = context.getResources().getDisplayMetrics();
+        mDisplayWidth = dm.widthPixels;
+        mDisplayHeight = dm.heightPixels;
+        //Log.v(TAG, "keyboard's display metrics:" + dm);
+        mDefaultHorizontalGap = 0;
+        mDefaultWidth = mDisplayWidth / 10;
+        mDefaultVerticalGap = 0;
+        mDefaultHeight = mDefaultWidth;
+        mKeys = new ArrayList<Key>();
+        mModifierKeys = new ArrayList<Key>();
+        mKeyboardMode = modeId;
+        loadKeyboard(context, context.getResources().getXml(xmlLayoutResId));
+    }
+    /**
+     * <p>Creates a blank keyboard from the given resource file and populates it with the specified
+     * characters in left-to-right, top-to-bottom fashion, using the specified number of columns.
+     * </p>
+     * <p>If the specified number of columns is -1, then the keyboard will fit as many keys as
+     * possible in each row.</p>
+     * @param context the application or service context
+     * @param layoutTemplateResId the layout template file, containing no keys.
+     * @param characters the list of characters to display on the keyboard. One key will be created
+     * for each character.
+     * @param columns the number of columns of keys to display. If this number is greater than the 
+     * number of keys that can fit in a row, it will be ignored. If this number is -1, the 
+     * keyboard will fit as many keys as possible in each row.
+     */
+    public Keyboard(Context context, int layoutTemplateResId, 
+            CharSequence characters, int columns, int horizontalPadding) {
+        this(context, layoutTemplateResId);
+        int x = 0;
+        int y = 0;
+        int column = 0;
+        mTotalWidth = 0;
+        
+        Row row = new Row(this);
+        row.defaultHeight = mDefaultHeight;
+        row.defaultWidth = mDefaultWidth;
+        row.defaultHorizontalGap = mDefaultHorizontalGap;
+        row.verticalGap = mDefaultVerticalGap;
+        row.rowEdgeFlags = EDGE_TOP | EDGE_BOTTOM;
+        final int maxColumns = columns == -1 ? Integer.MAX_VALUE : columns;
+        for (int i = 0; i < characters.length(); i++) {
+            char c = characters.charAt(i);
+            if (column >= maxColumns 
+                    || x + mDefaultWidth + horizontalPadding > mDisplayWidth) {
+                x = 0;
+                y += mDefaultVerticalGap + mDefaultHeight;
+                column = 0;
+            }
+            final Key key = new Key(row);
+            key.x = x;
+            key.y = y;
+            key.label = String.valueOf(c);
+            key.codes = new int[] { c };
+            column++;
+            x += key.width + key.gap;
+            mKeys.add(key);
+            row.mKeys.add(key);
+            if (x > mTotalWidth) {
+                mTotalWidth = x;
+            }
+        }
+        mTotalHeight = y + mDefaultHeight;
+        rows.add(row);
+    }
+
+    final void resize(int newWidth, int newHeight) {
+        int numRows = rows.size();
+        for (int rowIndex = 0; rowIndex < numRows; ++rowIndex) {
+            Row row = rows.get(rowIndex);
+            int numKeys = row.mKeys.size();
+            int totalGap = 0;
+            int totalWidth = 0;
+            for (int keyIndex = 0; keyIndex < numKeys; ++keyIndex) {
+                Key key = row.mKeys.get(keyIndex);
+                if (keyIndex > 0) {
+                    totalGap += key.gap;
+                }
+                totalWidth += key.width;
+            }
+            if (totalGap + totalWidth > newWidth) {
+                int x = 0;
+                float scaleFactor = (float)(newWidth - totalGap) / totalWidth;
+                for (int keyIndex = 0; keyIndex < numKeys; ++keyIndex) {
+                    Key key = row.mKeys.get(keyIndex);
+                    key.width *= scaleFactor;
+                    key.x = x;
+                    x += key.width + key.gap;
+                }
+            }
+        }
+        mTotalWidth = newWidth;
+        // TODO: This does not adjust the vertical placement according to the new size.
+        // The main problem in the previous code was horizontal placement/size, but we should
+        // also recalculate the vertical sizes/positions when we get this resize call.
+    }
+    
+    public List<Key> getKeys() {
+        return mKeys;
+    }
+    
+    public List<Key> getModifierKeys() {
+        return mModifierKeys;
+    }
+    
+    protected int getHorizontalGap() {
+        return mDefaultHorizontalGap;
+    }
+    
+    protected void setHorizontalGap(int gap) {
+        mDefaultHorizontalGap = gap;
+    }
+    protected int getVerticalGap() {
+        return mDefaultVerticalGap;
+    }
+    protected void setVerticalGap(int gap) {
+        mDefaultVerticalGap = gap;
+    }
+    protected int getKeyHeight() {
+        return mDefaultHeight;
+    }
+    protected void setKeyHeight(int height) {
+        mDefaultHeight = height;
+    }
+    protected int getKeyWidth() {
+        return mDefaultWidth;
+    }
+    
+    protected void setKeyWidth(int width) {
+        mDefaultWidth = width;
+    }
+    /**
+     * Returns the total height of the keyboard
+     * @return the total height of the keyboard
+     */
+    public int getHeight() {
+        return mTotalHeight;
+    }
+    
+    public int getMinWidth() {
+        return mTotalWidth;
+    }
+    public boolean setShifted(boolean shiftState) {
+        for (Key shiftKey : mShiftKeys) {
+            if (shiftKey != null) {
+                shiftKey.on = shiftState;
+            }
+        }
+        if (mShifted != shiftState) {
+            mShifted = shiftState;
+            return true;
+        }
+        return false;
+    }
+    public boolean isShifted() {
+        return mShifted;
+    }
+    /**
+     * @hide
+     */
+    public int[] getShiftKeyIndices() {
+        return mShiftKeyIndices;
+    }
+    public int getShiftKeyIndex() {
+        return mShiftKeyIndices[0];
+    }
+    
+    private void computeNearestNeighbors() {
+        // Round-up so we don't have any pixels outside the grid
+        mCellWidth = (getMinWidth() + GRID_WIDTH - 1) / GRID_WIDTH;
+        mCellHeight = (getHeight() + GRID_HEIGHT - 1) / GRID_HEIGHT;
+        mGridNeighbors = new int[GRID_SIZE][];
+        int[] indices = new int[mKeys.size()];
+        final int gridWidth = GRID_WIDTH * mCellWidth;
+        final int gridHeight = GRID_HEIGHT * mCellHeight;
+        for (int x = 0; x < gridWidth; x += mCellWidth) {
+            for (int y = 0; y < gridHeight; y += mCellHeight) {
+                int count = 0;
+                for (int i = 0; i < mKeys.size(); i++) {
+                    final Key key = mKeys.get(i);
+                    if (key.squaredDistanceFrom(x, y) < mProximityThreshold ||
+                            key.squaredDistanceFrom(x + mCellWidth - 1, y) < mProximityThreshold ||
+                            key.squaredDistanceFrom(x + mCellWidth - 1, y + mCellHeight - 1) 
+                                < mProximityThreshold ||
+                            key.squaredDistanceFrom(x, y + mCellHeight - 1) < mProximityThreshold) {
+                        indices[count++] = i;
+                    }
+                }
+                int [] cell = new int[count];
+                System.arraycopy(indices, 0, cell, 0, count);
+                mGridNeighbors[(y / mCellHeight) * GRID_WIDTH + (x / mCellWidth)] = cell;
+            }
+        }
+    }
+    
+    /**
+     * Returns the indices of the keys that are closest to the given point.
+     * @param x the x-coordinate of the point
+     * @param y the y-coordinate of the point
+     * @return the array of integer indices for the nearest keys to the given point. If the given
+     * point is out of range, then an array of size zero is returned.
+     */
+    public int[] getNearestKeys(int x, int y) {
+        if (mGridNeighbors == null) computeNearestNeighbors();
+        if (x >= 0 && x < getMinWidth() && y >= 0 && y < getHeight()) {
+            int index = (y / mCellHeight) * GRID_WIDTH + (x / mCellWidth);
+            if (index < GRID_SIZE) {
+                return mGridNeighbors[index];
+            }
+        }
+        return new int[0];
+    }
+    protected Row createRowFromXml(Resources res, XmlResourceParser parser) {
+        return new Row(res, this, parser);
+    }
+    
+    protected Key createKeyFromXml(Resources res, Row parent, int x, int y, 
+            XmlResourceParser parser) {
+        return new Key(res, parent, x, y, parser);
+    }
+    private void loadKeyboard(Context context, XmlResourceParser parser) {
+        boolean inKey = false;
+        boolean inRow = false;
+        boolean leftMostKey = false;
+        int row = 0;
+        int x = 0;
+        int y = 0;
+        Key key = null;
+        Row currentRow = null;
+        Resources res = context.getResources();
+        boolean skipRow = false;
+        try {
+            int event;
+            while ((event = parser.next()) != XmlResourceParser.END_DOCUMENT) {
+                if (event == XmlResourceParser.START_TAG) {
+                    String tag = parser.getName();
+                    if (TAG_ROW.equals(tag)) {
+                        inRow = true;
+                        x = 0;
+                        currentRow = createRowFromXml(res, parser);
+                        rows.add(currentRow);
+                        skipRow = currentRow.mode != 0 && currentRow.mode != mKeyboardMode;
+                        if (skipRow) {
+                            skipToEndOfRow(parser);
+                            inRow = false;
+                        }
+                   } else if (TAG_KEY.equals(tag)) {
+                        inKey = true;
+                        key = createKeyFromXml(res, currentRow, x, y, parser);
+                        mKeys.add(key);
+                        if (key.codes[0] == KEYCODE_SHIFT) {
+                            // Find available shift key slot and put this shift key in it
+                            for (int i = 0; i < mShiftKeys.length; i++) {
+                                if (mShiftKeys[i] == null) {
+                                    mShiftKeys[i] = key;
+                                    mShiftKeyIndices[i] = mKeys.size()-1;
+                                    break;
+                                }
+                            }
+                            mModifierKeys.add(key);
+                        } else if (key.codes[0] == KEYCODE_ALT) {
+                            mModifierKeys.add(key);
+                        }
+                        currentRow.mKeys.add(key);
+                    } else if (TAG_KEYBOARD.equals(tag)) {
+                        parseKeyboardAttributes(res, parser);
+                    }
+                } else if (event == XmlResourceParser.END_TAG) {
+                    if (inKey) {
+                        inKey = false;
+                        x += key.gap + key.width;
+                        if (x > mTotalWidth) {
+                            mTotalWidth = x;
+                        }
+                    } else if (inRow) {
+                        inRow = false;
+                        y += currentRow.verticalGap;
+                        y += currentRow.defaultHeight;
+                        row++;
+                    } else {
+                        // TODO: error or extend?
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Parse error:" + e);
+            e.printStackTrace();
+        }
+        mTotalHeight = y - mDefaultVerticalGap;
+    }
+    private void skipToEndOfRow(XmlResourceParser parser) 
+            throws XmlPullParserException, IOException {
+        int event;
+        while ((event = parser.next()) != XmlResourceParser.END_DOCUMENT) {
+            if (event == XmlResourceParser.END_TAG 
+                    && parser.getName().equals(TAG_ROW)) {
+                break;
+            }
+        }
+    }
+    
+    private void parseKeyboardAttributes(Resources res, XmlResourceParser parser) {
+        TypedArray a = res.obtainAttributes(Xml.asAttributeSet(parser), 
+                R.styleable.Keyboard);
+        mDefaultWidth = getDimensionOrFraction(a,
+                R.styleable.Keyboard_keyWidth,
+                mDisplayWidth, mDisplayWidth / 10);
+        mDefaultHeight = getDimensionOrFraction(a,
+                R.styleable.Keyboard_keyHeight,
+                mDisplayHeight, 50);
+        mDefaultHorizontalGap = getDimensionOrFraction(a,
+                R.styleable.Keyboard_horizontalGap,
+                mDisplayWidth, 0);
+        mDefaultVerticalGap = getDimensionOrFraction(a,
+                R.styleable.Keyboard_verticalGap,
+                mDisplayHeight, 0);
+        mProximityThreshold = (int) (mDefaultWidth * SEARCH_DISTANCE);
+        mProximityThreshold = mProximityThreshold * mProximityThreshold; // Square it for comparison
+        a.recycle();
+    }
+    
+    static int getDimensionOrFraction(TypedArray a, int index, int base, int defValue) {
+        TypedValue value = a.peekValue(index);
+        if (value == null) return defValue;
+        if (value.type == TypedValue.TYPE_DIMENSION) {
+            return a.getDimensionPixelOffset(index, defValue);
+        } else if (value.type == TypedValue.TYPE_FRACTION) {
+            // Round it to avoid values like 47.9999 from getting truncated
+            return Math.round(a.getFraction(index, base, base, defValue));
+        }
+        return defValue;
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/input/KeyboardView.java
+++ b/app/src/common/shared/com/igalia/wolvic/input/KeyboardView.java
@@ -13,13 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-package com.igalia.wolvic.ui.views;
-
+package com.igalia.wolvic.input;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Bitmap;
-import android.graphics.BlendMode;
-import android.graphics.BlendModeColorFilter;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
@@ -27,11 +24,11 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import com.igalia.wolvic.input.Keyboard;
 import com.igalia.wolvic.input.Keyboard.Key;
 import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -43,42 +40,35 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup.LayoutParams;
 import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityManager;
 import android.widget.PopupWindow;
 import android.widget.TextView;
-
-import androidx.annotation.NonNull;
-
 import com.igalia.wolvic.R;
-import com.igalia.wolvic.input.CustomKeyboard;
-
-import java.lang.ref.WeakReference;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
 /**
  * A view that renders a virtual {@link Keyboard}. It handles rendering of keys and
  * detecting key presses and touch movements.
  *
- * @attr ref android.R.styleable#KeyboardView_keyBackground
- * @attr ref android.R.styleable#KeyboardView_keyPreviewLayout
- * @attr ref android.R.styleable#KeyboardView_keyPreviewOffset
- * @attr ref android.R.styleable#KeyboardView_labelTextSize
- * @attr ref android.R.styleable#KeyboardView_keyTextSize
- * @attr ref android.R.styleable#KeyboardView_keyTextColor
- * @attr ref android.R.styleable#KeyboardView_verticalCorrection
- * @attr ref android.R.styleable#KeyboardView_popupLayout
+ * @attr ref R.styleable#KeyboardView_keyBackground
+ * @attr ref R.styleable#KeyboardView_keyPreviewLayout
+ * @attr ref R.styleable#KeyboardView_keyPreviewOffset
+ * @attr ref R.styleable#KeyboardView_keyPreviewHeight
+ * @attr ref R.styleable#KeyboardView_labelTextSize
+ * @attr ref R.styleable#KeyboardView_keyTextSize
+ * @attr ref R.styleable#KeyboardView_keyTextColor
+ * @attr ref R.styleable#KeyboardView_verticalCorrection
+ * @attr ref R.styleable#KeyboardView_popupLayout
+ *
+ * This class is copied from AOSP as instructed.
  */
-public class CustomKeyboardView extends View implements View.OnClickListener {
-
+public class KeyboardView extends View implements View.OnClickListener {
     /**
      * Listener for virtual keyboard events.
      */
     public interface OnKeyboardActionListener {
-
         /**
          * Called when the user presses a key. This is sent before the {@link #onKey} is called.
          * For keys that repeat, this is only called once.
@@ -86,18 +76,12 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
          * key, the value will be zero.
          */
         void onPress(int primaryCode);
-
-        void onLongPress(Key popupKey);
-
-        void onMultiTap(Key popupKey);
-
         /**
          * Called when the user releases a key. This is sent after the {@link #onKey} is called.
          * For keys that repeat, this is only called once.
          * @param primaryCode the code of the key that was released
          */
         void onRelease(int primaryCode);
-
         /**
          * Send a key press to the listener.
          * @param primaryCode this is the key that was pressed
@@ -108,42 +92,33 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
          * These codes are useful to correct for accidental presses of a key adjacent to
          * the intended key.
          */
-        void onKey(int primaryCode, int[] keyCodes, boolean hasPopup);
-
-        void onNoKey();
-
+        void onKey(int primaryCode, int[] keyCodes);
         /**
          * Sends a sequence of characters to the listener.
          * @param text the sequence of characters to be displayed.
          */
         void onText(CharSequence text);
-
         /**
          * Called when the user quickly moves the finger from right to left.
          */
         void swipeLeft();
-
         /**
          * Called when the user quickly moves the finger from left to right.
          */
         void swipeRight();
-
         /**
          * Called when the user quickly moves the finger from up to down.
          */
         void swipeDown();
-
         /**
          * Called when the user quickly moves the finger from down to up.
          */
         void swipeUp();
     }
-
     private static final boolean DEBUG = false;
     private static final int NOT_A_KEY = -1;
     private static final int[] KEY_DELETE = { Keyboard.KEYCODE_DELETE };
-    private static int[] LONG_PRESSABLE_STATE_SET = { android.R.attr.state_hovered };
-
+    private static final int[] LONG_PRESSABLE_STATE_SET = { R.attr.state_long_pressable };
     private Keyboard mKeyboard;
     private int mCurrentKeyIndex = NOT_A_KEY;
     private int mLabelTextSize;
@@ -152,7 +127,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     private float mShadowRadius;
     private int mShadowColor;
     private float mBackgroundDimAmount;
-
     private TextView mPreviewText;
     private PopupWindow mPreviewPopup;
     private int mPreviewTextSizeLarge;
@@ -160,65 +134,44 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     private int mPreviewHeight;
     // Working variable
     private final int[] mCoordinates = new int[2];
-
     private PopupWindow mPopupKeyboard;
     private View mMiniKeyboardContainer;
-    private CustomKeyboardView mMiniKeyboard;
+    private KeyboardView mMiniKeyboard;
     private boolean mMiniKeyboardOnScreen;
     private View mPopupParent;
     private int mMiniKeyboardOffsetX;
     private int mMiniKeyboardOffsetY;
     private Map<Key,View> mMiniKeyboardCache;
     private Key[] mKeys;
-
+    /** Listener for {@link OnKeyboardActionListener}. */
     private OnKeyboardActionListener mKeyboardActionListener;
-
     private static final int MSG_SHOW_PREVIEW = 1;
     private static final int MSG_REMOVE_PREVIEW = 2;
     private static final int MSG_REPEAT = 3;
     private static final int MSG_LONGPRESS = 4;
-
     private static final int DELAY_BEFORE_PREVIEW = 0;
     private static final int DELAY_AFTER_PREVIEW = 70;
     private static final int DEBOUNCE_TIME = 70;
-
-    private final static int[] KEY_STATE_HOVERED = {
-            android.R.attr.state_hovered,
-            android.R.attr.state_checkable,
-            android.R.attr.state_checked
-    };
-
-    private final static int[] KEY_STATE_NORMAL = {
-    };
-
     private int mVerticalCorrection;
     private int mProximityThreshold;
-
     private boolean mPreviewCentered = false;
     private boolean mShowPreview = true;
     private boolean mShowTouchPoints = true;
     private int mPopupPreviewX;
     private int mPopupPreviewY;
-
     private int mLastX;
     private int mLastY;
     private int mStartX;
     private int mStartY;
-
     private boolean mProximityCorrectOn;
-
     private Paint mPaint;
     private Rect mPadding;
-
     private long mDownTime;
     private long mLastMoveTime;
     private int mLastKey;
     private int mLastCodeX;
     private int mLastCodeY;
     private int mCurrentKey = NOT_A_KEY;
-    // Fork
-    private int[] mHoveredKey = new int[3];
-    private int[] mPrevHoveredKey = new int[3];
     private int mDownKey = NOT_A_KEY;
     private long mLastKeyTime;
     private long mCurrentKeyTime;
@@ -235,34 +188,23 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     private SwipeTracker mSwipeTracker = new SwipeTracker();
     private int mSwipeThreshold;
     private boolean mDisambiguateSwipe;
-    private float mKeyboardHoveredPadding = 0.0f;
-    private float mKeyboardPressedPadding = 0.0f;
-
     // Variables for dealing with multiple pointers
     private int mOldPointerCount = 1;
     private float mOldPointerX;
     private float mOldPointerY;
-
     private Drawable mKeyBackground;
-    private Drawable mKeyCapStartBackground = null;
-    private Drawable mKeyCapEndBackground = null;
-    private Drawable mKeySingleBackground = null;
-
     private static final int REPEAT_INTERVAL = 50; // ~20 keys per second
     private static final int REPEAT_START_DELAY = 400;
     private static final int LONGPRESS_TIMEOUT = ViewConfiguration.getLongPressTimeout();
-
     private static int MAX_NEARBY_KEYS = 12;
     private int[] mDistances = new int[MAX_NEARBY_KEYS];
-
     // For multi-tap
     private int mLastSentIndex;
     private int mTapCount;
     private long mLastTapTime;
     private boolean mInMultiTap;
-    private static final int MULTITAP_INTERVAL = 250; // milliseconds
+    private static final int MULTITAP_INTERVAL = 800; // milliseconds
     private StringBuilder mPreviewLabel = new StringBuilder(1);
-
     /** Whether the keyboard bitmap needs to be redrawn before it's blitted. **/
     private boolean mDrawPending;
     /** The dirty region in the keyboard bitmap */
@@ -273,83 +215,69 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     private boolean mKeyboardChanged;
     /** The canvas for the above mutable keyboard bitmap */
     private Canvas mCanvas;
+    /** The accessibility manager for accessibility support */
+    private AccessibilityManager mAccessibilityManager;
     /** The audio manager for accessibility support */
     private AudioManager mAudioManager;
     /** Whether the requirement of a headset to hear passwords if accessibility is enabled is announced. */
     private boolean mHeadsetRequiredToHearPasswordsAnnounced;
-
-    // Fork
-    private Drawable mFeaturedKeyBackground;
-    private HashSet<Integer> mFeaturedKeyCodes = new HashSet<>();
-    private int mSelectedForegroundColor;
-    private int mForegroundColor;
-
-    private Handler mHandler;
-
-    private static class MessageHandler extends Handler {
-        private WeakReference<CustomKeyboardView> mView;
-
-        @Deprecated
-        public MessageHandler(@NonNull CustomKeyboardView view) {
-            mView = new WeakReference<>(view);
-        }
-
-        @Override
-        public void handleMessage(Message msg) {
-            if (mView.get() != null) {
-                switch (msg.what) {
-                    case MSG_SHOW_PREVIEW:
-                        mView.get().showKey(msg.arg1);
-                        break;
-                    case MSG_REMOVE_PREVIEW:
-                        mView.get().getPreviewText().setVisibility(INVISIBLE);
-                        break;
-                    case MSG_REPEAT:
-                        if (mView.get().repeatKey()) {
-                            Message repeat = Message.obtain(this, MSG_REPEAT);
-                            sendMessageDelayed(repeat, REPEAT_INTERVAL);
-                        }
-                        break;
-                    case MSG_LONGPRESS:
-                        mView.get().openPopupIfRequired((MotionEvent) msg.obj);
-                        break;
-                }
-            }
-        }
+    Handler mHandler;
+    public KeyboardView(Context context, AttributeSet attrs) {
+        this(context, attrs, R.attr.keyboardViewStyle);
     }
-
-    public CustomKeyboardView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
-    }
-
-    public CustomKeyboardView(Context context, AttributeSet attrs, int defStyleAttr) {
+    public KeyboardView(Context context, AttributeSet attrs, int defStyleAttr) {
         this(context, attrs, defStyleAttr, 0);
     }
-
-    public CustomKeyboardView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    public KeyboardView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
-
+        TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.KeyboardView, defStyleAttr, defStyleRes);
         LayoutInflater inflate =
                 (LayoutInflater) context
                         .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-
         int previewLayout = 0;
         int keyTextSize = 0;
-        mKeyBackground = context.getDrawable(R.drawable.keyboard_key_background);
-        mKeyCapStartBackground = context.getDrawable(R.drawable.keyboard_key_background);
-        mVerticalCorrection = 0;
-        previewLayout = 0;
-        mPreviewOffset = 0;
-        mPreviewHeight = 80;
-        mKeyTextSize = context.getResources().getDimensionPixelSize(R.dimen.keyboard_key_text_size);
-        mKeyTextColor = 0xFFFFFFFF;
-        mLabelTextSize = context.getResources().getDimensionPixelSize(R.dimen.keyboard_key_longtext_size);
-        mPopupLayout = R.layout.keyboard;
-        mShadowColor = 0;
-        mShadowRadius = 0;
+        int n = a.getIndexCount();
+        for (int i = 0; i < n; i++) {
+            int attr = a.getIndex(i);
+            switch (attr) {
+            case R.styleable.KeyboardView_keyBackground:
+                mKeyBackground = a.getDrawable(attr);
+                break;
+            case R.styleable.KeyboardView_verticalCorrection:
+                mVerticalCorrection = a.getDimensionPixelOffset(attr, 0);
+                break;
+            case R.styleable.KeyboardView_keyPreviewLayout:
+                previewLayout = a.getResourceId(attr, 0);
+                break;
+            case R.styleable.KeyboardView_keyPreviewOffset:
+                mPreviewOffset = a.getDimensionPixelOffset(attr, 0);
+                break;
+            case R.styleable.KeyboardView_keyPreviewHeight:
+                mPreviewHeight = a.getDimensionPixelSize(attr, 80);
+                break;
+            case R.styleable.KeyboardView_keyTextSize:
+                mKeyTextSize = a.getDimensionPixelSize(attr, 18);
+                break;
+            case R.styleable.KeyboardView_keyTextColor:
+                mKeyTextColor = a.getColor(attr, 0xFF000000);
+                break;
+            case R.styleable.KeyboardView_labelTextSize:
+                mLabelTextSize = a.getDimensionPixelSize(attr, 14);
+                break;
+            case R.styleable.KeyboardView_popupLayout:
+                mPopupLayout = a.getResourceId(attr, 0);
+                break;
+            case R.styleable.KeyboardView_shadowColor:
+                mShadowColor = a.getColor(attr, 0);
+                break;
+            case R.styleable.KeyboardView_shadowRadius:
+                mShadowRadius = a.getFloat(attr, 0f);
+                break;
+            }
+        }
+        a.recycle();
         mBackgroundDimAmount = 0.5f;
-        clearHover();
-
         mPreviewPopup = new PopupWindow(context);
         if (previewLayout != 0) {
             mPreviewText = (TextView) inflate.inflate(previewLayout, null);
@@ -359,91 +287,62 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         } else {
             mShowPreview = false;
         }
-
         mPreviewPopup.setTouchable(false);
-
         mPopupKeyboard = new PopupWindow(context);
         mPopupKeyboard.setBackgroundDrawable(null);
         //mPopupKeyboard.setClippingEnabled(false);
-
         mPopupParent = this;
         //mPredicting = true;
-
         mPaint = new Paint();
         mPaint.setAntiAlias(true);
         mPaint.setTextSize(keyTextSize);
         mPaint.setTextAlign(Align.CENTER);
         mPaint.setAlpha(255);
-        mPaint.setTypeface(Typeface.create("sans-serif",Typeface.NORMAL));
-
         mPadding = new Rect(0, 0, 0, 0);
-        mMiniKeyboardCache = new HashMap<>();
+        mMiniKeyboardCache = new HashMap<Key,View>();
         mKeyBackground.getPadding(mPadding);
-        mKeyboardHoveredPadding = getResources().getDimensionPixelSize(R.dimen.keyboard_key_hovered_padding);
-        mKeyboardPressedPadding = getResources().getDimensionPixelSize(R.dimen.keyboard_key_pressed_padding);
-
         mSwipeThreshold = (int) (500 * getResources().getDisplayMetrics().density);
-        mDisambiguateSwipe = false;
-
+        mDisambiguateSwipe = getResources().getBoolean(
+                R.bool.config_swipeDisambiguation);
+        mAccessibilityManager = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
         mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-
         resetMultiTap();
-
-        mForegroundColor = context.getColor(R.color.asphalt);
-        mSelectedForegroundColor = context.getColor(R.color.fog);
     }
-
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         initGestureDetector();
         if (mHandler == null) {
-            mHandler = new MessageHandler(this);
+            mHandler = new Handler(Looper.getMainLooper()) {
+                @Override
+                public void handleMessage(Message msg) {
+                    switch (msg.what) {
+                        case MSG_SHOW_PREVIEW:
+                            showKey(msg.arg1);
+                            break;
+                        case MSG_REMOVE_PREVIEW:
+                            mPreviewText.setVisibility(INVISIBLE);
+                            break;
+                        case MSG_REPEAT:
+                            if (repeatKey()) {
+                                Message repeat = Message.obtain(this, MSG_REPEAT);
+                                sendMessageDelayed(repeat, REPEAT_INTERVAL);
+                            }
+                            break;
+                        case MSG_LONGPRESS:
+                            openPopupIfRequired((MotionEvent) msg.obj);
+                            break;
+                    }
+                }
+            };
         }
     }
-
-    public void setKeyBackground(Drawable resId) {
-        mKeyBackground = resId;
-    }
-
-    public void setKeyCapStartBackground(Drawable resId) {
-        mKeyCapStartBackground = resId;
-    }
-
-    public void setKeySingleStartBackground(Drawable resId) {
-        mKeySingleBackground = resId;
-    }
-
-    public void setKeyCapEndBackground(Drawable resId) {
-        mKeyCapEndBackground = resId;
-    }
-
-    public void setKeyTextColor(int color) {
-        mKeyTextColor = color;
-    }
-
-    public void setSelectedForegroundColor(int color) {
-        mSelectedForegroundColor = color;
-    }
-
-    public void setForegroundColor(int color) {
-        mForegroundColor = color;
-    }
-
-    public void setKeyboardHoveredPadding(int padding) {
-        mKeyboardHoveredPadding = padding;
-    }
-
-    public void setKeyboardPressedPadding(int padding) {
-        mKeyboardPressedPadding = padding;
-    }
-
     private void initGestureDetector() {
         if (mGestureDetector == null) {
             mGestureDetector = new GestureDetector(getContext(), new GestureDetector.SimpleOnGestureListener() {
                 @Override
                 public boolean onFling(MotionEvent me1, MotionEvent me2,
-                                       float velocityX, float velocityY) {
+                        float velocityX, float velocityY) {
                     if (mPossiblePoly) return false;
                     final float absX = Math.abs(velocityX);
                     final float absY = Math.abs(velocityY);
@@ -484,30 +383,25 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                             return true;
                         }
                     }
-
                     if (sendDownKey) {
                         detectAndSendKey(mDownKey, mStartX, mStartY, me1.getEventTime());
                     }
                     return false;
                 }
             });
-
             mGestureDetector.setIsLongpressEnabled(false);
         }
     }
-
     public void setOnKeyboardActionListener(OnKeyboardActionListener listener) {
         mKeyboardActionListener = listener;
     }
-
     /**
-     * Returns the {@link com.igalia.wolvic.input.KeyboardView.OnKeyboardActionListener} object.
+     * Returns the {@link OnKeyboardActionListener} object.
      * @return the listener attached to this keyboard
      */
     protected OnKeyboardActionListener getOnKeyboardActionListener() {
         return mKeyboardActionListener;
     }
-
     /**
      * Attaches a keyboard to this view. The keyboard can be switched at any time and the
      * view will re-layout itself to accommodate the keyboard.
@@ -534,7 +428,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         // doesn't get delivered to the old or new keyboard
         mAbortKey = true; // Until the next ACTION_DOWN
     }
-
     /**
      * Returns the current keyboard being displayed by this view.
      * @return the currently attached keyboard
@@ -543,28 +436,27 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     public Keyboard getKeyboard() {
         return mKeyboard;
     }
-
     /**
      * Sets the state of the shift key of the keyboard, if any.
      * @param shifted whether or not to enable the state of the shift key
      * @return true if the shift key state changed, false if there was no change
-     * @see com.igalia.wolvic.input.KeyboardView#isShifted()
+     * @see KeyboardView#isShifted()
      */
     public boolean setShifted(boolean shifted) {
         if (mKeyboard != null) {
-            mKeyboard.setShifted(shifted);
-            // The whole keyboard probably needs to be redrawn
-            invalidateAllKeys();
-            return true;
+            if (mKeyboard.setShifted(shifted)) {
+                // The whole keyboard probably needs to be redrawn
+                invalidateAllKeys();
+                return true;
+            }
         }
         return false;
     }
-
     /**
      * Returns the state of the shift key of the keyboard, if any.
      * @return true if the shift is in a pressed state, false otherwise. If there is
      * no shift key on the keyboard or there is no keyboard attached, it returns false.
-     * @see com.igalia.wolvic.input.KeyboardView#setShifted(boolean)
+     * @see KeyboardView#setShifted(boolean)
      */
     public boolean isShifted() {
         if (mKeyboard != null) {
@@ -572,7 +464,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         }
         return false;
     }
-
     /**
      * Enables or disables the key feedback popup. This is a popup that shows a magnified
      * version of the depressed key. By default the preview is enabled.
@@ -582,7 +473,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     public void setPreviewEnabled(boolean previewEnabled) {
         mShowPreview = previewEnabled;
     }
-
     /**
      * Returns the enabled state of the key feedback popup.
      * @return whether or not the key feedback popup is enabled
@@ -591,14 +481,11 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     public boolean isPreviewEnabled() {
         return mShowPreview;
     }
-
     public void setVerticalCorrection(int verticalOffset) {
-
     }
     public void setPopupParent(View v) {
         mPopupParent = v;
     }
-
     public void setPopupOffset(int x, int y) {
         mMiniKeyboardOffsetX = x;
         mMiniKeyboardOffsetY = y;
@@ -606,9 +493,8 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             mPreviewPopup.dismiss();
         }
     }
-
     /**
-     * When enabled, calls to {@link com.igalia.wolvic.input.KeyboardView.OnKeyboardActionListener#onKey} will include key
+     * When enabled, calls to {@link OnKeyboardActionListener#onKey} will include key
      * codes for adjacent keys.  When disabled, only the primary key code will be
      * reported.
      * @param enabled whether or not the proximity correction is enabled
@@ -616,14 +502,12 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     public void setProximityCorrectionEnabled(boolean enabled) {
         mProximityCorrectOn = enabled;
     }
-
     /**
      * Returns true if proximity correction is enabled.
      */
     public boolean isProximityCorrectionEnabled() {
         return mProximityCorrectOn;
     }
-
     /**
      * Popup keyboard close button clicked.
      * @hide
@@ -631,29 +515,30 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
     public void onClick(View v) {
         dismissPopupKeyboard();
     }
-
     private CharSequence adjustCase(CharSequence label) {
-        if (mKeyboard.isShifted() && label != null && label.length() > 0 && label.length() < 3
+        if (mKeyboard.isShifted() && label != null && label.length() < 3
                 && Character.isLowerCase(label.charAt(0))) {
             label = label.toString().toUpperCase();
         }
         return label;
     }
-
     @Override
     public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int mPaddingLeft = getPaddingLeft();
+        int mPaddingRight = getPaddingRight();
+        int mPaddingTop = getPaddingTop();
+        int mPaddingBottom = getPaddingBottom();
         // Round up a little
         if (mKeyboard == null) {
-            setMeasuredDimension(getPaddingLeft() + getPaddingRight(), getPaddingTop() + getPaddingBottom());
+            setMeasuredDimension(mPaddingLeft + mPaddingRight, mPaddingTop + mPaddingBottom);
         } else {
-            int width = mKeyboard.getMinWidth() + getPaddingLeft() + getPaddingRight();
+            int width = mKeyboard.getMinWidth() + mPaddingLeft + mPaddingRight;
             if (MeasureSpec.getSize(widthMeasureSpec) < width + 10) {
                 width = MeasureSpec.getSize(widthMeasureSpec);
             }
-            setMeasuredDimension(width, mKeyboard.getHeight() + getPaddingTop() + getPaddingBottom());
+            setMeasuredDimension(width, mKeyboard.getHeight() + mPaddingTop + mPaddingBottom);
         }
     }
-
     /**
      * Compute the average distance between adjacent keys (horizontally and vertically)
      * and square it to get the proximity threshold. We use a square here and in computing
@@ -674,43 +559,23 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         mProximityThreshold = (int) (dimensionSum * 1.4f / length);
         mProximityThreshold *= mProximityThreshold; // Square it
     }
-
-    private Method mResizeMethod;
     @Override
     public void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         if (mKeyboard != null) {
-            if (mResizeMethod == null) {
-                try {
-                    mResizeMethod = Keyboard.class.getDeclaredMethod("resize", int.class, int.class);
-                }
-                catch (Exception ex) {
-                    ex.printStackTrace();
-                }
-            }
-            if (mResizeMethod != null) {
-                try {
-                    mResizeMethod.setAccessible(true);
-                    mResizeMethod.invoke(mKeyboard, w, h);
-                }
-                catch (Exception ex) {
-                    ex.printStackTrace();
-                }
-            }
+            mKeyboard.resize(w, h);
         }
         // Release the buffer, if any and it will be reallocated on the next draw
         mBuffer = null;
     }
-
     @Override
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
         if (mDrawPending || mBuffer == null || mKeyboardChanged) {
             onBufferDraw();
         }
-        canvas.drawBitmap(mBuffer, 0, 0, mPaint);
+        canvas.drawBitmap(mBuffer, 0, 0, null);
     }
-
     private void onBufferDraw() {
         if (mBuffer == null || mKeyboardChanged) {
             if (mBuffer == null || mKeyboardChanged &&
@@ -724,30 +589,28 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             invalidateAllKeys();
             mKeyboardChanged = false;
         }
-        final Canvas canvas = mCanvas;
-        mCanvas.save();
-        canvas.clipRect(mDirtyRect);
-
         if (mKeyboard == null) return;
-
+        mCanvas.save();
+        final Canvas canvas = mCanvas;
+        canvas.clipRect(mDirtyRect);
         final Paint paint = mPaint;
+        final Drawable keyBackground = mKeyBackground;
         final Rect clipRegion = mClipRegion;
         final Rect padding = mPadding;
         final int kbdPaddingLeft = getPaddingLeft();
         final int kbdPaddingTop = getPaddingTop();
         final Key[] keys = mKeys;
         final Key invalidKey = mInvalidatedKey;
-
         paint.setColor(mKeyTextColor);
         boolean drawSingleKey = false;
         if (invalidKey != null && canvas.getClipBounds(clipRegion)) {
-            // Is clipRegion completely contained within the invalidated key?
-            if (invalidKey.x + kbdPaddingLeft - 1 <= clipRegion.left &&
-                    invalidKey.y + kbdPaddingTop - 1 <= clipRegion.top &&
-                    invalidKey.x + invalidKey.width + kbdPaddingLeft + 1 >= clipRegion.right &&
-                    invalidKey.y + invalidKey.height + kbdPaddingTop + 1 >= clipRegion.bottom) {
-                drawSingleKey = true;
-            }
+          // Is clipRegion completely contained within the invalidated key?
+          if (invalidKey.x + kbdPaddingLeft - 1 <= clipRegion.left &&
+                  invalidKey.y + kbdPaddingTop - 1 <= clipRegion.top &&
+                  invalidKey.x + invalidKey.width + kbdPaddingLeft + 1 >= clipRegion.right &&
+                  invalidKey.y + invalidKey.height + kbdPaddingTop + 1 >= clipRegion.bottom) {
+              drawSingleKey = true;
+          }
         }
         canvas.drawColor(0x00000000, PorterDuff.Mode.CLEAR);
         final int keyCount = keys.length;
@@ -756,45 +619,10 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             if (drawSingleKey && invalidKey != key) {
                 continue;
             }
-
-            boolean stateHovered = false;
-            boolean statePressed = false;
             int[] drawableState = key.getCurrentDrawableState();
-
-            if (((CustomKeyboard)mKeyboard).isKeyEnabled(i)) {
-                if (isKeyHovered(i) && !key.pressed) {
-                    // Fork: implement hovered key
-                    drawableState = KEY_STATE_HOVERED;
-                }
-
-                for (int state : drawableState) {
-                    if (state == android.R.attr.state_hovered) {
-                        stateHovered = true;
-                    } else if (state == android.R.attr.state_pressed) {
-                        statePressed = true;
-                    }
-                }
-
-            } else {
-                drawableState = KEY_STATE_NORMAL;
-            }
-
-            Drawable keyBackground = mKeyBackground;
-            int columns = ((CustomKeyboard)mKeyboard).getMaxColumns();
-            if (mFeaturedKeyBackground != null && mFeaturedKeyCodes.contains(key.codes[0])) {
-                keyBackground = mFeaturedKeyBackground;
-            } else if ((i == columns && i == keyCount - 1) && mKeySingleBackground != null) {
-                keyBackground = mKeySingleBackground;
-            } else if ((i == 0 || i == columns) && mKeyCapStartBackground != null) {
-                keyBackground = mKeyCapStartBackground;
-            } else if ((i == keyCount  - 1 || i == columns - 1)&& mKeyCapEndBackground != null) {
-                keyBackground = mKeyCapEndBackground;
-            }
             keyBackground.setState(drawableState);
-
             // Switch the character to uppercase if shift is pressed
-            String label = key.label == null ? null : adjustCase(key.label).toString();
-
+            String label = key.label == null? null : adjustCase(key.label).toString();
             final Rect bounds = keyBackground.getBounds();
             if (key.width != bounds.right ||
                     key.height != bounds.bottom) {
@@ -802,64 +630,34 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             }
             canvas.translate(key.x + kbdPaddingLeft, key.y + kbdPaddingTop);
             keyBackground.draw(canvas);
-
-            // Get the button state related padding
-            float statePadding = 0.0f;
-            if (stateHovered) {
-                statePadding = -mKeyboardHoveredPadding;
-
-            } else if (statePressed) {
-                statePadding = mKeyboardPressedPadding;
-            }
-
-            int targetColor = mKeyTextColor;
-            if (stateHovered) {
-                targetColor = mForegroundColor;
-            } else if (statePressed) {
-                targetColor = mSelectedForegroundColor;
-            }
-
             if (label != null) {
-                float descent;
-
                 // For characters, use large font. For labels like "Done", use small font.
                 if (label.length() > 1 && key.codes.length < 2) {
                     paint.setTextSize(mLabelTextSize);
                     paint.setTypeface(Typeface.DEFAULT_BOLD);
-                    descent = mLabelTextSize * 0.1f;
-
                 } else {
                     paint.setTextSize(mKeyTextSize);
                     paint.setTypeface(Typeface.DEFAULT);
-                    descent = paint.descent();
                 }
-                paint.setColor(targetColor);
-
                 // Draw a drop shadow for the text
                 paint.setShadowLayer(mShadowRadius, 0, 0, mShadowColor);
-
                 // Draw the text
                 canvas.drawText(label,
-                        (key.width - padding.left - padding.right) / 2.0f
-                                + padding.left  + statePadding,
-                        (key.height - padding.top - padding.bottom) / 2.0f
-                                + (paint.getTextSize() / 2)  - descent + padding.top  + statePadding,
-                        paint);
+                    (key.width - padding.left - padding.right) / 2
+                            + padding.left,
+                    (key.height - padding.top - padding.bottom) / 2
+                            + (paint.getTextSize() - paint.descent()) / 2 + padding.top,
+                    paint);
                 // Turn off drop shadow
                 paint.setShadowLayer(0, 0, 0, 0);
-
             } else if (key.icon != null) {
-                final float drawableX = (key.width - padding.left - padding.right - key.icon.getIntrinsicWidth()) / 2.0f
-                        + padding.left + statePadding;
-                final float drawableY = (key.height - padding.top - padding.bottom - key.icon.getIntrinsicHeight()) / 2.0f
-                        + padding.top + statePadding;
+                final int drawableX = (key.width - padding.left - padding.right
+                                - key.icon.getIntrinsicWidth()) / 2 + padding.left;
+                final int drawableY = (key.height - padding.top - padding.bottom
+                        - key.icon.getIntrinsicHeight()) / 2 + padding.top;
                 canvas.translate(drawableX, drawableY);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    key.icon.setColorFilter(new BlendModeColorFilter(targetColor, BlendMode.MODULATE));
-                } else {
-                    key.icon.setColorFilter(targetColor, PorterDuff.Mode.MULTIPLY);
-                }
-                key.icon.setBounds(0, 0, key.icon.getIntrinsicWidth(), key.icon.getIntrinsicHeight());
+                key.icon.setBounds(0, 0,
+                        key.icon.getIntrinsicWidth(), key.icon.getIntrinsicHeight());
                 key.icon.draw(canvas);
                 canvas.translate(-drawableX, -drawableY);
             }
@@ -871,7 +669,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             paint.setColor((int) (mBackgroundDimAmount * 0xFF) << 24);
             canvas.drawRect(0, 0, getWidth(), getHeight(), paint);
         }
-
         if (DEBUG && mShowTouchPoints) {
             paint.setAlpha(128);
             paint.setColor(0xFFFF0000);
@@ -882,24 +679,10 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             paint.setColor(0xFF00FF00);
             canvas.drawCircle((mStartX + mLastX) / 2, (mStartY + mLastY) / 2, 2, paint);
         }
-
         mCanvas.restore();
         mDrawPending = false;
         mDirtyRect.setEmpty();
     }
-
-    /**
-     * We use our own Key.isInside implementation {@link Keyboard#isInside} as that one assumes that the
-     * motion event is inside the key if it is an edge key.
-     */
-    public boolean isInside(Key key, int x, int y) {
-        if ((x >= key.x) && (x < key.x + key.width) && (y >= key.y) && (y < key.y + key.height)) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     private int getKeyIndices(int x, int y, int[] allKeys) {
         final Key[] keys = mKeys;
         int primaryIndex = NOT_A_KEY;
@@ -911,11 +694,10 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         for (int i = 0; i < keyCount; i++) {
             final Key key = keys[nearestKeyIndices[i]];
             int dist = 0;
-            boolean isInside = isInside(key, x,y);
+            boolean isInside = key.isInside(x,y);
             if (isInside) {
                 primaryIndex = nearestKeyIndices[i];
             }
-
             if (((mProximityCorrectOn
                     && (dist = key.squaredDistanceFrom(x, y)) < mProximityThreshold)
                     || isInside)
@@ -926,9 +708,7 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                     closestKeyDist = dist;
                     closestKey = nearestKeyIndices[i];
                 }
-
                 if (allKeys == null) continue;
-
                 for (int j = 0; j < mDistances.length; j++) {
                     if (mDistances[j] > dist) {
                         // Make space for nCodes codes
@@ -950,56 +730,34 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         }
         return primaryIndex;
     }
-
     private void detectAndSendKey(int index, int x, int y, long eventTime) {
         if (index != NOT_A_KEY && index < mKeys.length) {
             final Key key = mKeys[index];
-            if (key.text != null && (key.popupCharacters == null || key.popupCharacters.length() == 0)) {
-                if (mKeyboardActionListener != null) {
-                    mKeyboardActionListener.onText(key.text);
-                    mKeyboardActionListener.onRelease(NOT_A_KEY);
-                }
+            if (key.text != null) {
+                mKeyboardActionListener.onText(key.text);
+                mKeyboardActionListener.onRelease(NOT_A_KEY);
             } else {
                 int code = key.codes[0];
-                boolean hasPopup = key.popupCharacters != null && key.popupCharacters.length() > 0;
                 //TextEntryState.keyPressedAt(key, x, y);
                 int[] codes = new int[MAX_NEARBY_KEYS];
                 Arrays.fill(codes, NOT_A_KEY);
                 getKeyIndices(x, y, codes);
                 // Multi-tap
                 if (mInMultiTap) {
-                    if (mTapCount != -1 && mKeyboardActionListener != null) {
-                        if (code != CustomKeyboard.KEYCODE_SHIFT) {
-                            mKeyboardActionListener.onKey(Keyboard.KEYCODE_DELETE, KEY_DELETE, hasPopup);
-                        }
+                    if (mTapCount != -1) {
+                        mKeyboardActionListener.onKey(Keyboard.KEYCODE_DELETE, KEY_DELETE);
                     } else {
                         mTapCount = 0;
                     }
                     code = key.codes[mTapCount];
-
-                    if (mKeyboardActionListener != null) {
-                        mKeyboardActionListener.onMultiTap(key);
-                    }
                 }
-                if (mKeyboardActionListener != null) {
-                    mKeyboardActionListener.onKey(code, codes, hasPopup);
-                    mKeyboardActionListener.onRelease(code);
-                }
+                mKeyboardActionListener.onKey(code, codes);
+                mKeyboardActionListener.onRelease(code);
             }
             mLastSentIndex = index;
             mLastTapTime = eventTime;
-
-        } else {
-            if (mKeyboardActionListener != null) {
-                mKeyboardActionListener.onNoKey();
-            }
         }
     }
-
-    private TextView getPreviewText() {
-        return mPreviewText;
-    }
-
     /**
      * Handle multi-tap keys by producing the key label for the current multi-tap state.
      */
@@ -1013,11 +771,9 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             return adjustCase(key.label);
         }
     }
-
     private void showPreview(int keyIndex) {
         int oldKeyIndex = mCurrentKeyIndex;
         final PopupWindow previewPopup = mPreviewPopup;
-
         mCurrentKeyIndex = keyIndex;
         // Release the old key and press the new key
         final Key[] keys = mKeys;
@@ -1051,7 +807,7 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             if (previewPopup.isShowing()) {
                 if (keyIndex == NOT_A_KEY) {
                     mHandler.sendMessageDelayed(mHandler
-                                    .obtainMessage(MSG_REMOVE_PREVIEW),
+                            .obtainMessage(MSG_REMOVE_PREVIEW),
                             DELAY_AFTER_PREVIEW);
                 }
             }
@@ -1067,7 +823,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             }
         }
     }
-
     private void showKey(final int keyIndex) {
         final PopupWindow previewPopup = mPreviewPopup;
         final Key[] keys = mKeys;
@@ -1110,13 +865,11 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         getLocationInWindow(mCoordinates);
         mCoordinates[0] += mMiniKeyboardOffsetX; // Offset may be zero
         mCoordinates[1] += mMiniKeyboardOffsetY; // Offset may be zero
-
         // Set the preview background state
         mPreviewText.getBackground().setState(
                 key.popupResId != 0 ? LONG_PRESSABLE_STATE_SET : EMPTY_STATE_SET);
         mPopupPreviewX += mCoordinates[0];
         mPopupPreviewY += mCoordinates[1];
-
         // If the popup cannot be shown above the key, put it on the side
         getLocationOnScreen(mCoordinates);
         if (mPopupPreviewY + mCoordinates[1] < 0) {
@@ -1129,7 +882,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             }
             mPopupPreviewY += popupHeight;
         }
-
         if (previewPopup.isShowing()) {
             previewPopup.update(mPopupPreviewX, mPopupPreviewY,
                     popupWidth, popupHeight);
@@ -1141,11 +893,46 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         }
         mPreviewText.setVisibility(VISIBLE);
     }
-
     private void sendAccessibilityEventForUnicodeCharacter(int eventType, int code) {
-        // TODO: We need to implement AccessibilityNodeProvider for this view.
-    }
+        if (mAccessibilityManager.isEnabled()) {
+            AccessibilityEvent event;
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+                event = new AccessibilityEvent(eventType);
+            } else {
+                event = AccessibilityEvent.obtain(eventType);
+            }
 
+            onInitializeAccessibilityEvent(event);
+            final String text;
+            switch (code) {
+                case Keyboard.KEYCODE_ALT:
+                    text = getContext().getString(R.string.keyboardview_keycode_alt);
+                    break;
+                case Keyboard.KEYCODE_CANCEL:
+                    text = getContext().getString(R.string.keyboardview_keycode_cancel);
+                    break;
+                case Keyboard.KEYCODE_DELETE:
+                    text = getContext().getString(R.string.keyboardview_keycode_delete);
+                    break;
+                case Keyboard.KEYCODE_DONE:
+                    text = getContext().getString(R.string.keyboardview_keycode_done);
+                    break;
+                case Keyboard.KEYCODE_MODE_CHANGE:
+                    text = getContext().getString(R.string.keyboardview_keycode_mode_change);
+                    break;
+                case Keyboard.KEYCODE_SHIFT:
+                    text = getContext().getString(R.string.keyboardview_keycode_shift);
+                    break;
+                case '\n':
+                    text = getContext().getString(R.string.keyboardview_keycode_enter);
+                    break;
+                default:
+                    text = String.valueOf((char) code);
+            }
+            event.getText().add(text);
+            mAccessibilityManager.sendAccessibilityEvent(event);
+        }
+    }
     /**
      * Requests a redraw of the entire keyboard. Calling {@link #invalidate} is not sufficient
      * because the keyboard renders the keys to an off-screen buffer and an invalidate() only
@@ -1153,12 +940,10 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
      * @see #invalidateKey(int)
      */
     public void invalidateAllKeys() {
-        clearHover();
         mDirtyRect.union(0, 0, getWidth(), getHeight());
         mDrawPending = true;
         invalidate();
     }
-
     /**
      * Invalidates a key so that it will be redrawn on the next repaint. Use this method if only
      * one key is changing it's content. Any changes that affect the position or size of the key
@@ -1173,12 +958,13 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         }
         final Key key = mKeys[keyIndex];
         mInvalidatedKey = key;
-        mDirtyRect.union(key.x + getPaddingLeft(), key.y + getPaddingTop(),
-                key.x + key.width + getPaddingLeft(), key.y + key.height + getPaddingTop());
+        int mPaddingLeft = getPaddingLeft();
+        int mPaddingTop = getPaddingTop();
+        mDirtyRect.union(key.x + mPaddingLeft, key.y + mPaddingTop,
+                key.x + key.width + mPaddingLeft, key.y + key.height + mPaddingTop);
         onBufferDraw();
         invalidate();
     }
-
     private boolean openPopupIfRequired(MotionEvent me) {
         // Check if we have a popup layout specified first.
         if (mPopupLayout == 0) {
@@ -1187,7 +973,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         if (mCurrentKey < 0 || mCurrentKey >= mKeys.length) {
             return false;
         }
-
         Key popupKey = mKeys[mCurrentKey];
         boolean result = onLongPress(popupKey);
         if (result) {
@@ -1196,7 +981,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         }
         return result;
     }
-
     /**
      * Called when a key is long pressed. By default this will open any popup keyboard associated
      * with this key through the attributes popupLayout and popupCharacters.
@@ -1205,12 +989,97 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
      * method on the base class if the subclass doesn't wish to handle the call.
      */
     protected boolean onLongPress(Key popupKey) {
-        if (mKeyboardActionListener != null) {
-            mKeyboardActionListener.onLongPress(popupKey);
+        int popupKeyboardId = popupKey.popupResId;
+        if (popupKeyboardId != 0) {
+            mMiniKeyboardContainer = mMiniKeyboardCache.get(popupKey);
+            if (mMiniKeyboardContainer == null) {
+                LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(
+                        Context.LAYOUT_INFLATER_SERVICE);
+                mMiniKeyboardContainer = inflater.inflate(mPopupLayout, null);
+                mMiniKeyboard = (KeyboardView) mMiniKeyboardContainer.findViewById(
+                        R.id.keyboardView);
+                View closeButton = mMiniKeyboardContainer.findViewById(
+                        R.id.closeButton);
+                if (closeButton != null) closeButton.setOnClickListener(this);
+                mMiniKeyboard.setOnKeyboardActionListener(new OnKeyboardActionListener() {
+                    public void onKey(int primaryCode, int[] keyCodes) {
+                        mKeyboardActionListener.onKey(primaryCode, keyCodes);
+                        dismissPopupKeyboard();
+                    }
+                    public void onText(CharSequence text) {
+                        mKeyboardActionListener.onText(text);
+                        dismissPopupKeyboard();
+                    }
+                    public void swipeLeft() { }
+                    public void swipeRight() { }
+                    public void swipeUp() { }
+                    public void swipeDown() { }
+                    public void onPress(int primaryCode) {
+                        mKeyboardActionListener.onPress(primaryCode);
+                    }
+                    public void onRelease(int primaryCode) {
+                        mKeyboardActionListener.onRelease(primaryCode);
+                    }
+                });
+                //mInputView.setSuggest(mSuggest);
+                Keyboard keyboard;
+                if (popupKey.popupCharacters != null) {
+                    keyboard = new Keyboard(getContext(), popupKeyboardId,
+                            popupKey.popupCharacters, -1, getPaddingLeft() + getPaddingRight());
+                } else {
+                    keyboard = new Keyboard(getContext(), popupKeyboardId);
+                }
+                mMiniKeyboard.setKeyboard(keyboard);
+                mMiniKeyboard.setPopupParent(this);
+                mMiniKeyboardContainer.measure(
+                        MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.AT_MOST),
+                        MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.AT_MOST));
+                mMiniKeyboardCache.put(popupKey, mMiniKeyboardContainer);
+            } else {
+                mMiniKeyboard = (KeyboardView) mMiniKeyboardContainer.findViewById(
+                        R.id.keyboardView);
+            }
+            getLocationInWindow(mCoordinates);
+            int mPaddingLeft = getPaddingLeft();
+            int mPaddingTop = getPaddingTop();
+            mPopupX = popupKey.x + mPaddingLeft;
+            mPopupY = popupKey.y + mPaddingTop;
+            mPopupX = mPopupX + popupKey.width - mMiniKeyboardContainer.getMeasuredWidth();
+            mPopupY = mPopupY - mMiniKeyboardContainer.getMeasuredHeight();
+            final int x = mPopupX + mMiniKeyboardContainer.getPaddingRight() + mCoordinates[0];
+            final int y = mPopupY + mMiniKeyboardContainer.getPaddingBottom() + mCoordinates[1];
+            mMiniKeyboard.setPopupOffset(x < 0 ? 0 : x, y);
+            mMiniKeyboard.setShifted(isShifted());
+            mPopupKeyboard.setContentView(mMiniKeyboardContainer);
+            mPopupKeyboard.setWidth(mMiniKeyboardContainer.getMeasuredWidth());
+            mPopupKeyboard.setHeight(mMiniKeyboardContainer.getMeasuredHeight());
+            mPopupKeyboard.showAtLocation(this, Gravity.NO_GRAVITY, x, y);
+            mMiniKeyboardOnScreen = true;
+            //mMiniKeyboard.onTouchEvent(getTranslatedEvent(me));
+            invalidateAllKeys();
+            return true;
         }
         return false;
     }
-
+    @Override
+    public boolean onHoverEvent(MotionEvent event) {
+        if (mAccessibilityManager.isTouchExplorationEnabled() && event.getPointerCount() == 1) {
+            final int action = event.getAction();
+            switch (action) {
+                case MotionEvent.ACTION_HOVER_ENTER: {
+                    event.setAction(MotionEvent.ACTION_DOWN);
+                } break;
+                case MotionEvent.ACTION_HOVER_MOVE: {
+                    event.setAction(MotionEvent.ACTION_MOVE);
+                } break;
+                case MotionEvent.ACTION_HOVER_EXIT: {
+                    event.setAction(MotionEvent.ACTION_UP);
+                } break;
+            }
+            return onTouchEvent(event);
+        }
+        return true;
+    }
     @Override
     public boolean onTouchEvent(MotionEvent me) {
         // Convert multi-pointer up/down events to single up/down events to
@@ -1219,7 +1088,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         final int action = me.getAction();
         boolean result = false;
         final long now = me.getEventTime();
-
         if (pointerCount != mOldPointerCount) {
             if (pointerCount == 1) {
                 // Send a down event for the latest pointer
@@ -1249,122 +1117,38 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             }
         }
         mOldPointerCount = pointerCount;
-
         return result;
     }
-
-    // Fork: Implement keyboard hover events
-    @Override
-    public boolean onHoverEvent(MotionEvent event) {
-        boolean result = super.onHoverEvent(event);
-
-        int keyIndex = NOT_A_KEY;
-        if (event.getAction() != MotionEvent.ACTION_HOVER_EXIT) {
-            int touchX = (int) event.getX() - getPaddingLeft();
-            int touchY = (int) event.getY() - getPaddingTop();
-            if (touchY >= -mVerticalCorrection) {
-                touchY += mVerticalCorrection;
-            }
-            keyIndex = getKeyIndices(touchX, touchY, null);
-        }
-
-        mPrevHoveredKey[event.getDeviceId()] = mHoveredKey[event.getDeviceId()];
-        mHoveredKey[event.getDeviceId()] = keyIndex;
-        int prevHovered = mPrevHoveredKey[event.getDeviceId()];
-        int currentHovered = mHoveredKey[event.getDeviceId()];
-        if (currentHovered != NOT_A_KEY && prevHovered != currentHovered) {
-            invalidateKey(currentHovered);
-        }
-        if (prevHovered != NOT_A_KEY && prevHovered != currentHovered) {
-            invalidateKey(prevHovered);
-        }
-        return result;
-    }
-
-    @Override
-    public void setHovered(boolean hovered) {
-        if (!hovered) {
-            boolean hasChanged = false;
-            for (int i=0; i<mHoveredKey.length; i++) {
-                hasChanged |= mPrevHoveredKey[i] != mHoveredKey[i];
-            }
-
-            if (hasChanged) {
-                clearHover();
-                invalidateAllKeys();
-            }
-        }
-        super.setHovered(hovered);
-    }
-
-    @Override
-    public boolean isHovered() {
-        boolean isHovered = false;
-        for (int value : mHoveredKey) {
-            isHovered |= value != NOT_A_KEY;
-        }
-        return isHovered;
-    }
-
-    private boolean isKeyHovered(int keyIndex) {
-        boolean isHovered = false;
-        for (int value : mHoveredKey) {
-            isHovered |= value == keyIndex;
-        }
-
-        return isHovered;
-    }
-
-    private void clearHover() {
-        Arrays.fill(mHoveredKey, NOT_A_KEY);
-        Arrays.fill(mPrevHoveredKey, NOT_A_KEY);
-    }
-
-    public void setFeaturedKeyBackground(int resId, int[] keyCodes) {
-        mFeaturedKeyBackground = getResources().getDrawable(resId, getContext().getTheme());
-        mFeaturedKeyCodes.clear();
-        for (int value: keyCodes) {
-            mFeaturedKeyCodes.add(value);
-        }
-    }
-
     private boolean onModifiedTouchEvent(MotionEvent me, boolean possiblePoly) {
-        int touchX = (int) me.getX() - getPaddingLeft();
-        int touchY = (int) me.getY() - getPaddingTop();
-        if (touchY >= -mVerticalCorrection) {
+        int mPaddingLeft = getPaddingLeft();
+        int mPaddingTop = getPaddingTop();
+        int touchX = (int) me.getX() - mPaddingLeft;
+        int touchY = (int) me.getY() - mPaddingTop;
+        if (touchY >= -mVerticalCorrection)
             touchY += mVerticalCorrection;
-        }
         final int action = me.getAction();
         final long eventTime = me.getEventTime();
         int keyIndex = getKeyIndices(touchX, touchY, null);
         mPossiblePoly = possiblePoly;
-
-        if (keyIndex != NOT_A_KEY && !((CustomKeyboard)mKeyboard).isKeyEnabled(keyIndex)) {
-            return true;
-        }
-
         // Track the last few movements to look for spurious swipes.
         if (action == MotionEvent.ACTION_DOWN) mSwipeTracker.clear();
         mSwipeTracker.addMovement(me);
-
         // Ignore all motion events until a DOWN.
-        if (mAbortKey && action != MotionEvent.ACTION_DOWN && action != MotionEvent.ACTION_CANCEL) {
+        if (mAbortKey
+                && action != MotionEvent.ACTION_DOWN && action != MotionEvent.ACTION_CANCEL) {
             return true;
         }
-
         if (mGestureDetector.onTouchEvent(me)) {
             showPreview(NOT_A_KEY);
             mHandler.removeMessages(MSG_REPEAT);
             mHandler.removeMessages(MSG_LONGPRESS);
             return true;
         }
-
         // Needs to be called after the gesture detector gets a turn, as it may have
         // displayed the mini keyboard
         if (mMiniKeyboardOnScreen && action != MotionEvent.ACTION_CANCEL) {
             return true;
         }
-
         switch (action) {
             case MotionEvent.ACTION_DOWN:
                 mAbortKey = false;
@@ -1380,9 +1164,8 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 mDownTime = me.getEventTime();
                 mLastMoveTime = mDownTime;
                 checkMultiTap(eventTime, keyIndex);
-                if (mKeyboardActionListener != null) {
-                    mKeyboardActionListener.onPress(keyIndex != NOT_A_KEY ? mKeys[keyIndex].codes[0] : 0);
-                }
+                mKeyboardActionListener.onPress(keyIndex != NOT_A_KEY ?
+                        mKeys[keyIndex].codes[0] : 0);
                 if (mCurrentKey >= 0 && mKeys[mCurrentKey].repeatable) {
                     mRepeatKeyIndex = mCurrentKey;
                     Message msg = mHandler.obtainMessage(MSG_REPEAT);
@@ -1400,7 +1183,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 }
                 showPreview(keyIndex);
                 break;
-
             case MotionEvent.ACTION_MOVE:
                 boolean continueLongPress = false;
                 if (keyIndex != NOT_A_KEY) {
@@ -1413,11 +1195,12 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                             continueLongPress = true;
                         } else if (mRepeatKeyIndex == NOT_A_KEY) {
                             resetMultiTap();
-                            mLastKey = mDownKey;
+                            mLastKey = mCurrentKey;
                             mLastCodeX = mLastX;
                             mLastCodeY = mLastY;
-                            mLastKeyTime = mCurrentKeyTime + eventTime - mLastMoveTime;
-                            mCurrentKey = mDownKey;
+                            mLastKeyTime =
+                                    mCurrentKeyTime + eventTime - mLastMoveTime;
+                            mCurrentKey = keyIndex;
                             mCurrentKeyTime = 0;
                         }
                     }
@@ -1434,7 +1217,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 showPreview(mCurrentKey);
                 mLastMoveTime = eventTime;
                 break;
-
             case MotionEvent.ACTION_UP:
                 removeMessages();
                 if (keyIndex == mCurrentKey) {
@@ -1456,7 +1238,7 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 Arrays.fill(mKeyIndices, NOT_A_KEY);
                 // If we're not on a repeating key (which sends on a DOWN event)
                 if (mRepeatKeyIndex == NOT_A_KEY && !mMiniKeyboardOnScreen && !mAbortKey) {
-                    detectAndSendKey(mDownKey, touchX, touchY, eventTime);
+                    detectAndSendKey(mCurrentKey, touchX, touchY, eventTime);
                 }
                 invalidateKey(keyIndex);
                 mRepeatKeyIndex = NOT_A_KEY;
@@ -1473,49 +1255,33 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         mLastY = touchY;
         return true;
     }
-
     private boolean repeatKey() {
         Key key = mKeys[mRepeatKeyIndex];
         detectAndSendKey(mCurrentKey, key.x, key.y, mLastTapTime);
         return true;
     }
-
     protected void swipeRight() {
-        if (mKeyboardActionListener != null) {
-            mKeyboardActionListener.swipeRight();
-        }
+        mKeyboardActionListener.swipeRight();
     }
-
     protected void swipeLeft() {
-        if (mKeyboardActionListener != null) {
-            mKeyboardActionListener.swipeLeft();
-        }
+        mKeyboardActionListener.swipeLeft();
     }
-
     protected void swipeUp() {
-        if (mKeyboardActionListener != null) {
-            mKeyboardActionListener.swipeUp();
-        }
+        mKeyboardActionListener.swipeUp();
     }
-
     protected void swipeDown() {
-        if (mKeyboardActionListener != null) {
-            mKeyboardActionListener.swipeDown();
-        }
+        mKeyboardActionListener.swipeDown();
     }
-
     public void closing() {
         if (mPreviewPopup.isShowing()) {
             mPreviewPopup.dismiss();
         }
         removeMessages();
-
         dismissPopupKeyboard();
         mBuffer = null;
         mCanvas = null;
         mMiniKeyboardCache.clear();
     }
-
     private void removeMessages() {
         if (mHandler != null) {
             mHandler.removeMessages(MSG_REPEAT);
@@ -1523,13 +1289,11 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             mHandler.removeMessages(MSG_SHOW_PREVIEW);
         }
     }
-
     @Override
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         closing();
     }
-
     private void dismissPopupKeyboard() {
         if (mPopupKeyboard.isShowing()) {
             mPopupKeyboard.dismiss();
@@ -1537,7 +1301,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             invalidateAllKeys();
         }
     }
-
     public boolean handleBack() {
         if (mPopupKeyboard.isShowing()) {
             dismissPopupKeyboard();
@@ -1545,14 +1308,12 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         }
         return false;
     }
-
     private void resetMultiTap() {
         mLastSentIndex = NOT_A_KEY;
         mTapCount = 0;
         mLastTapTime = -1;
         mInMultiTap = false;
     }
-
     private void checkMultiTap(long eventTime, int keyIndex) {
         if (keyIndex == NOT_A_KEY) return;
         Key key = mKeys[keyIndex];
@@ -1566,36 +1327,23 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 mTapCount = -1;
                 return;
             }
-
-        } else if (key.codes[0] == CustomKeyboard.KEYCODE_SHIFT) {
-            if (eventTime < mLastTapTime + MULTITAP_INTERVAL
-                    && keyIndex == mLastSentIndex) {
-                mInMultiTap = true;
-            }
         }
-
         if (eventTime > mLastTapTime + MULTITAP_INTERVAL || keyIndex != mLastSentIndex) {
             resetMultiTap();
         }
     }
-
     private static class SwipeTracker {
-
         static final int NUM_PAST = 4;
         static final int LONGEST_PAST_TIME = 200;
-
-        final float[] mPastX = new float[NUM_PAST];
-        final float[] mPastY = new float[NUM_PAST];
-        final long[] mPastTime = new long[NUM_PAST];
-
+        final float mPastX[] = new float[NUM_PAST];
+        final float mPastY[] = new float[NUM_PAST];
+        final long mPastTime[] = new long[NUM_PAST];
         float mYVelocity;
         float mXVelocity;
-
         public void clear() {
             mPastTime[0] = 0;
         }
-
-        void addMovement(MotionEvent ev) {
+        public void addMovement(MotionEvent ev) {
             long time = ev.getEventTime();
             final int N = ev.getHistorySize();
             for (int i=0; i<N; i++) {
@@ -1604,7 +1352,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             }
             addPoint(ev.getX(), ev.getY(), time);
         }
-
         private void addPoint(float x, float y, long time) {
             int drop = -1;
             int i;
@@ -1638,16 +1385,13 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 pastTime[i] = 0;
             }
         }
-
-        void computeCurrentVelocity(int units) {
+        public void computeCurrentVelocity(int units) {
             computeCurrentVelocity(units, Float.MAX_VALUE);
         }
-
-        void computeCurrentVelocity(int units, float maxVelocity) {
+        public void computeCurrentVelocity(int units, float maxVelocity) {
             final float[] pastX = mPastX;
             final float[] pastY = mPastY;
             final long[] pastTime = mPastTime;
-
             final float oldestX = pastX[0];
             final float oldestY = pastY[0];
             final long oldestTime = pastTime[0];
@@ -1660,7 +1404,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 }
                 N++;
             }
-
             for (int i=1; i < N; i++) {
                 final int dur = (int)(pastTime[i] - oldestTime);
                 if (dur == 0) continue;
@@ -1668,7 +1411,6 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 float vel = (dist/dur) * units;   // pixels/frame.
                 if (accumX == 0) accumX = vel;
                 else accumX = (accumX + vel) * .5f;
-
                 dist = pastY[i] - oldestY;
                 vel = (dist/dur) * units;   // pixels/frame.
                 if (accumY == 0) accumY = vel;
@@ -1679,12 +1421,10 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
             mYVelocity = accumY < 0.0f ? Math.max(accumY, -maxVelocity)
                     : Math.min(accumY, maxVelocity);
         }
-
-        float getXVelocity() {
+        public float getXVelocity() {
             return mXVelocity;
         }
-
-        float getYVelocity() {
+        public float getYVelocity() {
             return mYVelocity;
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChineseZhuyinKeyboard.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChineseZhuyinKeyboard.java
@@ -3,7 +3,7 @@ package com.igalia.wolvic.ui.keyboards;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.inputmethodservice.Keyboard.Key;
+import com.igalia.wolvic.input.Keyboard.Key;
 import android.util.Log;
 
 import androidx.annotation.NonNull;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -8,7 +8,7 @@ package com.igalia.wolvic.ui.widgets;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.inputmethodservice.Keyboard;
+import com.igalia.wolvic.input.Keyboard;
 import android.os.Handler;
 import android.os.LocaleList;
 import android.text.Editable;

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -104,4 +104,133 @@
         <attr name="android:fastScrollAlwaysVisible" />
         <attr name="dynamicHeight" format="boolean"/>
     </declare-styleable>
+
+    <!-- {Copied from com.android.internal.R} -->
+    <declare-styleable name="KeyboardView">
+        <!-- Default KeyboardView style.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyboardViewStyle" format="reference" />
+        <!-- Image for the key. This image needs to be a StateListDrawable, with the following
+             possible states: normal, pressed, checkable, checkable+pressed, checkable+checked,
+             checkable+checked+pressed.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyBackground" format="reference" />
+        <!-- Size of the text for character keys.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyTextSize" format="dimension" />
+        <!-- Size of the text for custom keys with some text and no icon.
+             {Copied from com.android.internal.R} -->
+        <attr name="labelTextSize" format="dimension" />
+        <!-- Color to use for the label in a key.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyTextColor" format="color" />
+        <!-- Layout resource for key press feedback.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyPreviewLayout" format="reference" />
+        <!-- Vertical offset of the key press feedback from the key.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyPreviewOffset" format="dimension" />
+        <!-- Height of the key press feedback popup.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyPreviewHeight" format="dimension" />
+        <!-- Amount to offset the touch Y coordinate by, for bias correction.
+             {Copied from com.android.internal.R} -->
+        <attr name="verticalCorrection" format="dimension" />
+        <!-- Layout resource for popup keyboards.
+             {Copied from com.android.internal.R} -->
+        <attr name="popupLayout" format="reference" />
+        <!-- {Copied from com.android.internal.R} -->
+        <attr name="shadowColor" format="color" />
+        <!-- {Copied from com.android.internal.R} -->
+        <attr name="shadowRadius" format="float" />
+    </declare-styleable>
+    <!-- {Copied from com.android.internal.R} -->
+    <declare-styleable name="KeyboardViewPreviewState">
+        <!-- State for {@link com.igalia.wolvic.input.KeyboardView KeyboardView}
+                key preview background.
+             {Copied from com.android.internal.R} -->
+        <attr name="state_long_pressable" format="boolean" />
+    </declare-styleable>
+    <!-- {Copied from com.android.internal.R} -->
+    <declare-styleable name="Keyboard">
+        <!-- Default width of a key, in pixels or percentage of display width.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyWidth" format="dimension|fraction" />
+        <!-- Default height of a key, in pixels or percentage of display width.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyHeight" format="dimension|fraction" />
+        <!-- Default horizontal gap between keys.
+             {Copied from com.android.internal.R} -->
+        <attr name="horizontalGap" format="dimension|fraction" />
+        <!-- Default vertical gap between rows of keys.
+             {Copied from com.android.internal.R} -->
+        <attr name="verticalGap" format="dimension|fraction" />
+    </declare-styleable>
+    <!-- {Copied from com.android.internal.R} -->
+    <declare-styleable name="Keyboard_Row">
+        <!-- Row edge flags.
+             {Copied from com.android.internal.R} -->
+        <attr name="rowEdgeFlags">
+            <!-- Row is anchored to the top of the keyboard.
+             {Copied from com.android.internal.R} -->
+            <flag name="top" value="4" />
+            <!-- Row is anchored to the bottom of the keyboard.
+             {Copied from com.android.internal.R} -->
+            <flag name="bottom" value="8" />
+        </attr>
+        <!-- Mode of the keyboard. If the mode doesn't match the
+             requested keyboard mode, the row will be skipped.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyboardMode" format="reference" />
+    </declare-styleable>
+    <!-- {Copied from com.android.internal.R} -->
+    <declare-styleable name="Keyboard_Key">
+        <!-- The unicode value or comma-separated values that this key outputs.
+             {Copied from com.android.internal.R} -->
+        <attr name="codes" format="integer|string" />
+        <!-- The XML keyboard layout of any popup keyboard.
+             {Copied from com.android.internal.R} -->
+        <attr name="popupKeyboard" format="reference" />
+        <!-- The characters to display in the popup keyboard.
+             {Copied from com.android.internal.R} -->
+        <attr name="popupCharacters" format="string" />
+        <!-- Key edge flags.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyEdgeFlags">
+            <!-- Key is anchored to the left of the keyboard.
+                 {Copied from com.android.internal.R} -->
+            <flag name="left" value="1" />
+            <!-- Key is anchored to the right of the keyboard.
+                 {Copied from com.android.internal.R} -->
+            <flag name="right" value="2" />
+        </attr>
+        <!-- Whether this is a modifier key such as Alt or Shift.
+             {Copied from com.android.internal.R} -->
+        <attr name="isModifier" format="boolean" />
+        <!-- Whether this is a toggle key.
+             {Copied from com.android.internal.R} -->
+        <attr name="isSticky" format="boolean" />
+        <!-- Whether long-pressing on this key will make it repeat.
+             {Copied from com.android.internal.R} -->
+        <attr name="isRepeatable" format="boolean" />
+        <!-- The icon to show in the popup preview.
+             {Copied from com.android.internal.R} -->
+        <attr name="iconPreview" format="reference" />
+        <!-- The string of characters to output when this key is pressed.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyOutputText" format="string" />
+        <!-- The label to display on the key.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyLabel" format="string" />
+        <!-- The icon to display on the key instead of the label.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyIcon" format="reference" />
+        <!-- Mode of the keyboard. If the mode doesn't match the
+             requested keyboard mode, the key will be skipped.
+             {Copied from com.android.internal.R} -->
+        <attr name="keyboardMode" />
+    </declare-styleable>
+    <!-- Enables swipe versus poly-finger touch disambiguation in the KeyboardView -->
+    <bool name="config_swipeDisambiguation">true</bool>
+    <item type="id" name="keyboardView" />
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2468,4 +2468,20 @@ the Select` button. When clicked it closes all the previously selected tabs -->
      be prompted for that specific permission in that same web page. -->
     <string name="permissions_dialog_remember_choice">Remember this decision</string>
 
+    <!-- KeyboardView - accessibility support -->
+    <!-- Description of the Alt button in a KeyboardView. [CHAR LIMIT=NONE] -->
+    <string name="keyboardview_keycode_alt">Alt</string>
+    <!-- Description of the Cancel button in a KeyboardView. [CHAR LIMIT=NONE] -->
+    <string name="keyboardview_keycode_cancel">Cancel</string>
+    <!-- Description of the Delete button in a KeyboardView. [CHAR LIMIT=NONE] -->
+    <string name="keyboardview_keycode_delete">Delete</string>
+    <!-- Description of the Done button in a KeyboardView. [CHAR LIMIT=NONE] -->
+    <string name="keyboardview_keycode_done">Done</string>
+    <!-- Description of the Mode change button in a KeyboardView. [CHAR LIMIT=NONE] -->
+    <string name="keyboardview_keycode_mode_change">Mode change</string>
+    <!-- Description of the Shift button in a KeyboardView. [CHAR LIMIT=NONE] -->
+    <string name="keyboardview_keycode_shift">Shift</string>
+    <!-- Description of the Enter button in a KeyboardView. [CHAR LIMIT=NONE] -->
+    <string name="keyboardview_keycode_enter">Enter</string>
+
 </resources>

--- a/app/src/main/res/xml/keyboard_numeric.xml
+++ b/app/src/main/res/xml/keyboard_numeric.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="55" android:keyLabel="7" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
-        <Key android:codes="56" android:keyLabel="8"/>
-        <Key android:codes="57" android:keyLabel="9"/>
+        <Key app:codes="55" app:keyLabel="7" app:keyEdgeFlags="left" app:horizontalGap="0dp"/>
+        <Key app:codes="56" app:keyLabel="8"/>
+        <Key app:codes="57" app:keyLabel="9"/>
     </Row>
     <Row>
-        <Key android:codes="52" android:keyLabel="4" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
-        <Key android:codes="53" android:keyLabel="5"/>
-        <Key android:codes="54" android:keyLabel="6"/>
+        <Key app:codes="52" app:keyLabel="4" app:keyEdgeFlags="left" app:horizontalGap="0dp"/>
+        <Key app:codes="53" app:keyLabel="5"/>
+        <Key app:codes="54" app:keyLabel="6"/>
     </Row>
     <Row>
-        <Key android:codes="49" android:keyLabel="1"  android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
-        <Key android:codes="50" android:keyLabel="2"/>
-        <Key android:codes="51" android:keyLabel="3"/>
+        <Key app:codes="49" app:keyLabel="1"  app:keyEdgeFlags="left" app:horizontalGap="0dp"/>
+        <Key app:codes="50" app:keyLabel="2"/>
+        <Key app:codes="51" app:keyLabel="3"/>
     </Row>
     <Row>
-        <Key android:codes="35" android:keyLabel="#" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
-        <Key android:codes="48" android:keyLabel="0"/>
-        <Key android:codes="42" android:keyIcon="@drawable/ic_keyboard_asterisk"/>
+        <Key app:codes="35" app:keyLabel="#" app:keyEdgeFlags="left" app:horizontalGap="0dp"/>
+        <Key app:codes="48" app:keyLabel="0"/>
+        <Key app:codes="42" app:keyIcon="@drawable/ic_keyboard_asterisk"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_popup.xml
+++ b/app/src/main/res/xml/keyboard_popup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="0dp"
-    android:verticalGap="0dp"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="0dp"
+    app:verticalGap="0dp"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty.xml
+++ b/app/src/main/res/xml/keyboard_qwerty.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q"  />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q"  />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_danish.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_danish.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q" android:horizontalGap="@dimen/keyboard_left_margin_half"/>
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_da_DK_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_da_DK_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_da_DK_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_da_DK_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_da_DK_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="å" android:keyLabel="å"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q" app:horizontalGap="@dimen/keyboard_left_margin_half"/>
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_da_DK_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_da_DK_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_da_DK_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_da_DK_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_da_DK_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="å" app:keyLabel="å"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_da_DK_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_da_DK_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_da_DK_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_da_DK_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="æ" android:keyLabel="æ" android:popupCharacters="@string/keyboard_da_DK_popup_æ" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:keyOutputText="ø" android:keyLabel="ø" android:popupCharacters="@string/keyboard_da_DK_popup_ø" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_da_DK_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left"/>
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_da_DK_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_da_DK_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_da_DK_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="æ" app:keyLabel="æ" app:popupCharacters="@string/keyboard_da_DK_popup_æ" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:keyOutputText="ø" app:keyLabel="ø" app:popupCharacters="@string/keyboard_da_DK_popup_ø" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off"/>
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off"/>
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_dutch.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_dutch.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q" />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_nl_NL_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_nl_NL_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_nl_NL_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_nl_NL_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q" />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_nl_NL_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_nl_NL_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_nl_NL_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_nl_NL_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_nl_NL_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_nl_NL_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left" />
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off"/>
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left" />
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off"/>
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_finnish.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_finnish.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q" android:horizontalGap="@dimen/keyboard_left_margin_half" />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_fi_FI_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_fi_FI_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_fi_FI_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_fi_FI_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_fi_FI_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="å" android:keyLabel="å"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q" app:horizontalGap="@dimen/keyboard_left_margin_half" />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_fi_FI_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_fi_FI_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_fi_FI_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_fi_FI_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_fi_FI_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="å" app:keyLabel="å"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_fi_FI_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_fi_FI_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_fi_FI_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ö" android:keyLabel="ö" android:popupCharacters="@string/keyboard_fi_FI_popup_ö" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ä" android:keyLabel="ä" android:popupCharacters="@string/keyboard_fi_FI_popup_ä" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small" />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_fi_FI_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_fi_FI_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_fi_FI_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ö" app:keyLabel="ö" app:popupCharacters="@string/keyboard_fi_FI_popup_ö" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ä" app:keyLabel="ä" app:popupCharacters="@string/keyboard_fi_FI_popup_ä" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small" />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_fi_FI_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_fi_FI_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_fi_FI_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_fi_FI_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_fi_FI_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_fi_FI_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_french.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_french.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" />
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" />
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q" android:horizontalGap="@dimen/keyboard_left_margin"  />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q" app:horizontalGap="@dimen/keyboard_left_margin"  />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_german.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_german.xml
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q"  />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ü" android:keyLabel="ü" />
-        <Key android:keyOutputText="ß" android:keyLabel="ß"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" android:keyEdgeFlags="right" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q"  />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ü" app:keyLabel="ü" />
+        <Key app:keyOutputText="ß" app:keyLabel="ß"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" app:keyEdgeFlags="right" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ö" android:keyLabel="ö" />
-        <Key android:keyOutputText="ä" android:keyLabel="ä" />
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width" android:keyEdgeFlags="right"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ö" app:keyLabel="ö" />
+        <Key app:keyOutputText="ä" app:keyLabel="ä" />
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width" app:keyEdgeFlags="right"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="right" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="right" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_german_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_german_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_italian.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_italian.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q"  />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="è" android:keyLabel="è" android:popupCharacters="èeéëêęẽėē" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q"  />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="è" app:keyLabel="è" app:popupCharacters="èeéëêęẽėē" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="à" android:keyLabel="à" android:popupCharacters="àaáäãåâąæā" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="à" app:keyLabel="à" app:popupCharacters="àaáäãåâąæā" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ò" android:keyLabel="ò" android:popupCharacters="òoóºöôõøœō" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ì" android:keyLabel="ì" android:popupCharacters="ìiíïîįī" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ù" android:keyLabel="ù" android:popupCharacters="ùuúüûū" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ò" app:keyLabel="ò" app:popupCharacters="òoóºöôõøœō" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ì" app:keyLabel="ì" app:popupCharacters="ìiíïîįī" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ù" app:keyLabel="ù" app:popupCharacters="ùuúüûū" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_japanese.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_japanese.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" />
-        <Key android:codes="119" android:keyLabel="w" />
-        <Key android:codes="101" android:keyLabel="e" />
-        <Key android:codes="114" android:keyLabel="r" />
-        <Key android:codes="116" android:keyLabel="t" />
-        <Key android:codes="121" android:keyLabel="y" />
-        <Key android:codes="117" android:keyLabel="u" />
-        <Key android:codes="105" android:keyLabel="i" />
-        <Key android:codes="111" android:keyLabel="o" />
-        <Key android:codes="112" android:keyLabel="p" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" />
+        <Key app:codes="119" app:keyLabel="w" />
+        <Key app:codes="101" app:keyLabel="e" />
+        <Key app:codes="114" app:keyLabel="r" />
+        <Key app:codes="116" app:keyLabel="t" />
+        <Key app:codes="121" app:keyLabel="y" />
+        <Key app:codes="117" app:keyLabel="u" />
+        <Key app:codes="105" app:keyLabel="i" />
+        <Key app:codes="111" app:keyLabel="o" />
+        <Key app:codes="112" app:keyLabel="p" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" />
-        <Key android:codes="100" android:keyLabel="d" />
-        <Key android:codes="102" android:keyLabel="f" />
-        <Key android:codes="103" android:keyLabel="g" />
-        <Key android:codes="104" android:keyLabel="h" />
-        <Key android:codes="106" android:keyLabel="j" />
-        <Key android:codes="107" android:keyLabel="k" />
-        <Key android:codes="108" android:keyLabel="l" />
-        <Key android:keyOutputText="ー" android:keyLabel="ー"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="97" app:keyLabel="a" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" />
+        <Key app:codes="100" app:keyLabel="d" />
+        <Key app:codes="102" app:keyLabel="f" />
+        <Key app:codes="103" app:keyLabel="g" />
+        <Key app:codes="104" app:keyLabel="h" />
+        <Key app:codes="106" app:keyLabel="j" />
+        <Key app:codes="107" app:keyLabel="k" />
+        <Key app:codes="108" app:keyLabel="l" />
+        <Key app:keyOutputText="ー" app:keyLabel="ー"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z" />
-        <Key android:codes="120" android:keyLabel="x" />
-        <Key android:codes="99" android:keyLabel="c"  />
-        <Key android:codes="118" android:keyLabel="v" />
-        <Key android:codes="98" android:keyLabel="b"  />
-        <Key android:codes="110" android:keyLabel="n" />
-        <Key android:codes="109" android:keyLabel="m" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="122" app:keyLabel="z" />
+        <Key app:codes="120" app:keyLabel="x" />
+        <Key app:codes="99" app:keyLabel="c"  />
+        <Key app:codes="118" app:keyLabel="v" />
+        <Key app:codes="98" app:keyLabel="b"  />
+        <Key app:codes="110" app:keyLabel="n" />
+        <Key app:codes="109" app:keyLabel="m" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:keyOutputText="、" android:keyLabel="、"/>
-        <Key android:keyOutputText="。" android:keyLabel="。"/>
-        <Key android:codes="33" android:keyLabel="!" />
-        <Key android:codes="63" android:keyLabel="\?" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:keyOutputText="、" app:keyLabel="、"/>
+        <Key app:keyOutputText="。" app:keyLabel="。"/>
+        <Key app:codes="33" app:keyLabel="!" />
+        <Key app:codes="63" app:keyLabel="\?" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_korean.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_korean.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:keyLabel="ㅂ" android:popupCharacters="ㅂㅃ" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left"  />
-        <Key android:keyLabel="ㅈ" android:popupCharacters="ㅈㅉ" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyLabel="ㄷ" android:popupCharacters="ㄷㄸ" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyLabel="ᄀ" android:popupCharacters="ᄀㄲ" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyLabel="ㅅ" android:popupCharacters="ㅅㅆ" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyLabel="ᅭ" />
-        <Key android:keyLabel="ᅧ" />
-        <Key android:keyLabel="ᅣ" />
-        <Key android:keyLabel="ᅢ" android:popupCharacters="ᅢᅤ" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyLabel="ᅦ" android:popupCharacters="ᅦᅨ" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:keyLabel="ㅂ" app:popupCharacters="ㅂㅃ" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left"  />
+        <Key app:keyLabel="ㅈ" app:popupCharacters="ㅈㅉ" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyLabel="ㄷ" app:popupCharacters="ㄷㄸ" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyLabel="ᄀ" app:popupCharacters="ᄀㄲ" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyLabel="ㅅ" app:popupCharacters="ㅅㅆ" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyLabel="ᅭ" />
+        <Key app:keyLabel="ᅧ" />
+        <Key app:keyLabel="ᅣ" />
+        <Key app:keyLabel="ᅢ" app:popupCharacters="ᅢᅤ" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyLabel="ᅦ" app:popupCharacters="ᅦᅨ" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:keyLabel="ㅁ" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:keyLabel="ㄴ" />
-        <Key android:keyLabel="ㅇ" />
-        <Key android:keyLabel="ㄹ" />
-        <Key android:keyLabel="ㅎ" />
-        <Key android:keyLabel="ᅩ" />
-        <Key android:keyLabel="ᅥ" />
-        <Key android:keyLabel="ᅡ" />
-        <Key android:keyLabel="ᅵ" />
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:keyLabel="ㅁ" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:keyLabel="ㄴ" />
+        <Key app:keyLabel="ㅇ" />
+        <Key app:keyLabel="ㄹ" />
+        <Key app:keyLabel="ㅎ" />
+        <Key app:keyLabel="ᅩ" />
+        <Key app:keyLabel="ᅥ" />
+        <Key app:keyLabel="ᅡ" />
+        <Key app:keyLabel="ᅵ" />
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="ㅋ" />
-        <Key android:keyLabel="ㅌ" />
-        <Key android:keyLabel="ㅊ" />
-        <Key android:keyLabel="ㅍ" />
-        <Key android:keyLabel="ᅲ" />
-        <Key android:keyLabel="ᅮ" />
-        <Key android:keyLabel="ᅳ" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="ㅋ" />
+        <Key app:keyLabel="ㅌ" />
+        <Key app:keyLabel="ㅊ" />
+        <Key app:keyLabel="ㅍ" />
+        <Key app:keyLabel="ᅲ" />
+        <Key app:keyLabel="ᅮ" />
+        <Key app:keyLabel="ᅳ" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_norwegian.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_norwegian.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q" android:horizontalGap="@dimen/keyboard_left_margin_half" />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_nb_NO_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_nb_NO_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_nb_NO_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="å" android:keyLabel="å"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q" app:horizontalGap="@dimen/keyboard_left_margin_half" />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_nb_NO_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_nb_NO_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_nb_NO_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="å" app:keyLabel="å"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_nb_NO_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ø" android:keyLabel="ö" android:popupCharacters="@string/keyboard_nb_NO_popup_ø" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="æ" android:keyLabel="ä" android:popupCharacters="@string/keyboard_nb_NO_popup_æ" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small" />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_nb_NO_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ø" app:keyLabel="ö" app:popupCharacters="@string/keyboard_nb_NO_popup_ø" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="æ" app:keyLabel="ä" app:popupCharacters="@string/keyboard_nb_NO_popup_æ" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small" />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_pinyin.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_pinyin.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q"  />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q"  />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ー" android:keyLabel="ー"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ー" app:keyLabel="ー"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:keyOutputText="，" android:keyLabel="，"/>
-        <Key android:keyOutputText="。" android:keyLabel="。"/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:keyOutputText="，" app:keyLabel="，"/>
+        <Key app:keyOutputText="。" app:keyLabel="。"/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_polish.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_polish.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q"  />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_pl_PL_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_pl_PL_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q"  />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_pl_PL_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_pl_PL_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_pl_PL_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_pl_PL_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_pl_PL_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_pl_PL_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_pl_PL_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_pl_PL_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_pl_PL_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_pl_PL_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_pl_PL_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_pl_PL_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_pl_PL_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_pl_PL_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_russian.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_russian.xml
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:keyLabel="й" android:keyEdgeFlags="left" />
-        <Key android:keyLabel="ц" />
-        <Key android:keyLabel="у" />
-        <Key android:keyLabel="к" />
-        <Key android:keyLabel="е" android:popupCharacters="её" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyLabel="н" />
-        <Key android:keyLabel="г" />
-        <Key android:keyLabel="ш" />
-        <Key android:keyLabel="щ" />
-        <Key android:keyLabel="з" />
-        <Key android:keyLabel="х" />
-        <Key android:keyLabel="ъ" />
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:keyLabel="й" app:keyEdgeFlags="left" />
+        <Key app:keyLabel="ц" />
+        <Key app:keyLabel="у" />
+        <Key app:keyLabel="к" />
+        <Key app:keyLabel="е" app:popupCharacters="её" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyLabel="н" />
+        <Key app:keyLabel="г" />
+        <Key app:keyLabel="ш" />
+        <Key app:keyLabel="щ" />
+        <Key app:keyLabel="з" />
+        <Key app:keyLabel="х" />
+        <Key app:keyLabel="ъ" />
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:keyLabel="ф" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:keyLabel="ы" />
-        <Key android:keyLabel="в" />
-        <Key android:keyLabel="а" />
-        <Key android:keyLabel="п" />
-        <Key android:keyLabel="р" />
-        <Key android:keyLabel="о" />
-        <Key android:keyLabel="л" />
-        <Key android:keyLabel="д" />
-        <Key android:keyLabel="ж" />
-        <Key android:keyLabel="э" />
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:keyLabel="ф" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:keyLabel="ы" />
+        <Key app:keyLabel="в" />
+        <Key app:keyLabel="а" />
+        <Key app:keyLabel="п" />
+        <Key app:keyLabel="р" />
+        <Key app:keyLabel="о" />
+        <Key app:keyLabel="л" />
+        <Key app:keyLabel="д" />
+        <Key app:keyLabel="ж" />
+        <Key app:keyLabel="э" />
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="я" />
-        <Key android:keyLabel="ч" />
-        <Key android:keyLabel="с" />
-        <Key android:keyLabel="м" />
-        <Key android:keyLabel="и" />
-        <Key android:keyLabel="т" />
-        <Key android:keyLabel="ь" />
-        <Key android:keyLabel="б" />
-        <Key android:keyLabel="ю" />
-        <Key android:keyLabel="ë" />
-        <Key android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="я" />
+        <Key app:keyLabel="ч" />
+        <Key app:keyLabel="с" />
+        <Key app:keyLabel="м" />
+        <Key app:keyLabel="и" />
+        <Key app:keyLabel="т" />
+        <Key app:keyLabel="ь" />
+        <Key app:keyLabel="б" />
+        <Key app:keyLabel="ю" />
+        <Key app:keyLabel="ë" />
+        <Key app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_spanish.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_spanish.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q"  />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q"  />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ñ" android:keyLabel="ñ" />
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ñ" app:keyLabel="ñ" />
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_swedish.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_swedish.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" android:popupKeyboard="@xml/keyboard_popup" android:popupCharacters="@string/keyboard_popup_q" android:horizontalGap="@dimen/keyboard_left_margin_half" />
-        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="@string/keyboard_popup_w" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/keyboard_sv_SE_popup_e" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="@string/keyboard_popup_r" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="@string/keyboard_popup_t" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/keyboard_popup_y" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/keyboard_sv_SE_popup_u" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/keyboard_popup_i" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/keyboard_sv_SE_popup_o" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="@string/keyboard_popup_p" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="å" android:keyLabel="å"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:codes="113" app:keyLabel="q" app:keyEdgeFlags="left" app:popupKeyboard="@xml/keyboard_popup" app:popupCharacters="@string/keyboard_popup_q" app:horizontalGap="@dimen/keyboard_left_margin_half" />
+        <Key app:codes="119" app:keyLabel="w" app:popupCharacters="@string/keyboard_popup_w" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="101" app:keyLabel="e" app:popupCharacters="@string/keyboard_sv_SE_popup_e" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="114" app:keyLabel="r" app:popupCharacters="@string/keyboard_popup_r" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="116" app:keyLabel="t" app:popupCharacters="@string/keyboard_popup_t" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="121" app:keyLabel="y" app:popupCharacters="@string/keyboard_popup_y" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="117" app:keyLabel="u" app:popupCharacters="@string/keyboard_sv_SE_popup_u" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="105" app:keyLabel="i" app:popupCharacters="@string/keyboard_popup_i" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="111" app:keyLabel="o" app:popupCharacters="@string/keyboard_sv_SE_popup_o" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="112" app:keyLabel="p" app:popupCharacters="@string/keyboard_popup_p" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="å" app:keyLabel="å"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="@string/keyboard_sv_SE_popup_a" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="left" />
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/keyboard_popup_s" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="@string/keyboard_popup_d" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="@string/keyboard_popup_f" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="@string/keyboard_popup_g" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="@string/keyboard_popup_h" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="@string/keyboard_popup_j" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="107" android:keyLabel="k" android:popupCharacters="@string/keyboard_popup_k" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/keyboard_popup_l" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ö" android:keyLabel="ö" android:popupCharacters="@string/keyboard_sv_SE_popup_ö" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyOutputText="ä" android:keyLabel="ä" android:popupCharacters="@string/keyboard_sv_SE_popup_ä" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small" />
+        <Key app:codes="97" app:keyLabel="a" app:popupCharacters="@string/keyboard_sv_SE_popup_a" app:popupKeyboard="@xml/keyboard_popup" app:keyEdgeFlags="left" />
+        <Key app:codes="115" app:keyLabel="s" app:popupCharacters="@string/keyboard_popup_s" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="100" app:keyLabel="d" app:popupCharacters="@string/keyboard_popup_d" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="102" app:keyLabel="f" app:popupCharacters="@string/keyboard_popup_f" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="103" app:keyLabel="g" app:popupCharacters="@string/keyboard_popup_g" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="104" app:keyLabel="h" app:popupCharacters="@string/keyboard_popup_h" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="106" app:keyLabel="j" app:popupCharacters="@string/keyboard_popup_j" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="107" app:keyLabel="k" app:popupCharacters="@string/keyboard_popup_k" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="108" app:keyLabel="l" app:popupCharacters="@string/keyboard_popup_l" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ö" app:keyLabel="ö" app:popupCharacters="@string/keyboard_sv_SE_popup_ö" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyOutputText="ä" app:keyLabel="ä" app:popupCharacters="@string/keyboard_sv_SE_popup_ä" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small" />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/keyboard_popup_z" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="@string/keyboard_popup_x" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/keyboard_popup_c" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="@string/keyboard_popup_v" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="98" android:keyLabel="b"  android:popupCharacters="@string/keyboard_popup_b" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/keyboard_popup_n" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="@string/keyboard_popup_m" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="122" app:keyLabel="z" app:popupCharacters="@string/keyboard_popup_z" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="120" app:keyLabel="x" app:popupCharacters="@string/keyboard_popup_x" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="99" app:keyLabel="c"  app:popupCharacters="@string/keyboard_popup_c" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:codes="118" app:keyLabel="v" app:popupCharacters="@string/keyboard_popup_v" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="98" app:keyLabel="b"  app:popupCharacters="@string/keyboard_popup_b" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="110" app:keyLabel="n" app:popupCharacters="@string/keyboard_popup_n" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="109" app:keyLabel="m" app:popupCharacters="@string/keyboard_popup_m" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="%&amp;=" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="%&amp;=" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_thai.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_thai.xml
@@ -1,82 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:keyLabel="ๅ" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="/"/>
-        <Key android:keyLabel="-"/>
-        <Key android:keyLabel="ภ"/>
-        <Key android:keyLabel="ถ"/>
-        <Key android:keyLabel="ุ"/>
-        <Key android:keyLabel="ึ"/>
-        <Key android:keyLabel="ค" android:popupCharacters="คฅ" android:popupKeyboard="@xml/keyboard_popup"/>
-        <Key android:keyLabel="ต"/>
-        <Key android:keyLabel="จ"/>
-        <Key android:keyLabel="ข"/>
-        <Key android:keyLabel="ช"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:keyLabel="ๅ" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="/"/>
+        <Key app:keyLabel="-"/>
+        <Key app:keyLabel="ภ"/>
+        <Key app:keyLabel="ถ"/>
+        <Key app:keyLabel="ุ"/>
+        <Key app:keyLabel="ึ"/>
+        <Key app:keyLabel="ค" app:popupCharacters="คฅ" app:popupKeyboard="@xml/keyboard_popup"/>
+        <Key app:keyLabel="ต"/>
+        <Key app:keyLabel="จ"/>
+        <Key app:keyLabel="ข"/>
+        <Key app:keyLabel="ช"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:keyLabel="ๆ" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="ไ"/>
-        <Key android:keyLabel="ำ"/>
-        <Key android:keyLabel="พ"/>
-        <Key android:keyLabel="ะ"/>
-        <Key android:keyLabel="ั"/>
-        <Key android:keyLabel="ี"/>
-        <Key android:keyLabel="ร"/>
-        <Key android:keyLabel="น"/>
-        <Key android:keyLabel="ย"/>
-        <Key android:keyLabel="บ"/>
-        <Key android:keyLabel="ล"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_thai_enter_width" android:keyHeight="@dimen/keyboard_key_thai_enter_height"/>
+        <Key app:keyLabel="ๆ" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="ไ"/>
+        <Key app:keyLabel="ำ"/>
+        <Key app:keyLabel="พ"/>
+        <Key app:keyLabel="ะ"/>
+        <Key app:keyLabel="ั"/>
+        <Key app:keyLabel="ี"/>
+        <Key app:keyLabel="ร"/>
+        <Key app:keyLabel="น"/>
+        <Key app:keyLabel="ย"/>
+        <Key app:keyLabel="บ"/>
+        <Key app:keyLabel="ล"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_thai_enter_width" app:keyHeight="@dimen/keyboard_key_thai_enter_height"/>
     </Row>
 
     <Row>
-        <Key android:keyLabel="ฟ"/>
-        <Key android:keyLabel="ห"/>
-        <Key android:keyLabel="ก"/>
-        <Key android:keyLabel="ด"/>
-        <Key android:keyLabel="เ"/>
-        <Key android:keyLabel="้"/>
-        <Key android:keyLabel="่" android:popupCharacters="ฺู๋๊็ํ่์" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:keyLabel="า"/>
-        <Key android:keyLabel="ส"/>
-        <Key android:keyLabel="ว"/>
-        <Key android:keyLabel="ง"/>
-        <Key android:keyLabel="ฃ"/>
+        <Key app:keyLabel="ฟ"/>
+        <Key app:keyLabel="ห"/>
+        <Key app:keyLabel="ก"/>
+        <Key app:keyLabel="ด"/>
+        <Key app:keyLabel="เ"/>
+        <Key app:keyLabel="้"/>
+        <Key app:keyLabel="่" app:popupCharacters="ฺู๋๊็ํ่์" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:keyLabel="า"/>
+        <Key app:keyLabel="ส"/>
+        <Key app:keyLabel="ว"/>
+        <Key app:keyLabel="ง"/>
+        <Key app:keyLabel="ฃ"/>
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="ผ"/>
-        <Key android:keyLabel="ป"/>
-        <Key android:keyLabel="แ"/>
-        <Key android:keyLabel="อ"/>
-        <Key android:keyLabel="ิ"/>
-        <Key android:keyLabel="ื"/>
-        <Key android:keyLabel="ท"/>
-        <Key android:keyLabel="ม"/>
-        <Key android:keyLabel="ใ"/>
-        <Key android:keyLabel="ฝ"/>
-        <Key android:keyLabel="\\"/>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="ผ"/>
+        <Key app:keyLabel="ป"/>
+        <Key app:keyLabel="แ"/>
+        <Key app:keyLabel="อ"/>
+        <Key app:keyLabel="ิ"/>
+        <Key app:keyLabel="ื"/>
+        <Key app:keyLabel="ท"/>
+        <Key app:keyLabel="ม"/>
+        <Key app:keyLabel="ใ"/>
+        <Key app:keyLabel="ฝ"/>
+        <Key app:keyLabel="\\"/>
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_thai_cap.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_thai_cap.xml
@@ -1,82 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:keyLabel="+" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="๑"/>
-        <Key android:keyLabel="๒"/>
-        <Key android:keyLabel="๓"/>
-        <Key android:keyLabel="๔"/>
-        <Key android:keyLabel="ู"/>
-        <Key android:keyLabel="฿"/>
-        <Key android:keyLabel="๕"/>
-        <Key android:keyLabel="๖"/>
-        <Key android:keyLabel="๗"/>
-        <Key android:keyLabel="๘"/>
-        <Key android:keyLabel="๙"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+        <Key app:keyLabel="+" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="๑"/>
+        <Key app:keyLabel="๒"/>
+        <Key app:keyLabel="๓"/>
+        <Key app:keyLabel="๔"/>
+        <Key app:keyLabel="ู"/>
+        <Key app:keyLabel="฿"/>
+        <Key app:keyLabel="๕"/>
+        <Key app:keyLabel="๖"/>
+        <Key app:keyLabel="๗"/>
+        <Key app:keyLabel="๘"/>
+        <Key app:keyLabel="๙"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width" />
     </Row>
 
     <Row>
-        <Key android:keyLabel="๐" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="&quot;" android:popupCharacters="“&quot;”„»«" android:popupKeyboard="@xml/keyboard_popup"/>/>
-        <Key android:keyLabel="ฎ"/>
-        <Key android:keyLabel="ฑ"/>
-        <Key android:keyLabel="ธ"/>
-        <Key android:keyLabel="ํ"/>
-        <Key android:keyLabel="๊"/>
-        <Key android:keyLabel="ณ"/>
-        <Key android:keyLabel="ฯ"/>
-        <Key android:keyLabel="ญ"/>
-        <Key android:keyLabel="ฐ"/>
-        <Key android:keyLabel=","/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_thai_enter_width" android:keyHeight="@dimen/keyboard_key_thai_enter_height"/>
+        <Key app:keyLabel="๐" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="&quot;" app:popupCharacters="“&quot;”„»«" app:popupKeyboard="@xml/keyboard_popup"/>/>
+        <Key app:keyLabel="ฎ"/>
+        <Key app:keyLabel="ฑ"/>
+        <Key app:keyLabel="ธ"/>
+        <Key app:keyLabel="ํ"/>
+        <Key app:keyLabel="๊"/>
+        <Key app:keyLabel="ณ"/>
+        <Key app:keyLabel="ฯ"/>
+        <Key app:keyLabel="ญ"/>
+        <Key app:keyLabel="ฐ"/>
+        <Key app:keyLabel=","/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_thai_enter_width" app:keyHeight="@dimen/keyboard_key_thai_enter_height"/>
     </Row>
 
     <Row>
-        <Key android:keyLabel="ฤ"/>
-        <Key android:keyLabel="ฆ"/>
-        <Key android:keyLabel="ฏ"/>
-        <Key android:keyLabel="โ"/>
-        <Key android:keyLabel="ฌ"/>
-        <Key android:keyLabel="็"/>
-        <Key android:keyLabel="๋"/>
-        <Key android:keyLabel="ษ"/>
-        <Key android:keyLabel="ศ"/>
-        <Key android:keyLabel="ซ"/>
-        <Key android:keyLabel="." android:popupCharacters=".…" android:popupKeyboard="@xml/keyboard_popup"/>/>
-        <Key android:keyLabel="ฅ"/>
+        <Key app:keyLabel="ฤ"/>
+        <Key app:keyLabel="ฆ"/>
+        <Key app:keyLabel="ฏ"/>
+        <Key app:keyLabel="โ"/>
+        <Key app:keyLabel="ฌ"/>
+        <Key app:keyLabel="็"/>
+        <Key app:keyLabel="๋"/>
+        <Key app:keyLabel="ษ"/>
+        <Key app:keyLabel="ศ"/>
+        <Key app:keyLabel="ซ"/>
+        <Key app:keyLabel="." app:popupCharacters=".…" app:popupKeyboard="@xml/keyboard_popup"/>/>
+        <Key app:keyLabel="ฅ"/>
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="("/>
-        <Key android:keyLabel=")"/>
-        <Key android:keyLabel="ฉ"/>
-        <Key android:keyLabel="ฮ"/>
-        <Key android:keyLabel="ฺ"/>
-        <Key android:keyLabel="์"/>
-        <Key android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup"/>/>
-        <Key android:keyLabel="ฒ"/>
-        <Key android:keyLabel="ฬ"/>
-        <Key android:keyLabel="ฦ"/>
-        <Key android:keyLabel="/"/>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" app:keyEdgeFlags="left"/>
+        <Key app:keyLabel="("/>
+        <Key app:keyLabel=")"/>
+        <Key app:keyLabel="ฉ"/>
+        <Key app:keyLabel="ฮ"/>
+        <Key app:keyLabel="ฺ"/>
+        <Key app:keyLabel="์"/>
+        <Key app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup"/>/>
+        <Key app:keyLabel="ฒ"/>
+        <Key app:keyLabel="ฬ"/>
+        <Key app:keyLabel="ฦ"/>
+        <Key app:keyLabel="/"/>
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_zhuyin.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_zhuyin.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="0x3105" android:keyLabel="ㄅ" android:keyEdgeFlags="left"/>
-        <Key android:codes="0x3109" android:keyLabel="ㄉ"/>
-        <Key android:codes="0x02C7" android:keyLabel="ˇ"/>
-        <Key android:codes="0x02CB" android:keyLabel="ˋ"/>
-        <Key android:codes="0x3113" android:keyLabel="ㄓ"/>
-        <Key android:codes="0x02CA" android:keyLabel="ˊ"/>
-        <Key android:codes="0x02D9" android:keyLabel="˙"/>
-        <Key android:codes="0x311A" android:keyLabel="ㄚ"/>
-        <Key android:codes="0x311E" android:keyLabel="ㄞ"/>
-        <Key android:codes="0x3122" android:keyLabel="ㄢ"/>
-        <Key android:codes="0x3126" android:keyLabel="ㄦ"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:isRepeatable="true"/>
+        <Key app:codes="0x3105" app:keyLabel="ㄅ" app:keyEdgeFlags="left"/>
+        <Key app:codes="0x3109" app:keyLabel="ㄉ"/>
+        <Key app:codes="0x02C7" app:keyLabel="ˇ"/>
+        <Key app:codes="0x02CB" app:keyLabel="ˋ"/>
+        <Key app:codes="0x3113" app:keyLabel="ㄓ"/>
+        <Key app:codes="0x02CA" app:keyLabel="ˊ"/>
+        <Key app:codes="0x02D9" app:keyLabel="˙"/>
+        <Key app:codes="0x311A" app:keyLabel="ㄚ"/>
+        <Key app:codes="0x311E" app:keyLabel="ㄞ"/>
+        <Key app:codes="0x3122" app:keyLabel="ㄢ"/>
+        <Key app:codes="0x3126" app:keyLabel="ㄦ"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:keyWidth="@dimen/keyboard_key_zhuyin_space_width" app:isRepeatable="true"/>
     </Row>
     <Row>
-        <Key android:codes="0x3106" android:keyLabel="ㄆ" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="0x310A" android:keyLabel="ㄊ"/>
-        <Key android:codes="0x310D" android:keyLabel="ㄍ"/>
-        <Key android:codes="0x3110" android:keyLabel="ㄐ"/>
-        <Key android:codes="0x3114" android:keyLabel="ㄔ"/>
-        <Key android:codes="0x3117" android:keyLabel="ㄗ"/>
-        <Key android:codes="0x3127" android:keyLabel="ㄧ"/>
-        <Key android:codes="0x311B" android:keyLabel="ㄛ"/>
-        <Key android:codes="0x311F" android:keyLabel="ㄟ"/>
-        <Key android:codes="0x3123" android:keyLabel="ㄣ"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_zhuyin_enter_width"/>
-    </Row>
-
-    <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="0x3107" android:keyLabel="ㄇ"/>
-        <Key android:codes="0x310B" android:keyLabel="ㄋ"/>
-        <Key android:codes="0x310E" android:keyLabel="ㄎ"/>
-        <Key android:codes="0x3111" android:keyLabel="ㄑ"/>
-        <Key android:codes="0x3115" android:keyLabel="ㄕ"/>
-        <Key android:codes="0x3118" android:keyLabel="ㄘ"/>
-        <Key android:codes="0x3128" android:keyLabel="ㄨ"/>
-        <Key android:codes="0x311C" android:keyLabel="ㄜ"/>
-        <Key android:codes="0x3120" android:keyLabel="ㄠ"/>
-        <Key android:codes="0x3124" android:keyLabel="ㄤ"/>
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:keyHeight="@dimen/keyboard_key_zhuyin_space_height" android:isRepeatable="true"/>
+        <Key app:codes="0x3106" app:keyLabel="ㄆ" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="0x310A" app:keyLabel="ㄊ"/>
+        <Key app:codes="0x310D" app:keyLabel="ㄍ"/>
+        <Key app:codes="0x3110" app:keyLabel="ㄐ"/>
+        <Key app:codes="0x3114" app:keyLabel="ㄔ"/>
+        <Key app:codes="0x3117" app:keyLabel="ㄗ"/>
+        <Key app:codes="0x3127" app:keyLabel="ㄧ"/>
+        <Key app:codes="0x311B" app:keyLabel="ㄛ"/>
+        <Key app:codes="0x311F" app:keyLabel="ㄟ"/>
+        <Key app:codes="0x3123" app:keyLabel="ㄣ"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_zhuyin_enter_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" android:keyEdgeFlags="left"/>
-        <Key android:codes="0x3108" android:keyLabel="ㄈ"/>
-        <Key android:codes="0x310C" android:keyLabel="ㄌ"/>
-        <Key android:codes="0x310F" android:keyLabel="ㄏ"/>
-        <Key android:codes="0x3112" android:keyLabel="ㄒ"/>
-        <Key android:codes="0x3116" android:keyLabel="ㄖ"/>
-        <Key android:codes="0x3119" android:keyLabel="ㄙ"/>
-        <Key android:codes="0x3129" android:keyLabel="ㄩ"/>
-        <Key android:codes="0x311D" android:keyLabel="ㄝ"/>
-        <Key android:codes="0x3121" android:keyLabel="ㄡ"/>
-        <Key android:codes="0x3125" android:keyLabel="ㄥ"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="0x3107" app:keyLabel="ㄇ"/>
+        <Key app:codes="0x310B" app:keyLabel="ㄋ"/>
+        <Key app:codes="0x310E" app:keyLabel="ㄎ"/>
+        <Key app:codes="0x3111" app:keyLabel="ㄑ"/>
+        <Key app:codes="0x3115" app:keyLabel="ㄕ"/>
+        <Key app:codes="0x3118" app:keyLabel="ㄘ"/>
+        <Key app:codes="0x3128" app:keyLabel="ㄨ"/>
+        <Key app:codes="0x311C" app:keyLabel="ㄜ"/>
+        <Key app:codes="0x3120" app:keyLabel="ㄠ"/>
+        <Key app:codes="0x3124" app:keyLabel="ㄤ"/>
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_zhuyin_space_width" app:keyHeight="@dimen/keyboard_key_zhuyin_space_height" app:isRepeatable="true"/>
+    </Row>
+
+    <Row>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" app:keyEdgeFlags="left"/>
+        <Key app:codes="0x3108" app:keyLabel="ㄈ"/>
+        <Key app:codes="0x310C" app:keyLabel="ㄌ"/>
+        <Key app:codes="0x310F" app:keyLabel="ㄏ"/>
+        <Key app:codes="0x3112" app:keyLabel="ㄒ"/>
+        <Key app:codes="0x3116" app:keyLabel="ㄖ"/>
+        <Key app:codes="0x3119" app:keyLabel="ㄙ"/>
+        <Key app:codes="0x3129" app:keyLabel="ㄩ"/>
+        <Key app:codes="0x311D" app:keyLabel="ㄝ"/>
+        <Key app:codes="0x3121" app:keyLabel="ㄡ"/>
+        <Key app:codes="0x3125" app:keyLabel="ㄥ"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols.xml
+++ b/app/src/main/res/xml/keyboard_symbols.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_danish.xml
+++ b/app/src/main/res/xml/keyboard_symbols_danish.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin_half"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="61" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin_half"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="61" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="183" android:keyLabel="·"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="183" app:keyLabel="·"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_finnish.xml
+++ b/app/src/main/res/xml/keyboard_symbols_finnish.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin_half"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="61" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin_half"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="61" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="183" android:keyLabel="·"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="183" app:keyLabel="·"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_german.xml
+++ b/app/src/main/res/xml/keyboard_symbols_german.xml
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:keyOutputText="ß" android:keyLabel="ß"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:keyOutputText="ß" app:keyLabel="ß"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="0xae" android:keyLabel="®"/>
-        <Key android:codes="0xa9" android:keyLabel="©"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="0xae" app:keyLabel="®"/>
+        <Key app:codes="0xa9" app:keyLabel="©"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="0x2122" android:keyLabel="™"/>
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="0x2122" app:keyLabel="™"/>
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_german_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_german_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_japanese.xml
+++ b/app/src/main/res/xml/keyboard_symbols_japanese.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="0x300C" android:keyLabel="「" />
-        <Key android:codes="0x300D" android:keyLabel="」" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="-13" android:keyLabel="^.^"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="0x300C" app:keyLabel="「" />
+        <Key app:codes="0x300D" app:keyLabel="」" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="-13" app:keyLabel="^.^"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_norwegian.xml
+++ b/app/src/main/res/xml/keyboard_symbols_norwegian.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin_half"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="61" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin_half"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="61" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="183" android:keyLabel="·"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="183" app:keyLabel="·"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_pinyin.xml
+++ b/app/src/main/res/xml/keyboard_symbols_pinyin.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="0x2026" android:keyLabel="…" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="0x3010" android:keyLabel="【"/>
-        <Key android:codes="0x3011" android:keyLabel="】"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="0x2026" app:keyLabel="…" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="0x3010" app:keyLabel="【"/>
+        <Key app:codes="0x3011" app:keyLabel="】"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
-        <Key android:codes="0x300a" android:keyLabel="《"/>
-        <Key android:codes="0x300b" android:keyLabel="》"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left"/>
+        <Key app:codes="0x300a" app:keyLabel="《"/>
+        <Key app:codes="0x300b" app:keyLabel="》"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="0x3001" android:keyLabel="、"/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="-13" android:keyLabel="^.^"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="0x3001" app:keyLabel="、"/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="-13" app:keyLabel="^.^"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_polish.xml
+++ b/app/src/main/res/xml/keyboard_symbols_polish.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="61" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="61" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="183" android:keyLabel="·"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="183" app:keyLabel="·"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_russian.xml
+++ b/app/src/main/res/xml/keyboard_symbols_russian.xml
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:keyOutputText="±" android:keyLabel="±"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:keyOutputText="±" app:keyLabel="±"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="176" android:keyLabel="°" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="183" android:keyLabel="·"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="0x2116" android:keyLabel="№"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="176" app:keyLabel="°" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="183" app:keyLabel="·"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="0x2116" app:keyLabel="№"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\" />
-        <Key android:keyOutputText="≠" android:keyLabel="≠" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\" />
+        <Key app:keyOutputText="≠" app:keyLabel="≠" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_swedish.xml
+++ b/app/src/main/res/xml/keyboard_symbols_swedish.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin_half"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="61" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin_half"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="61" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="0x2022" android:keyLabel="•"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="0x2022" app:keyLabel="•"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width_small"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\"/>
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\"/>
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_thai.xml
+++ b/app/src/main/res/xml/keyboard_symbols_thai.xml
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="0x2260" android:keyLabel="≠"/>
-        <Key android:codes="0xB1" android:keyLabel="±"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="0x2260" app:keyLabel="≠"/>
+        <Key app:codes="0xB1" app:keyLabel="±"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:isRepeatable="true" app:keyWidth="@dimen/keyboard_key_backspace_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="167" android:keyLabel="§" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="0x2022" android:keyLabel="•"/>
-        <Key android:codes="47" android:keyLabel="/"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="167" app:keyLabel="§" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="0x2022" app:keyLabel="•"/>
+        <Key app:codes="47" app:keyLabel="/"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_enter_width"  />
     </Row>
 
     <Row>
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
-        <Key android:codes="60" android:keyLabel="&lt;"/>
-        <Key android:codes="62" android:keyLabel="&gt;"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="0x2018" android:keyLabel="‘"/>
-        <Key android:codes="0x201C" android:keyLabel="“"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="95" android:keyLabel="_" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="92" android:keyLabel="\\" />
-        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" app:keyEdgeFlags="left"/>
+        <Key app:codes="60" app:keyLabel="&lt;"/>
+        <Key app:codes="62" app:keyLabel="&gt;"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="0x2018" app:keyLabel="‘"/>
+        <Key app:codes="0x201C" app:keyLabel="“"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="95" app:keyLabel="_" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="92" app:keyLabel="\\" />
+        <Key app:codes="-1" app:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="44" android:keyLabel=","/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="-14" android:keyLabel="\.com" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_mode_change" app:keyEdgeFlags="left" />
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_space_width" app:isRepeatable="true"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="44" app:keyLabel=","/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="-14" app:keyLabel="\.com" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_zhuyin.xml
+++ b/app/src/main/res/xml/keyboard_symbols_zhuyin.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:horizontalGap="@dimen/keyboard_horizontal_gap"
-    android:verticalGap="@dimen/keyboard_vertical_gap"
-    android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height">
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:horizontalGap="@dimen/keyboard_horizontal_gap"
+    app:verticalGap="@dimen/keyboard_vertical_gap"
+    app:keyWidth="@dimen/keyboard_key_width"
+    app:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
-        <Key android:codes="163" android:keyLabel="£"/>
-        <Key android:codes="165" android:keyLabel="¥"/>
-        <Key android:codes="36" android:keyLabel="$"/>
-        <Key android:codes="199" android:keyLabel="ç"/>
-        <Key android:codes="37" android:keyLabel="%"/>
-        <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="40" android:keyLabel="("/>
-        <Key android:codes="41" android:keyLabel=")"/>
-        <Key android:codes="61" android:keyLabel="="/>
-        <Key android:codes="95" android:keyLabel="_"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:isRepeatable="true"/>
+        <Key app:codes="8364" app:keyLabel="€" app:keyEdgeFlags="left"/>
+        <Key app:codes="163" app:keyLabel="£"/>
+        <Key app:codes="165" app:keyLabel="¥"/>
+        <Key app:codes="36" app:keyLabel="$"/>
+        <Key app:codes="199" app:keyLabel="ç"/>
+        <Key app:codes="37" app:keyLabel="%"/>
+        <Key app:codes="38" app:keyLabel="&amp;"/>
+        <Key app:codes="40" app:keyLabel="("/>
+        <Key app:codes="41" app:keyLabel=")"/>
+        <Key app:codes="61" app:keyLabel="="/>
+        <Key app:codes="95" app:keyLabel="_"/>
+        <Key app:codes="-5" app:keyIcon="@drawable/ic_icon_keyboard_backspace" app:keyWidth="@dimen/keyboard_key_zhuyin_space_width" app:isRepeatable="true"/>
     </Row>
     <Row>
-        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
-        <Key android:codes="94" android:keyLabel="^" />
-        <Key android:codes="0x22ef" android:keyLabel="⋯" />
-        <Key android:codes="123" android:keyLabel="{"/>
-        <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="91" android:keyLabel="["/>
-        <Key android:codes="93" android:keyLabel="]"/>
-        <Key android:codes="124" android:keyLabel="|"/>
-        <Key android:codes="59" android:keyLabel=";"/>
-        <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_zhuyin_enter_width"/>
-    </Row>
-
-    <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="0x300a" android:keyLabel="《"/>
-        <Key android:codes="0x300b" android:keyLabel="》"/>
-        <Key android:codes="96" android:keyLabel="`"/>
-        <Key android:codes="126" android:keyLabel="~"/>
-        <Key android:codes="39" android:keyLabel="'"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
-        <Key android:codes="92" android:keyLabel="\\" />
-        <Key android:codes="45" android:keyLabel="-" />
-        <Key android:codes="43" android:keyLabel="+" />
-        <Key android:codes="47" android:keyLabel="/" />
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:keyHeight="@dimen/keyboard_key_zhuyin_space_height" android:isRepeatable="true"/>
+        <Key app:codes="186" app:keyLabel="º" app:keyEdgeFlags="left" app:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key app:codes="94" app:keyLabel="^" />
+        <Key app:codes="0x22ef" app:keyLabel="⋯" />
+        <Key app:codes="123" app:keyLabel="{"/>
+        <Key app:codes="125" app:keyLabel="}"/>
+        <Key app:codes="91" app:keyLabel="["/>
+        <Key app:codes="93" app:keyLabel="]"/>
+        <Key app:codes="124" app:keyLabel="|"/>
+        <Key app:codes="59" app:keyLabel=";"/>
+        <Key app:codes="58" app:keyLabel=":"/>
+        <Key app:codes="-4" app:keyLabel="@string/keyboard_enter_label" app:keyWidth="@dimen/keyboard_key_zhuyin_enter_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe"/>
-        <Key android:codes="-13" android:keyLabel="^.^"/>
-        <Key android:codes="0x300C" android:keyLabel="「" />
-        <Key android:codes="0x300D" android:keyLabel="」" />
-        <Key android:codes="0xff64" android:keyLabel="､"/>
-        <Key android:codes="0xff61" android:keyLabel="｡"/>
-        <Key android:codes="0xff0c" android:keyLabel="，"/>
-        <Key android:codes="46" android:keyLabel="."/>
-        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
-        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key app:codes="-2" app:keyLabel="@string/keyboard_symbol" app:keyEdgeFlags="left"/>
+        <Key app:codes="0x300a" app:keyLabel="《"/>
+        <Key app:codes="0x300b" app:keyLabel="》"/>
+        <Key app:codes="96" app:keyLabel="`"/>
+        <Key app:codes="126" app:keyLabel="~"/>
+        <Key app:codes="39" app:keyLabel="'"/>
+        <Key app:codes="34" app:keyLabel="&quot;"/>
+        <Key app:codes="92" app:keyLabel="\\" />
+        <Key app:codes="45" app:keyLabel="-" />
+        <Key app:codes="43" app:keyLabel="+" />
+        <Key app:codes="47" app:keyLabel="/" />
+        <Key app:codes="32" app:keyLabel="" app:keyWidth="@dimen/keyboard_key_zhuyin_space_width" app:keyHeight="@dimen/keyboard_key_zhuyin_space_height" app:isRepeatable="true"/>
+    </Row>
+
+    <Row>
+        <Key app:codes="-12" app:keyIcon="@drawable/ic_icon_keyboard_globe"/>
+        <Key app:codes="-13" app:keyLabel="^.^"/>
+        <Key app:codes="0x300C" app:keyLabel="「" />
+        <Key app:codes="0x300D" app:keyLabel="」" />
+        <Key app:codes="0xff64" app:keyLabel="､"/>
+        <Key app:codes="0xff61" app:keyLabel="｡"/>
+        <Key app:codes="0xff0c" app:keyLabel="，"/>
+        <Key app:codes="46" app:keyLabel="."/>
+        <Key app:codes="33" app:keyLabel="!" app:popupCharacters="!¡" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="63" app:keyLabel="\?" app:popupCharacters="\?¿" app:popupKeyboard="@xml/keyboard_popup" />
+        <Key app:codes="64" app:keyLabel="\@"/>
     </Row>
 </Keyboard>


### PR DESCRIPTION
As instructed: https://developer.android.com/reference/android/inputmethodservice/KeyboardView

This class is deprecated because this is just a convenient UI widget class that application developers can re-implement on top of existing public APIs.  If you have already depended on this class, consider copying the implementation from AOSP into your project or re-implementing a similar widget by yourselves.