### PR TITLE
[Chromium] Add explicit dependency on androidx.core

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -535,6 +535,7 @@ dependencies {
     implementation deps.lifecycle.viewmodel
     implementation deps.lifecycle.java8
     implementation deps.lifecycle.process
+    implementation deps.support.core
     implementation deps.support.annotations
     implementation deps.support.app_compat
     implementation deps.support.recyclerview

--- a/versions.gradle
+++ b/versions.gradle
@@ -100,6 +100,7 @@ app_services.rustlog = "org.mozilla.appservices:rustlog:${versions.mozilla_appse
 deps.app_services = app_services
 
 def support = [:]
+support.core = "androidx.core:core:1.10.1"
 support.annotations = "androidx.annotation:annotation:1.1.0"
 support.app_compat = "androidx.appcompat:appcompat:1.4.2"
 support.recyclerview = "androidx.recyclerview:recyclerview:1.2.1"
@@ -187,7 +188,7 @@ build_versions.min_sdk_wave = 25
 build_versions.target_sdk = 31
 build_versions.target_sdk_wave = 31
 build_versions.target_sdk_spaces = 29
-build_versions.compile_sdk = 31
+build_versions.compile_sdk = 33
 build_versions.build_tools = "30.0.3"
 ext.build_versions = build_versions
 


### PR DESCRIPTION
This change adds an explicit dependency on androidx.core and updates the compile sdk version to 33 (required by androidx.core:1.10.1).

This is required by the new versions of the Chromium backend.