### PR TITLE
Use the OculusTouch3 controllers for WebXR session in Lynx R1

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -255,6 +255,10 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
       // FIXME: Gecko does not support ML2 device yet, so let's use a similar one for WebXR.
       result = mozilla::gfx::VRControllerType::OculusGo;
       break;
+    case device::LynxR1:
+      // FIXME: Gecko does not support LynxR1 device yet, so let's use a similar one for WebXR.
+      result = mozilla::gfx::VRControllerType::OculusTouch3;
+      break;
     case device::UnknownType:
     default:
       result = mozilla::gfx::VRControllerType::_empty;


### PR DESCRIPTION
Gecko does not provide support for the LynxR1 controllers, so we use a similar one for now when entering in a WebXR session.

Fixes #833 