### PR TITLE
Fix duplicated toolbars in phone UI

### DIFF
--- a/app/src/hvr/java/com/igalia/wolvic/LandingPageFragment.java
+++ b/app/src/hvr/java/com/igalia/wolvic/LandingPageFragment.java
@@ -32,6 +32,26 @@ public class LandingPageFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        Toolbar toolbar = view.findViewById(R.id.toolbar);
+        if (toolbar != null) {
+            toolbar.setTitle(R.string.app_name);
+            toolbar.showOverflowMenu();
+            toolbar.inflateMenu(R.menu.app_menu);
+            toolbar.setOnMenuItemClickListener(item -> {
+                if (item.getItemId() == R.id.enter_vr) {
+                    showEnterVr();
+                    return true;
+                } else if (item.getItemId() == R.id.terms_service) {
+                    showLegalDocument(LegalDocumentFragment.LegalDocument.TERMS_OF_SERVICE);
+                    return true;
+                } else if (item.getItemId() == R.id.privacy_policy) {
+                    showLegalDocument(LegalDocumentFragment.LegalDocument.PRIVACY_POLICY);
+                    return true;
+                }
+                return false;
+            });
+        }
+
         WebView webView = view.findViewById(R.id.web_view);
 
         // Links to wolvic.com will be opened in this Web view, "mailto" links will launch the email app
@@ -81,31 +101,6 @@ public class LandingPageFragment extends Fragment {
         enterVrButton.setOnClickListener(v -> {
             showEnterVr();
         });
-    }
-
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-
-        Toolbar toolbar = getActivity().findViewById(R.id.toolbar);
-        if (toolbar != null) {
-            toolbar.setTitle(R.string.app_name);
-            toolbar.showOverflowMenu();
-            toolbar.inflateMenu(R.menu.app_menu);
-            toolbar.setOnMenuItemClickListener(item -> {
-                if (item.getItemId() == R.id.enter_vr) {
-                    showEnterVr();
-                    return true;
-                } else if (item.getItemId() == R.id.terms_service) {
-                    showLegalDocument(LegalDocumentFragment.LegalDocument.TERMS_OF_SERVICE);
-                    return true;
-                } else if (item.getItemId() == R.id.privacy_policy) {
-                    showLegalDocument(LegalDocumentFragment.LegalDocument.PRIVACY_POLICY);
-                    return true;
-                }
-                return false;
-            });
-        }
     }
 
     private void showEnterVr() {

--- a/app/src/hvr/java/com/igalia/wolvic/PrivacyPolicyFragment.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PrivacyPolicyFragment.java
@@ -1,7 +1,6 @@
 package com.igalia.wolvic;
 
 import android.app.Fragment;
-import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -22,21 +21,16 @@ public class PrivacyPolicyFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        Toolbar toolbar = view.findViewById(R.id.toolbar);
+        if (toolbar != null) {
+            toolbar.setTitle(R.string.privacy_policy_title);
+            toolbar.hideOverflowMenu();
+        }
+
         view.findViewById(R.id.button_decline).setOnClickListener(
                 button -> getActivity().finish());
 
         view.findViewById(R.id.button_accept).setOnClickListener(
                 button -> SettingsStore.getInstance(getContext()).setPrivacyPolicyAccepted(true));
-    }
-
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-
-        Toolbar toolbar = getActivity().findViewById(R.id.toolbar);
-        if (toolbar != null) {
-            toolbar.setTitle(R.string.privacy_policy_title);
-            toolbar.hideOverflowMenu();
-        }
     }
 }

--- a/app/src/hvr/java/com/igalia/wolvic/TermsServiceFragment.java
+++ b/app/src/hvr/java/com/igalia/wolvic/TermsServiceFragment.java
@@ -1,7 +1,6 @@
 package com.igalia.wolvic;
 
 import android.app.Fragment;
-import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -22,21 +21,16 @@ public class TermsServiceFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        Toolbar toolbar = view.findViewById(R.id.toolbar);
+        if (toolbar != null) {
+            toolbar.setTitle(R.string.terms_service_title);
+            toolbar.hideOverflowMenu();
+        }
+
         view.findViewById(R.id.button_decline).setOnClickListener(
                 button -> getActivity().finish());
 
         view.findViewById(R.id.button_accept).setOnClickListener(
                 button -> SettingsStore.getInstance(getContext()).setTermsServiceAccepted(true));
-    }
-
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-
-        Toolbar toolbar = getActivity().findViewById(R.id.toolbar);
-        if (toolbar != null) {
-            toolbar.setTitle(R.string.terms_service_title);
-            toolbar.hideOverflowMenu();
-        }
     }
 }

--- a/app/src/hvr/res/layout/fragment_content_holder.xml
+++ b/app/src/hvr/res/layout/fragment_content_holder.xml
@@ -7,14 +7,6 @@
     android:background="@color/white"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
-        style="@style/Widget.MaterialComponents.Toolbar.Primary"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:elevation="4dp"
-        app:popupTheme="@style/Theme.WolvicPhone.PopupOverlay" />
-
     <FrameLayout
         android:id="@+id/fragment_placeholder"
         android:layout_width="match_parent"

--- a/app/src/hvr/res/layout/fragment_landing_page.xml
+++ b/app/src/hvr/res/layout/fragment_landing_page.xml
@@ -5,6 +5,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:elevation="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:popupTheme="@style/Theme.WolvicPhone.PopupOverlay" />
+
     <WebView
         android:id="@+id/web_view"
         android:layout_width="0dp"
@@ -13,7 +24,7 @@
         app:layout_constraintBottom_toTopOf="@id/bottom_toolbar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
     <FrameLayout
         android:id="@+id/bottom_toolbar"


### PR DESCRIPTION
Sometimes pages in the phone UI have two toolbars, which looks like a visual glitch.

This was happening because fragment_content_holder.xml had a toolbar, but at the same time it was embedding other fragments that also had their own toolbar.

This PR cleans that up and ensures that the layout is always correct.