### PR TITLE
Introducing the GestureManager

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -123,6 +123,7 @@ if(OPENXR)
             src/openxr/cpp/DeviceDelegateOpenXR.cpp
             src/openxr/cpp/OpenXRSwapChain.cpp
             src/openxr/cpp/OpenXRLayers.cpp
+            src/openxr/cpp/OpenXRGestureManager.cpp
             src/openxr/cpp/OpenXRInput.cpp
             src/openxr/cpp/OpenXRInputSource.cpp
             src/openxr/cpp/OpenXRActionSet.cpp

--- a/app/src/openxr/cpp/OpenXRGestureManager.cpp
+++ b/app/src/openxr/cpp/OpenXRGestureManager.cpp
@@ -1,0 +1,77 @@
+//
+// Created by sergio on 05/07/23.
+//
+
+#include <cstring>
+#include "OpenXRGestureManager.h"
+
+namespace crow {
+
+void
+OpenXRGestureManagerFBHandTrackingAim::populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) {
+    memset(&mFBAimState, 0, sizeof(XrHandTrackingAimStateFB));
+    mFBAimState = { XR_TYPE_HAND_TRACKING_AIM_STATE_FB, handJointLocations.next, 0  };
+    handJointLocations.next = &mFBAimState;
+}
+
+bool
+OpenXRGestureManagerFBHandTrackingAim::hasAim() const {
+    return mFBAimState.status & XR_HAND_TRACKING_AIM_VALID_BIT_FB;
+}
+
+XrPosef
+OpenXRGestureManagerFBHandTrackingAim::aimPose(const XrHandJointLocationsEXT& handJointLocations, const XrTime predictedDisplayTime, const OpenXRHandFlags handeness, const vrb::Matrix& head) const {
+    ASSERT(hasAim());
+    return mFBAimState.aimPose;
+}
+
+OpenXRGestureManagerHandJoints::OpenXRGestureManagerHandJoints(HandJointsArray& handJoints)
+    : mHandJoints(handJoints)
+    , mOneEuroFilterPosition(std::make_unique<OneEuroFilterVector>(0.25, 0.1, 1)) {
+}
+
+bool
+OpenXRGestureManagerHandJoints::hasAim() const {
+    return IsHandJointPositionValid(XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT, mHandJoints);
+}
+
+XrPosef
+OpenXRGestureManagerHandJoints::aimPose(const XrHandJointLocationsEXT& handJointLocations, const XrTime predictedDisplayTime, const OpenXRHandFlags handeness, const vrb::Matrix& head) const {
+    ASSERT(hasAim());
+    auto lookAt = [](const vrb::Vector& sourcePoint, const vrb::Vector& destPoint) -> vrb::Quaternion {
+        const float EPSILON = 0.000001f;
+        vrb::Vector worldForward = { 0, 0, 1 };
+        vrb::Vector forwardVector = (destPoint - sourcePoint).Normalize();
+        float dot = worldForward.Dot(forwardVector);
+
+        // Vectors pointing to opposite directions -> 180 turn around up direction.
+        if (abs(dot - (-1.0f)) < EPSILON) {
+            return {0, 1, 0, M_PI };
+        }
+        // Vectors pointing in the same direction -> identity quaternion (no rotation)
+        if (abs(dot - (1.0f)) < EPSILON) {
+            return {0, 0, 0, 1 };
+        }
+
+        auto quaternionFromAxisAndAngle = [](const vrb::Vector& axis, float angle) -> vrb::Quaternion {
+            float halfAngle = angle * .5f;
+            float s = sin(halfAngle);
+            return { axis.x() * s, axis.y() * s, axis.z() * s, cos(halfAngle) };
+        };
+
+        float rotationAngle = acos(dot);
+        auto rotationAxis = worldForward.Cross(forwardVector);
+        return quaternionFromAxisAndAngle(rotationAxis.Normalize(), rotationAngle);
+    };
+
+    auto aimPose = handJointLocations.jointLocations[XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT].pose;
+    auto pos = vrb::Vector(aimPose.position.x, aimPose.position.y, aimPose.position.z);
+    float* filteredPos = mOneEuroFilterPosition->filter(predictedDisplayTime, pos.Data());
+
+    auto shoulder = head.MultiplyDirection({handeness == Right ? 0.15f : -0.15f,-0.25,0});
+    auto q = lookAt({filteredPos[0], filteredPos[1], filteredPos[2]}, shoulder);
+    aimPose.orientation = {q.x(), q.y(), q.z(), q.w() };
+    return aimPose;
+}
+
+}

