### PR TITLE
Fix left hand action button on Lynx

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -548,23 +548,22 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
     if (controller.modelToggle)
       controller.modelToggle->ToggleAll(controller.mode == ControllerMode::Device);
 
+    // If we are rendering hands using spheres, update the joints' transforms here.
+    if (controller.handJointTransforms.size() > 0) {
+      assert(controller.handJointTransforms.size() == controller.meshJointTransforms.size());
+      for (int i = 0; i < controller.handJointTransforms.size(); i++)
+        controller.handJointTransforms[i]->SetTransform(controller.meshJointTransforms[i]);
+    }
+
     if (controller.handActionEnabled && controller.handActionButtonTransform != nullptr) {
       // Layout the button between the thumb and index fingertips
       const int indexTipIndex = device->GetHandTrackingJointIndex(HandTrackingJoints::IndexTip);
       const int thumbTipIndex = device->GetHandTrackingJointIndex(HandTrackingJoints::ThumbTip);
       vrb::Matrix indexTipMatrix;
       vrb::Matrix thumbTipMatrix;
-      if (controller.handMesh) {
-        assert(controller.meshJointTransforms.size() > 0);
-        // We substract 1 from the index because we removed the palm joint (index 0) to match
-        // the joints in our hand mesh.
-        indexTipMatrix = controller.meshJointTransforms[indexTipIndex - 1];
-        thumbTipMatrix = controller.meshJointTransforms[thumbTipIndex - 1];
-      } else {
-        assert(controller.handJointTransforms.size() > 0);
-        indexTipMatrix = controller.handJointTransforms[indexTipIndex]->GetTransform();
-        thumbTipMatrix = controller.handJointTransforms[thumbTipIndex]->GetTransform();
-      }
+      indexTipMatrix = controller.meshJointTransforms[indexTipIndex];
+      thumbTipMatrix = controller.meshJointTransforms[thumbTipIndex];
+
       vrb::Vector center = (indexTipMatrix.GetTranslation() - thumbTipMatrix.GetTranslation()) / 2.0f;
       vrb::Vector position = indexTipMatrix.GetTranslation() - center;
 

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -211,6 +211,8 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
     if (!m.root)
         return;
 
+    controller.meshJointTransforms = jointTransforms;
+
     CreationContextPtr create = m.context.lock();
 
     // Initialize left and right hands action button, which for now triggers back navigation
@@ -272,30 +274,6 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
 
             controller.handMeshToggle->AddNode(transform);
         }
-    }
-
-    assert(jointTransforms.size() == controller.handJointTransforms.size());
-    for (uint32_t i = 0; i < jointTransforms.size(); i++) {
-        auto transform = jointTransforms[i];
-        assert(controller.handJointTransforms[i]);
-        controller.handJointTransforms[i]->SetTransform(transform);
-    }
-#else
-    std::vector<vrb::Matrix> tmpJointTransforms = jointTransforms;
-    // We ignore the first matrix, corresponding to the palm, because the
-    // models we are currently using don't include a palm joint.
-    tmpJointTransforms.erase(tmpJointTransforms.begin());
-
-    if (controller.meshJointTransforms.size() == 0)
-        controller.meshJointTransforms.resize(tmpJointTransforms.size());
-    assert(controller.meshJointTransforms.size() == tmpJointTransforms.size());
-
-    // The hand model we are currently using for the left hand has the
-    // bind matrices of the joints in reverse order with respect to that
-    // of the XR_EXT_hand_tracking extension, hence we correct it here
-    // before assigning.
-    for (int i = 0, j = tmpJointTransforms.size() - 1; i < tmpJointTransforms.size(); i++, j--) {
-        controller.meshJointTransforms[i] = tmpJointTransforms[controller.leftHanded ? j : i];
     }
 #endif
 }

--- a/app/src/main/cpp/HandModels.cpp
+++ b/app/src/main/cpp/HandModels.cpp
@@ -195,11 +195,8 @@ HandModels::Draw(const vrb::Camera& aCamera, const Controller& aController) {
   // of the XR_EXT_hand_tracking extension, hence we correct it here
   // before assigning.
   if (aController.leftHanded) {
-    for (int i = 0; i < jointMatrices.size() / 2; i++) {
-      auto tmp = jointMatrices[i];
-      jointMatrices[i] = jointMatrices[jointMatrices.size() - i - 1];
-      jointMatrices[jointMatrices.size() - i - 1] = tmp;
-    }
+    for (int i = 0; i < jointMatrices.size() / 2; i++)
+      std::swap(jointMatrices[i], jointMatrices[jointMatrices.size() - i - 1]);
   }
 
   assert(jointMatrices.size() == state.jointCount);


### PR DESCRIPTION
When we introduced the generic hand mesh rendering we broke the left hand button action on Lynx. This patch fixes that and also simplifies the workflow of storing and indexing into the joint matrices vector.

The issue is that the skeleton of our left hand model has the order of the joints in reverse order with respect to what the XR_EXT_hand_tracking extension gives. So we had to correct the order of the matrices there. The problem is that we were doing that too early, during assignment and before calculating the left hand action button matrix, which requires indexing the joint matrices to get the thumb and index tips.

Both Oculus and Lynx use the generic mesh rendering code-path, but only Lynx uses the left hand action button (in Oculus it is already provided by the system). Hence the bug went unnoticed until we tested it on Lynx.

Fixes #839