### PR TITLE
Use androidx's PreferenceManager

### DIFF
--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -14,7 +14,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.hardware.display.DisplayManager;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Surface;


### PR DESCRIPTION
The class android.preference.PreferenceManager has been deprecated, so this PR replaces it with the androidx version.

This line was recently changed because of an unintentional mistake.