### PR TITLE
Add support for XR_MSFT_hand_tracking_mesh

### DIFF
--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -210,14 +210,14 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
 
     controller.handJointTransforms = jointTransforms;
 
-    CreationContextPtr create = m.context.lock();
-
     // Initialize left and right hands action button, which for now triggers back navigation
     // and exit app respectively.
     // Note that Quest's runtime already shows the hamburger menu button when left
     // hand is facing head and the system menu for the right hand gesture.
 #if !defined(OCULUSVR)
     if (controller.handActionButtonToggle == nullptr) {
+        CreationContextPtr create = m.context.lock();
+
         TextureGLPtr texture = create->LoadTexture(controller.leftHanded ? "menu.png" : "exit.png") ;
         assert(texture);
         texture->SetTextureParameter(GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/app/src/main/cpp/HandMeshRenderer.cpp
+++ b/app/src/main/cpp/HandMeshRenderer.cpp
@@ -35,7 +35,7 @@ struct HandMeshRendererSpheres::State {
     std::vector<HandMeshSpheres> handMeshState;
 };
 
-HandMeshRendererSpheres::HandMeshRendererSpheres(State &aState, vrb::CreationContextPtr& aContext)
+HandMeshRendererSpheres::HandMeshRendererSpheres(State& aState, vrb::CreationContextPtr& aContext)
     : m(aState) {
     context = aContext;
 }
@@ -257,7 +257,7 @@ struct HandMeshRendererSkinned::State {
     std::vector<HandMeshGLState> handGLState = { };
 };
 
-HandMeshRendererSkinned::HandMeshRendererSkinned(State &aState, vrb::CreationContextPtr& aContext)
+HandMeshRendererSkinned::HandMeshRendererSkinned(State& aState, vrb::CreationContextPtr& aContext)
     : m(aState) {
     m.vertexShader = vrb::LoadShader(GL_VERTEX_SHADER, sVertexShader);
     m.fragmentShader = vrb::LoadShader(GL_FRAGMENT_SHADER, sFragmentShader);

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -19,6 +19,8 @@ PFN_xrCreatePassthroughFB OpenXRExtensions::sXrCreatePassthroughFB = nullptr;
 PFN_xrDestroyPassthroughFB OpenXRExtensions::sXrDestroyPassthroughFB = nullptr;
 PFN_xrCreatePassthroughLayerFB OpenXRExtensions::sXrCreatePassthroughLayerFB = nullptr;
 PFN_xrDestroyPassthroughLayerFB OpenXRExtensions::sXrDestroyPassthroughLayerFB = nullptr;
+PFN_xrCreateHandMeshSpaceMSFT OpenXRExtensions::sXrCreateHandMeshSpaceMSFT = nullptr;
+PFN_xrUpdateHandMeshMSFT OpenXRExtensions::sXrUpdateHandMeshMSFT = nullptr;
 
 void OpenXRExtensions::Initialize() {
     // Extensions.
@@ -86,6 +88,13 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
                                         reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyHandTrackerEXT)));
         CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrLocateHandJointsEXT",
                                         reinterpret_cast<PFN_xrVoidFunction *>(&sXrLocateHandJointsEXT)));
