### PR TITLE
Support per-architecture dependency substitutions for Gecko

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This could be done either by using a [local maven repository](https://mozilla-mo
 Currently, the substitution flow is streamlined for some of the core dependencies via configuration flags in `local.properties`. You can build against a local checkout of the following dependencies by specifying their local paths:
 - [GeckoView](https://hg.mozilla.org/mozilla-central), specifying its path via `dependencySubstitutions.geckoviewTopsrcdir=/path/to/mozilla-central` (and, optionally, `dependencySubstitutions.geckoviewTopobjdir=/path/to/topobjdir`). See [Bug 1533465](https://bugzilla.mozilla.org/show_bug.cgi?id=1533465).
   - This assumes that you have built, packaged, and published your local GeckoView -- but don't worry, the dependency substitution script has the latest instructions for doing that.
+  - If you want to build for different architectures at the same time, you can specify the aarch64 path via `dependencySubstitutions.geckoviewTopobjdir` while the x86_64 path via `dependencySubstitutions.geckoviewTopobjdirX64`
 
 Do not forget to run a Gradle sync in Android Studio after changing `local.properties`. If you specified any substitutions, they will be reflected in the modules list, and you'll be able to modify them from a single Android Studio window.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -694,7 +694,10 @@ if(gradle.hasProperty("userProperties.openxr") && !gradle.startParameter.taskNam
 }
 
 if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcdir')) {
-    if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopobjdir')) {
+    if (getGradle().getStartParameter().getTaskRequests().toString().toLowerCase().contains('x86_64')
+            && gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopobjdirX64')) {
+        ext.topobjdir = gradle."localProperties.dependencySubstitutions.geckoviewTopobjdirX64"
+    } else if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopobjdir')) {
         ext.topobjdir = gradle."localProperties.dependencySubstitutions.geckoviewTopobjdir"
     }
     ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"


### PR DESCRIPTION
MagicLeap2 is x86, so it needs an x86 Android gecko to build. With this PR, we don't have to manually change the location of the gecko build dir to use it.

If you want to build for different architectures at the same time, you can specify the aarch64 path via `dependencySubstitutions.geckoviewTopobjdir` while the x86_64 path via `dependencySubstitutions.geckoviewTopobjdirX64` in local.properties