### PR TITLE
[OpenXR] Add support for XR_EXTX_overlay extension

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1446,7 +1446,11 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
   createInfo.systemId = m.system;
 
   if (OpenXRExtensions::IsExtensionSupported(XR_EXTX_OVERLAY_EXTENSION_NAME)) {
-    XrSessionCreateInfoOverlayEXTX overlayInfo { .type = XR_TYPE_SESSION_CREATE_INFO_OVERLAY_EXTX, .createFlags = 0, .sessionLayersPlacement = 0 };
+    XrSessionCreateInfoOverlayEXTX overlayInfo {
+      .type = XR_TYPE_SESSION_CREATE_INFO_OVERLAY_EXTX,
+      .createFlags = 0,
+      .sessionLayersPlacement = 0
+    };
     auto oldNext = createInfo.next;
     createInfo.next = &overlayInfo;
     overlayInfo.next = oldNext;

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -181,6 +181,9 @@ struct DeviceDelegateOpenXR::State {
     if (OpenXRExtensions::IsExtensionSupported(XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME))
         extensions.push_back(XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME);
 
+    if (OpenXRExtensions::IsExtensionSupported(XR_EXTX_OVERLAY_EXTENSION_NAME))
+        extensions.push_back(XR_EXTX_OVERLAY_EXTENSION_NAME);
+
     java = {XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR};
     java.applicationVM = javaContext->vm;
     java.applicationActivity = javaContext->activity;
@@ -888,6 +891,12 @@ DeviceDelegateOpenXR::ProcessEvents() {
         }
         break;
       }
+      case XR_TYPE_EVENT_DATA_MAIN_SESSION_VISIBILITY_CHANGED_EXTX: {
+        assert(OpenXRExtensions::IsExtensionSupported(XR_EXTX_OVERLAY_EXTENSION_NAME));
+        const auto &event = *reinterpret_cast<const XrEventDataMainSessionVisibilityChangedEXTX *>(ev);
+        VRB_LOG("OpenXR main session is now %s", event.visible == XR_TRUE ? "visible" : "not visible");
+        break;
+      }
       default: {
         VRB_DEBUG("OpenXR ignoring event type %d", ev->type);
         break;
@@ -1435,6 +1444,14 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
   XrSessionCreateInfo createInfo{XR_TYPE_SESSION_CREATE_INFO};
   createInfo.next = reinterpret_cast<const XrBaseInStructure*>(&m.graphicsBinding);
   createInfo.systemId = m.system;
+
+  if (OpenXRExtensions::IsExtensionSupported(XR_EXTX_OVERLAY_EXTENSION_NAME)) {
+    XrSessionCreateInfoOverlayEXTX overlayInfo { .type = XR_TYPE_SESSION_CREATE_INFO_OVERLAY_EXTX, .createFlags = 0, .sessionLayersPlacement = 0 };
+    auto oldNext = createInfo.next;
+    createInfo.next = &overlayInfo;
+    overlayInfo.next = oldNext;
+  }
+
   CHECK_XRCMD(xrCreateSession(m.instance, &createInfo, &m.session));
   CHECK(m.session != XR_NULL_HANDLE);
   VRB_LOG("OpenXR session created succesfully");


### PR DESCRIPTION
This provisional extension allows multiple OpenXR apps to run concurrently
and get their contents composited. Apps specify at which level they'd like
to be composited from 0 (first to be composited) to MAX_UINT32 (last to be
composited on top of all the other ones). We initially selected 0 so that all
the other OpenXR apps supporting this extension will render on top
(unless one uses also 0 and is launched before Wolvic).

From the list of currently supported devices Pico 4 & 4E, Lynx-R1 and 
Lenovo A3 devices support this extension.