+
+        if (IsExtensionSupported(XR_MSFT_HAND_TRACKING_MESH_EXTENSION_NAME)) {
+            CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreateHandMeshSpaceMSFT",
+                                              reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreateHandMeshSpaceMSFT)));
+            CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrUpdateHandMeshMSFT",
+                                              reinterpret_cast<PFN_xrVoidFunction *>(&sXrUpdateHandMeshMSFT)));
+        }
     }
 
     if (IsExtensionSupported(XR_FB_PASSTHROUGH_EXTENSION_NAME)) {

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -33,6 +33,9 @@ namespace crow {
     static PFN_xrDestroyPassthroughFB sXrDestroyPassthroughFB;
     static PFN_xrCreatePassthroughLayerFB sXrCreatePassthroughLayerFB;
     static PFN_xrDestroyPassthroughLayerFB sXrDestroyPassthroughLayerFB;
+
+    static PFN_xrCreateHandMeshSpaceMSFT sXrCreateHandMeshSpaceMSFT;
+    static PFN_xrUpdateHandMeshMSFT sXrUpdateHandMeshMSFT;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
      static std::unordered_set<std::string> sSupportedApiLayers;

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -130,6 +130,18 @@ OpenXRInputMapping* OpenXRInput::GetActiveInputMapping() const
   return nullptr;
 }
 
+void OpenXRInput::SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount) {
+  for (auto& input : mInputSources) {
+    input->SetHandMeshBufferSizes(indexCount, vertexCount);
+  }
+}
+
+HandMeshBufferPtr OpenXRInput::GetNextHandMeshBuffer(const int32_t aControllerIndex) {
+  if (!mInputSources.at(aControllerIndex))
+    return nullptr;
+  return mInputSources.at(aControllerIndex)->GetNextHandMeshBuffer();
+}
+
 OpenXRInput::~OpenXRInput() {
 }
 

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -18,6 +18,9 @@ class OpenXRInputMapping;
 class OpenXRActionSet;
 typedef std::shared_ptr<OpenXRActionSet> OpenXRActionSetPtr;
 
+struct HandMeshBuffer;
+typedef std::shared_ptr<HandMeshBuffer> HandMeshBufferPtr;
+
 class OpenXRInput {
 private:
   OpenXRInput(XrInstance, XrSession, XrSystemProperties, ControllerDelegate& delegate);
@@ -38,7 +41,8 @@ public:
   std::string GetControllerModelName(const int32_t aModelIndex) const;
   void UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);
   bool AreControllersReady() const;
-
+  void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
+  HandMeshBufferPtr GetNextHandMeshBuffer(const int32_t aControllerIndex);
   ~OpenXRInput();
 };
 

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -5,6 +5,7 @@
 #include "OpenXRHelpers.h"
 #include "OpenXRActionSet.h"
 #include "ElbowModel.h"
+#include "HandMeshRenderer.h"
 #include "OpenXRGestureManager.h"
 #include <optional>
 #include <unordered_map>
@@ -74,6 +75,23 @@ private:
     double mSmoothIndexThumbDistance { 0 };
     OpenXRGesturePtr mGestureManager;
 
+    struct HandMeshMSFT {
+        XrSpace space = XR_NULL_HANDLE;
+        XrHandMeshMSFT handMesh;
+        HandMeshBufferPtr buffer = nullptr;
+
+        std::vector<HandMeshBufferMSFTPtr> buffers;
+        std::vector<HandMeshBufferMSFTPtr> usedBuffers;
+        ~HandMeshMSFT() {
+            for (auto& buf: buffers)
+                buf.reset();
+            for (auto& buf: usedBuffers)
+                buf.reset();
+        }
+    } mHandMeshMSFT;
+    HandMeshBufferPtr AcquireHandMeshBuffer();
+    void ReleaseHandMeshBuffer();
+
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);
     ~OpenXRInputSource();
@@ -83,6 +101,8 @@ public:
     XrResult UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }
+    void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
+    HandMeshBufferPtr GetNextHandMeshBuffer();
 };
 
 } // namespace crow


### PR DESCRIPTION
https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_MSFT_hand_tracking_mesh

This extension allows us to render good-looking hands during hand-tracking on devices that support the extension.

For now, it is only enabled on devices running Snapdragon Spaces Services, and has been tested on the Lenovo A3. The resulting hands look great but they appear a bit displaced with respect to the actual hands (which you can still see on the A3 being a see-through device). Also, the normals are apparently a bit off because the lighting on the hands is weird. But since we are not modifying the vertex data in any way as fed by the runtime, for now I will assume this is a limitation on the SDK part.  

Unlike our other existing hand rendering methods, this extension feeds hand mesh geometry data on a per-frame basis, with all transformations already applied to the vertices' position and normal. This adds even more complexity to the already complex hand mesh rendering code in Wolvic, since there is very little code re-use. That said, we are already working on a follow-up series that will bring some sanity and encapsulation to this part of the code.