### PR TITLE
Chromium: Add targetRayOrientation field to VRControllerState

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -528,6 +528,9 @@ ExternalVR::PushFramePoses(const vrb::Matrix& aHeadTransform, const std::vector<
         vrb::Vector position(controller.transformMatrix.GetTranslation());
         memcpy(&(immersiveController.targetRayPose.position), position.Data(), sizeof(immersiveController.targetRayPose.position));
       }
+
+      vrb::Quaternion immersiveBeamRotate(controller.immersiveBeamTransform);
+      memcpy(&(immersiveController.targetRayOrientation), immersiveBeamRotate.Data(), sizeof(immersiveController.targetRayOrientation));
     }
 
     if (flags & static_cast<uint16_t>(mozilla::gfx::ControllerCapabilityFlags::Cap_GripSpacePosition)) {

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -428,6 +428,11 @@ struct VRControllerState {
   // https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace
   VRPose targetRayPose;
 
+  // When Cap_Orientation is set in flags, targetRayOrientation corresponds
+  // to the orientation of the target ray (origin of the ray is determined by
+  // the controller position). Only used by the Chromium backend.
+  float targetRayOrientation[4];
+
   bool isPositionValid;
   bool isOrientationValid;
 


### PR DESCRIPTION
Update moz_external_vr.h to include an additional field that represents the orientation component of the controller's target ray. This field is required by the Chromium's vr_service.mojom API.