### PR TITLE
Homepage bypass cache so that it can work corectly after a language change

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -876,7 +876,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     }
 
     public void loadHomePage() {
-        loadUri(getHomeUri());
+        loadUri(getHomeUri(), WSession.LOAD_FLAGS_BYPASS_CACHE);
     }
 
     public void loadPrivateBrowsingPage() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -259,7 +259,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
         mBinding.navigationBarNavigation.homeButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
-            getSession().loadUri(getSession().getHomeUri());
+            getSession().loadUri(getSession().getHomeUri(), WSession.LOAD_FLAGS_BYPASS_CACHE);
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }


### PR DESCRIPTION
We shouldn't have caching on the homepage since now we use the multilingual URL for jumping to the right language version of the homepage. https://github.com/Igalia/wolvic/commit/8eb00c4ec1dfd1a6e594fb611e01ec0a591e0519

With caching, if we change the system language to another one, the behavior will break (stick to the old one and won't land on the changed language).