--- a/app/src/openxr/cpp/OpenXRGestureManager.cpp
+++ b/app/src/openxr/cpp/OpenXRGestureManager.cpp
@@ -7,6 +7,26 @@
 
 namespace crow {
 
+// This threshold is used to detect when palm is facing the head,
+// and enable the left hand action gesture. The higher the threshold
+// the more aligned objects should be to be considered facing each other.
+// 0.7 is generally accepted as good for objects facing each other.
+const float kPalmHeadThreshold = 0.7;
+
+bool
+OpenXRGestureManager::palmFacesHead(const vrb::Matrix &palm, const vrb::Matrix &head) const {
+    // For the hand we take the Y axis because that corresponds to head's Z axis when
+    // the hand is in upright position facing head (the gesture we want to detect).
+#ifdef PICOXR
+    // Axis are inverted in Pico
+    auto vectorPalm = palm.MultiplyDirection({0, 0, -1});
+#else
+    auto vectorPalm = palm.MultiplyDirection({0, 1, 0});
+#endif
+    auto vectorHead = head.MultiplyDirection({0, 0, -1});
+    return vectorPalm.Dot(vectorHead) > kPalmHeadThreshold;
+}
+
 void
 OpenXRGestureManagerFBHandTrackingAim::populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) {
     memset(&mFBAimState, 0, sizeof(XrHandTrackingAimStateFB));
@@ -20,9 +40,19 @@ OpenXRGestureManagerFBHandTrackingAim::hasAim() const {
 }
 
 XrPosef
-OpenXRGestureManagerFBHandTrackingAim::aimPose(const XrHandJointLocationsEXT& handJointLocations, const XrTime predictedDisplayTime, const OpenXRHandFlags handeness, const vrb::Matrix& head) const {
+OpenXRGestureManagerFBHandTrackingAim::aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags handeness, const vrb::Matrix& head) const {
     ASSERT(hasAim());
     return mFBAimState.aimPose;
+}
+
+bool
+OpenXRGestureManagerFBHandTrackingAim::systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const {
+#ifdef PICOXR
+    // Pico does not correctly implement the SYSTEM_GESTURE_BIT_FB flags.
+    return palmFacesHead(palm, head) && !hasAim();
+#else
+    return mFBAimState.status & XR_HAND_TRACKING_AIM_SYSTEM_GESTURE_BIT_FB;
+#endif
 }
 
 OpenXRGestureManagerHandJoints::OpenXRGestureManagerHandJoints(HandJointsArray& handJoints)
@@ -36,7 +66,7 @@ OpenXRGestureManagerHandJoints::hasAim() const {
 }
 
 XrPosef
-OpenXRGestureManagerHandJoints::aimPose(const XrHandJointLocationsEXT& handJointLocations, const XrTime predictedDisplayTime, const OpenXRHandFlags handeness, const vrb::Matrix& head) const {
+OpenXRGestureManagerHandJoints::aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags handeness, const vrb::Matrix& head) const {
     ASSERT(hasAim());
     auto lookAt = [](const vrb::Vector& sourcePoint, const vrb::Vector& destPoint) -> vrb::Quaternion {
         const float EPSILON = 0.000001f;
@@ -64,7 +94,7 @@ OpenXRGestureManagerHandJoints::aimPose(const XrHandJointLocationsEXT& handJoint
         return quaternionFromAxisAndAngle(rotationAxis.Normalize(), rotationAngle);
     };
 
-    auto aimPose = handJointLocations.jointLocations[XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT].pose;
+    auto aimPose = mHandJoints[XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT].pose;
     auto pos = vrb::Vector(aimPose.position.x, aimPose.position.y, aimPose.position.z);
     float* filteredPos = mOneEuroFilterPosition->filter(predictedDisplayTime, pos.Data());
 
@@ -72,6 +102,11 @@ OpenXRGestureManagerHandJoints::aimPose(const XrHandJointLocationsEXT& handJoint
     auto q = lookAt({filteredPos[0], filteredPos[1], filteredPos[2]}, shoulder);
     aimPose.orientation = {q.x(), q.y(), q.z(), q.w() };
     return aimPose;
+}
+
+bool
+OpenXRGestureManagerHandJoints::systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const {
+    return palmFacesHead(palm, head);
 }
 
 }

--- a/app/src/openxr/cpp/OpenXRGestureManager.h
+++ b/app/src/openxr/cpp/OpenXRGestureManager.h
@@ -21,14 +21,19 @@ virtual ~OpenXRGestureManager() = default;
 
 virtual void populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) {};
 virtual bool hasAim() const = 0;
-virtual XrPosef aimPose(const XrHandJointLocationsEXT&, const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const = 0;
+virtual XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const = 0;
+virtual bool systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const = 0;
+
+protected:
+bool palmFacesHead(const vrb::Matrix& palm, const vrb::Matrix& head) const;
 };
 
 class OpenXRGestureManagerFBHandTrackingAim : public OpenXRGestureManager {
 private:
 void populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) override;
 bool hasAim() const override;
-XrPosef aimPose(const XrHandJointLocationsEXT&, const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
+XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
+bool systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const override;
 
 XrHandTrackingAimStateFB mFBAimState;
 };
@@ -38,7 +43,9 @@ public:
 OpenXRGestureManagerHandJoints(HandJointsArray& handJoints);
 private:
 bool hasAim() const override;
-XrPosef aimPose(const XrHandJointLocationsEXT&, const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
+XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
+bool systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const override;
+
 HandJointsArray& mHandJoints;
 std::unique_ptr<OneEuroFilterVector> mOneEuroFilterPosition;
 };

--- a/app/src/openxr/cpp/OpenXRGestureManager.h
+++ b/app/src/openxr/cpp/OpenXRGestureManager.h
@@ -1,0 +1,48 @@
+//
+// Created by sergio on 05/07/23.
+//
+
+#pragma once
+
+#include <memory>
+#include <openxr/openxr.h>
+#include "OneEuroFilter.h"
+#include "OpenXRHelpers.h"
+#include "OpenXRInputMappings.h"
+
+namespace crow {
+
+class OpenXRGestureManager;
+typedef std::unique_ptr<OpenXRGestureManager> OpenXRGesturePtr;
+
+class OpenXRGestureManager {
+public:
+virtual ~OpenXRGestureManager() = default;
+
+virtual void populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) {};
+virtual bool hasAim() const = 0;
+virtual XrPosef aimPose(const XrHandJointLocationsEXT&, const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const = 0;
+};
+
+class OpenXRGestureManagerFBHandTrackingAim : public OpenXRGestureManager {
+private:
+void populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) override;
+bool hasAim() const override;
+XrPosef aimPose(const XrHandJointLocationsEXT&, const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
+
+XrHandTrackingAimStateFB mFBAimState;
+};
+
+class OpenXRGestureManagerHandJoints : public OpenXRGestureManager {
+public:
+OpenXRGestureManagerHandJoints(HandJointsArray& handJoints);
+private:
+bool hasAim() const override;
+XrPosef aimPose(const XrHandJointLocationsEXT&, const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
+HandJointsArray& mHandJoints;
+std::unique_ptr<OneEuroFilterVector> mOneEuroFilterPosition;
+};
+
+} // namespace crow
+
+

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -43,7 +43,6 @@ private:
     void UpdateHaptics(ControllerDelegate&);
     bool GetHandTrackingInfo(const XrFrameState&, XrSpace, const vrb::Matrix& head);
     float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
-    bool IsHandJointPositionValid(const enum XrHandJointEXT aJoint);
     void EmulateControllerFromHand(device::RenderMode renderMode, const vrb::Matrix& head, ControllerDelegate& delegate);
 
     XrInstance mInstance { XR_NULL_HANDLE };
@@ -69,7 +68,7 @@ private:
     std::vector<float> axesContainer;
     crow::ElbowModelPtr elbow;
     XrHandTrackerEXT mHandTracker { XR_NULL_HANDLE };
-    std::array<XrHandJointLocationEXT, XR_HAND_JOINT_COUNT_EXT> mHandJoints;
+    HandJointsArray mHandJoints;
     bool mHasHandJoints { false };
     bool mHasAimState { false };
     XrPosef mHandAimPose;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -41,9 +41,9 @@ private:
     XrResult applyHapticFeedback(XrAction, XrDuration, float = XR_FREQUENCY_UNSPECIFIED, float = 0.0) const;
     XrResult stopHapticFeedback(XrAction) const;
     void UpdateHaptics(ControllerDelegate&);
-    bool GetHandTrackingInfo(const XrFrameState&, XrSpace, const vrb::Matrix& head);
+    bool GetHandTrackingInfo(XrTime predictedDisplayTime, XrSpace, const vrb::Matrix& head);
     float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
-    void EmulateControllerFromHand(device::RenderMode renderMode, const vrb::Matrix& head, ControllerDelegate& delegate);
+    void EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, ControllerDelegate& delegate);
 
     XrInstance mInstance { XR_NULL_HANDLE };
     XrSession mSession { XR_NULL_HANDLE };
@@ -70,8 +70,6 @@ private:
     XrHandTrackerEXT mHandTracker { XR_NULL_HANDLE };
     HandJointsArray mHandJoints;
     bool mHasHandJoints { false };
-    bool mHasAimState { false };
-    XrPosef mHandAimPose;
     bool mSupportsFBHandTrackingAim { false };
     double mSmoothIndexThumbDistance { 0 };
     OpenXRGesturePtr mGestureManager;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -5,7 +5,7 @@
 #include "OpenXRHelpers.h"
 #include "OpenXRActionSet.h"
 #include "ElbowModel.h"
-#include "OneEuroFilter.h"
+#include "OpenXRGestureManager.h"
 #include <optional>
 #include <unordered_map>
 
@@ -74,7 +74,7 @@ private:
     XrPosef mHandAimPose;
     bool mSupportsFBHandTrackingAim { false };
     double mSmoothIndexThumbDistance { 0 };
-    std::unique_ptr<OneEuroFilterVector> mOneEuroFilterPosition;
+    OpenXRGesturePtr mGestureManager;
 
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);


### PR DESCRIPTION
We're steadily adding new gestures to Wolvic for hand tracking interaction. So far the code was 
intermixed with the rest of the generic code for controllers. It started to be a bit difficult to follow
and had the risk of becoming spaguetti code.

What's more, some vendors have specific OpenXR extensions for hand gestures. Integrating them
would worsen the overall situation. That's why we have decided to refactor that code in a new
class called OpenXRGestureManager. This class has different implementations depending on the
features supported by the runtime. Initally we'll have one subclass for the FB aim extension and
another one (the fallback one) for devices not supporting any specific extension. The latter will
use our code that detects gestures based on the hand joints.

Followup PRs will add support for pinching detection that can be done with the FB extension.

Last but not least, this changes completely remove (in my testing) phantom back/exit events
caused by the current incorrect detection of system gestures based on the hand tracking aim.