### PR TITLE
Fix several issues related to Download List

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -763,7 +763,7 @@ public class SettingsStore {
         editor.commit();
     }
 
-    public @SortingContextMenuWidget.Order int getDownloadsSortingOrder() {
+    public @Storage int getDownloadsSortingOrder() {
         return mPrefs.getInt(mContext.getString(R.string.settings_key_downloads_sorting_order), DOWNLOADS_SORTING_ORDER_DEFAULT);
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/downloads/CopyToContentUriCallback.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/CopyToContentUriCallback.java
@@ -1,9 +1,0 @@
-package com.igalia.wolvic.downloads;
-
-import android.net.Uri;
-
-public interface CopyToContentUriCallback {
-    void onSuccess(Uri uri, boolean isNewUri);
-
-    void onFailure(Download download);
-}

--- a/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
@@ -4,6 +4,7 @@ import android.app.DownloadManager;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.text.format.Formatter;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -193,30 +194,17 @@ public class Download {
         switch (download.mStatus) {
             case Download.RUNNING:
                 try {
-                    if (download.mSizeBytes < MEGABYTE) {
-                        return String.format(language.getLocale(), "%.2f/%.2fKb (%d%%)",
-                                ((double)download.mDownloadedBytes / (double)KILOBYTE),
-                                ((double)download.mSizeBytes / (double)KILOBYTE),
-                                (download.mDownloadedBytes*100)/download.mSizeBytes);
-
-                    } else {
-                        return String.format(language.getLocale(), "%.2f/%.2fMB (%d%%)",
-                                ((double)download.mDownloadedBytes / (double)MEGABYTE),
-                                ((double)download.mSizeBytes / (double)MEGABYTE),
-                                (download.mDownloadedBytes*100)/download.mSizeBytes);
-                    }
+                    return Formatter.formatFileSize(context, download.mDownloadedBytes) + '/' +
+                            Formatter.formatFileSize(context, download.mSizeBytes) +
+                            String.format(language.getLocale(), " (%d%%)",
+                            (download.mDownloadedBytes*100)/download.mSizeBytes);
 
                 } catch (Exception e) {
                     return "-/-";
                 }
 
             case Download.SUCCESSFUL:
-                if (download.mSizeBytes < MEGABYTE) {
-                    return String.format(language.getLocale(), "%.2fKb", ((double)download.mSizeBytes / (double)KILOBYTE));
-
-                } else {
-                    return String.format(language.getLocale(), "%.2fMB", ((double)download.mSizeBytes / (double)MEGABYTE));
-                }
+                return Formatter.formatFileSize(context, download.mSizeBytes);
 
             case Download.FAILED:
                 return context.getString(R.string.download_status_failed);

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -2,9 +2,6 @@ package com.igalia.wolvic.downloads;
 
 import android.app.DownloadManager;
 import android.content.BroadcastReceiver;
-import android.content.ContentResolver;
-import android.content.ContentUris;
-import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -17,14 +14,12 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
-import android.provider.MediaStore;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.utils.StringUtils;
@@ -35,11 +30,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -320,117 +312,10 @@ public class DownloadsManager {
         }
     };
 
-    //Returns the content URI of the public copy of this downloaded file, if it exists.
-    @RequiresApi(api = Build.VERSION_CODES.Q)
-    public Uri getContentUriForDownloadedFile(@NonNull Download download) {
-        ContentResolver contentResolver = mContext.getContentResolver();
-
-        // We assume that the copy would have the same name, origin, and size.
-        Cursor cursor = contentResolver.query(MediaStore.Downloads.EXTERNAL_CONTENT_URI,
-                new String[]{MediaStore.Downloads._ID},
-                MediaStore.Downloads.DISPLAY_NAME + "=? AND " +
-                        MediaStore.Downloads.DOWNLOAD_URI + "=? AND " +
-                        MediaStore.Downloads.SIZE + "=" + download.getSizeBytes(),
-                new String[]{
-                        download.getFilename(),
-                        download.getUri()
-                },
-                null,
-                null
-        );
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                return ContentUris.withAppendedId(MediaStore.Downloads.EXTERNAL_CONTENT_URI,
-                        cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Downloads._ID)));
-            }
-            cursor.close();
-        }
-        return null;
-    }
-
-    // Copies the downloaded file to a content URI in Android's media database.
-    @RequiresApi(api = Build.VERSION_CODES.Q)
-    public void copyToContentUri(long downloadId, @NonNull CopyToContentUriCallback callback) {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        Handler uiHandler = new Handler(Looper.getMainLooper());
-        ContentResolver contentResolver = mContext.getContentResolver();
-
-        Download download = getDownload(downloadId);
-        if (download == null) {
-            uiHandler.post(() -> callback.onFailure(null));
-            return;
-        }
-
-        // Check that the file has not already been copied before
-        Uri existingUri = getContentUriForDownloadedFile(download);
-        if (existingUri != null) {
-            uiHandler.post(() -> callback.onSuccess(existingUri, false));
-            return;
-        }
-
-        // Fill in the values for a new entry in the Downloads table in MediaStore.
-        ContentValues contentValues = new ContentValues();
-        contentValues.put(MediaStore.Downloads.DISPLAY_NAME, download.getFilename());
-        contentValues.put(MediaStore.Downloads.SIZE, download.getSizeBytes());
-        contentValues.put(MediaStore.Downloads.DATE_MODIFIED, download.getLastModified());
-        contentValues.put(MediaStore.Downloads.DOWNLOAD_URI, download.getUri());
-
-        String mimeFromExtension = null;
-        String extension = MimeTypeMap.getFileExtensionFromUrl(download.getOutputFileUriAsString());
-        if (extension != null) {
-            mimeFromExtension = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-        }
-
-        File downloadedFile = download.getOutputFile();
-        Uri downloadedFileUri = Uri.fromFile(downloadedFile);
-        String mimeFromFile = contentResolver.getType(downloadedFileUri);
-
-        String mimeFromDownload = download.getMediaType();
-
-        if (mimeFromExtension != null) {
-            contentValues.put(MediaStore.Downloads.MIME_TYPE, mimeFromExtension);
-        } else if (mimeFromFile != null) {
-            contentValues.put(MediaStore.Downloads.MIME_TYPE, mimeFromFile);
-        } else {
-            contentValues.put(MediaStore.Downloads.MIME_TYPE, mimeFromDownload);
-        }
-
-        // This flag indicates that the file is not yet ready.
-        contentValues.put(MediaStore.Downloads.IS_PENDING, 1);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            contentValues.put(MediaStore.Downloads.IS_DRM, 0);
-        }
-
-        Uri contentUri = contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues);
-
-        if (contentUri == null) {
-            uiHandler.post(() -> callback.onFailure(download));
-            return;
-        }
-
-        // Copy the file asynchronously. Callbacks will happen in the UI thread.
-        executor.execute(() -> {
-            try {
-                Files.copy(downloadedFile.toPath(), contentResolver.openOutputStream(contentUri));
-                contentValues.put(MediaStore.Downloads.IS_PENDING, 0);
-                contentResolver.update(contentUri, contentValues, null, null);
-
-                uiHandler.post(() -> callback.onSuccess(contentUri, true));
-            } catch (IOException e) {
-                Log.e(LOGTAG, "Error while copying: " + e.getMessage(), e);
-
-                contentResolver.delete(contentUri, null, null);
-
-                uiHandler.post(() -> callback.onFailure(download));
-            }
-        });
-    }
-
     private void notifyDownloadsUpdate() {
         List<Download> downloads = getDownloads();
         int filter = Download.RUNNING | Download.PAUSED | Download.PENDING;
-        boolean activeDownloads = downloads.stream().filter(d -> (d.getStatus() & filter) != 0).count() > 0;
+        boolean activeDownloads = downloads.stream().filter(d -> (d.getStatus() & filter) != 0).count()  > 0;
         mListeners.forEach(listener -> listener.onDownloadsUpdate(downloads));
         if (!activeDownloads) {
             stopUpdates();

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -138,7 +138,7 @@ public class DownloadsManager {
 
         if (job.getOutputPath() == null) {
             try {
-                request.setDestinationInExternalFilesDir(mContext, Environment.DIRECTORY_DOWNLOADS, job.getFilename());
+                request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, job.getFilename());
             } catch (IllegalStateException e) {
                 e.printStackTrace();
                 notifyDownloadError(mContext.getString(R.string.download_error_output), job.getFilename());
@@ -166,7 +166,7 @@ public class DownloadsManager {
             return;
         }
 
-        final File dir = mContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
+        final File dir = new File(Environment.getExternalStorageDirectory() + "/" + Environment.DIRECTORY_DOWNLOADS);
         if (dir == null) {
             Log.e(LOGTAG, "Error when saving " + job.getUri() + " : failed to get the Downloads directory");
             return;

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -6,9 +6,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
-import android.graphics.BlendMode;
-import android.graphics.BlendModeColorFilter;
-import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -179,11 +176,13 @@ public class DownloadsManager {
             int currentIndex = 0;
             int lastDashIndex = name.lastIndexOf('-');
             if (lastDashIndex >= 0) {
+                String nameBackup = name;
                 try {
                     name = name.substring(0, lastDashIndex - 1);
                     String index = name.substring(lastDashIndex + 1);
                     currentIndex = Integer.parseInt(index);
                 } catch (Exception e) {
+                    name = nameBackup;
                 }
             }
             do {
@@ -211,9 +210,11 @@ public class DownloadsManager {
         Log.i(LOGTAG, "Saved " + job.getUri() + " to " + file.getName() + " (" + readBytes + " bytes)");
 
         // TODO: Deprecated addCompletedDownload(...), see https://github.com/Igalia/wolvic/issues/798
-        mDownloadManager.addCompletedDownload(file.getName(), file.getName(),
+        long downloadId = mDownloadManager.addCompletedDownload(file.getName(), file.getName(),
                 true, UrlUtils.getMimeTypeFromUrl(file.getPath()), file.getPath(), readBytes, true,
-                Uri.parse(job.getUri().replaceFirst("^blob:","")), null);
+                Uri.parse(job.getUri().replaceFirst("^blob:", "")), null);
+
+        notifyDownloadCompleted(downloadId);
     }
 
     public void removeDownload(long downloadId, boolean deleteFiles) {
@@ -297,17 +298,8 @@ public class DownloadsManager {
             String action = intent.getAction();
             long downloadId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0);
 
-            if (mDownloadManager != null && DownloadManager.ACTION_DOWNLOAD_COMPLETE.equals(action)) {
-                DownloadManager.Query query = new DownloadManager.Query();
-                query.setFilterById(downloadId);
-                Cursor c = mDownloadManager.query(query);
-                if (c != null) {
-                    if (c.moveToFirst()) {
-                        notifyDownloadsUpdate();
-                        notifyDownloadCompleted(Download.from(c));
-                    }
-                    c.close();
-                }
+            if (DownloadManager.ACTION_DOWNLOAD_COMPLETE.equals(action)) {
+                notifyDownloadCompleted(downloadId);
             }
         }
     };
@@ -320,6 +312,23 @@ public class DownloadsManager {
         if (!activeDownloads) {
             stopUpdates();
         }
+    }
+
+    private void notifyDownloadCompleted(@NonNull long downloadId) {
+        if (mDownloadManager == null) {
+            return;
+        }
+        DownloadManager.Query query = new DownloadManager.Query();
+        query.setFilterById(downloadId);
+        Cursor c = mDownloadManager.query(query);
+        if (c == null) {
+            return;
+        }
+        if (c.moveToFirst()) {
+            notifyDownloadsUpdate();
+            notifyDownloadCompleted(Download.from(c));
+        }
+        c.close();
     }
 
     private void notifyDownloadCompleted(@NonNull Download download) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/callbacks/DownloadsContextMenuCallback.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/callbacks/DownloadsContextMenuCallback.java
@@ -3,7 +3,5 @@ package com.igalia.wolvic.ui.callbacks;
 import com.igalia.wolvic.ui.widgets.menus.library.DownloadsContextMenuWidget;
 
 public interface DownloadsContextMenuCallback extends LibraryContextMenuCallback {
-    void onCopyToContentUri(DownloadsContextMenuWidget.DownloadsContextMenuItem item);
-
     void onDelete(DownloadsContextMenuWidget.DownloadsContextMenuItem item);
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
@@ -9,14 +9,12 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.PointF;
 import android.graphics.Rect;
-import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -26,9 +24,7 @@ import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.engine.SessionStore;
-import com.igalia.wolvic.browser.extensions.LocalExtension;
 import com.igalia.wolvic.databinding.DownloadsBinding;
-import com.igalia.wolvic.downloads.CopyToContentUriCallback;
 import com.igalia.wolvic.downloads.Download;
 import com.igalia.wolvic.downloads.DownloadsManager;
 import com.igalia.wolvic.telemetry.TelemetryService;
@@ -45,12 +41,13 @@ import com.igalia.wolvic.ui.widgets.menus.library.DownloadsContextMenuWidget;
 import com.igalia.wolvic.ui.widgets.menus.library.LibraryContextMenuWidget;
 import com.igalia.wolvic.ui.widgets.menus.library.SortingContextMenuWidget;
 import com.igalia.wolvic.utils.SystemUtils;
+import com.igalia.wolvic.browser.extensions.LocalExtension;
 import com.igalia.wolvic.utils.UrlUtils;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.UUID;
 
 public class DownloadsView extends LibraryView implements DownloadsManager.DownloadsListener {
 
@@ -249,9 +246,6 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
 
         @Override
         public void onShowContextMenu(@NonNull View view, Download item, boolean isLastVisibleItem) {
-            boolean canCopyToContentUri = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-                    && mDownloadsManager.getContentUriForDownloadedFile(item) == null;
-
             showContextMenu(
                     view,
                     new DownloadsContextMenuWidget(getContext(),
@@ -259,8 +253,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                                     item.getOutputFileUriAsString(),
                                     item.getTitle(),
                                     item.getId()),
-                            mWidgetManager.canOpenNewWindow(),
-                            canCopyToContentUri),
+                            mWidgetManager.canOpenNewWindow()),
                     mCallback,
                     isLastVisibleItem);
         }
@@ -273,26 +266,6 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         @Override
         public void onShowSortingContextMenu(@NonNull View view) {
             showSortingContextMenu(view);
-        }
-    };
-
-    private CopyToContentUriCallback mCopyToContentUriCallback = new CopyToContentUriCallback() {
-        @Override
-        public void onSuccess(Uri uri, boolean isNewUri) {
-            mWidgetManager.getFocusedWindow().showAlert(
-                    getContext().getString(R.string.download_copy_to_content_uri_success_title),
-                    getContext().getString(R.string.download_copy_to_content_uri_success_body),
-                    null);
-        }
-
-        @Override
-        public void onFailure(Download download) {
-            String errorBody = (download != null) ?
-                    getContext().getString(R.string.download_copy_to_content_uri_error_body_v1, download.getFilename()) :
-                    getContext().getString(R.string.download_copy_to_content_uri_error_body);
-
-            mWidgetManager.getFocusedWindow().showAlert(
-                    getContext().getString(R.string.download_copy_to_content_uri_error_title), errorBody, null);
         }
     };
 
@@ -336,19 +309,6 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
             mWidgetManager.openNewTabForeground(item.getUrl());
             TelemetryService.Tabs.openedCounter(TelemetryService.Tabs.TabSource.DOWNLOADS);
             hideContextMenu();
-        }
-
-        @RequiresApi(api = Build.VERSION_CODES.Q)
-        @Override
-        public void onCopyToContentUri(DownloadsContextMenuWidget.DownloadsContextMenuItem item) {
-            mWidgetManager.getFocusedWindow().showConfirmPrompt(
-                    getContext().getString(R.string.download_copy_to_content_uri_confirm_title),
-                    getContext().getString(R.string.download_copy_to_content_uri_confirm_body),
-                    new String[]{getContext().getString(R.string.cancel_button),
-                            getContext().getString(R.string.ok_button)},
-                    (index, isChecked) -> {
-                        mDownloadsManager.copyToContentUri(item.getDownloadsId(), mCopyToContentUriCallback);
-                    });
         }
 
         @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/DownloadsContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/DownloadsContextMenuWidget.java
@@ -12,16 +12,14 @@ import java.util.EnumSet;
 public class DownloadsContextMenuWidget extends LibraryContextMenuWidget {
 
     public DownloadsContextMenuWidget(Context aContext, LibraryContextMenuItem item,
-                                      boolean canOpenWindows, boolean canCopyToContentUri) {
-        super(aContext, item, getAdditionalActions(canOpenWindows, canCopyToContentUri));
+                                      boolean canOpenWindows) {
+        super(aContext, item, getAdditionalActions(canOpenWindows));
     }
 
-    private static EnumSet<Action> getAdditionalActions(boolean canOpenWindows, boolean canCopyToContentUri) {
+    private static EnumSet<Action> getAdditionalActions(boolean canOpenWindows) {
         EnumSet<Action> additionalActions = EnumSet.noneOf(Action.class);
         if (canOpenWindows)
             additionalActions.add(Action.OPEN_WINDOW);
-        if (canCopyToContentUri)
-            additionalActions.add(Action.CAN_COPY);
         return additionalActions;
     }
 
@@ -43,18 +41,11 @@ public class DownloadsContextMenuWidget extends LibraryContextMenuWidget {
 
     @Override
     protected void setupCustomMenuItems(EnumSet<Action> additionalActions) {
-        if (additionalActions.contains(Action.CAN_COPY)) {
-            mItems.add(new MenuItem(getContext().getString(
-                    R.string.download_context_copy_to_content_uri),
-                    R.drawable.ic_icon_file_copy,
-                    () -> mItemDelegate.ifPresent((present ->
-                            ((DownloadsContextMenuCallback) mItemDelegate.get()).onCopyToContentUri((DownloadsContextMenuItem) mItem)))));
-        }
         mItems.add(new MenuItem(getContext().getString(
                 R.string.download_context_delete),
                 R.drawable.ic_icon_library_clearfromlist,
                 () -> mItemDelegate.ifPresent((present ->
-                        ((DownloadsContextMenuCallback) mItemDelegate.get()).onDelete((DownloadsContextMenuItem) mItem)))));
+                        ((DownloadsContextMenuCallback)mItemDelegate.get()).onDelete((DownloadsContextMenuItem)mItem)))));
     }
 
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/HistoryContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/HistoryContextMenuWidget.java
@@ -30,10 +30,10 @@ public class HistoryContextMenuWidget extends LibraryContextMenuWidget {
                 isBookmarked ? R.drawable.ic_icon_bookmarked_active : R.drawable.ic_icon_bookmarked,
                 () -> mItemDelegate.ifPresent((present -> {
                     if (isBookmarked) {
-                        ((HistoryContextMenuCallback) mItemDelegate.get()).onRemoveFromBookmarks(mItem);
+                        ((HistoryContextMenuCallback)mItemDelegate.get()).onRemoveFromBookmarks(mItem);
 
                     } else {
-                        ((HistoryContextMenuCallback) mItemDelegate.get()).onAddToBookmarks(mItem);
+                        ((HistoryContextMenuCallback)mItemDelegate.get()).onAddToBookmarks(mItem);
                     }
                 }))));
     }

--- a/app/src/main/res/drawable/ic_icon_file_copy.xml
+++ b/app/src/main/res/drawable/ic_icon_file_copy.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="@color/rhino"
-        android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM15,5l6,6v10c0,1.1 -0.9,2 -2,2L7.99,23C6.89,23 6,22.1 6,21l0.01,-14c0,-1.1 0.89,-2 1.99,-2h7zM14,12h5.5L14,6.5L14,12z" />
-</vector>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1634,8 +1634,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="permissions_dialog_remember_choice">Husk denne beslutning</string>
     <string name="hamburger_menu_save_web_app">Gem webapp…</string>
     <string name="web_apps_loading">Indlæsning af webapps</string>
-    <string name="download_context_copy_to_content_uri">Del med andre apps</string>
-    <string name="download_copy_to_content_uri_error_body_v1">Der opstod en fejl under kopiering af %1$s</string>
     <string name="upload_button">Upload</string>
     <string name="addons_experimental_section_title">Eksperimentelt</string>
     <string name="web_apps_title">Web apps</string>
@@ -1652,14 +1650,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_addon_install_confirm_install">Installer</string>
     <string name="download_addon_install_blocked">Lokal addon-installation blokeret</string>
     <string name="download_addon_install_blocked_body">Tillad lokal addon-installation i Udviklingsindstillinger for at fortsætte.</string>
-    <string name="download_copy_to_content_uri_confirm_title">Vil du kopiere filen\?</string>
-    <string name="download_copy_to_content_uri_confirm_body">Dette vil oprette en kopi af denne fil i systemets downloads-mappe, hvor den kan tilgås af andre apps.
-\n
-\nVil du fortsætte\?</string>
-    <string name="download_copy_to_content_uri_success_title">Kopieret med succes</string>
-    <string name="download_copy_to_content_uri_success_body">Filen blev kopieret med succes og er tilgængelig i systemets Downloads.</string>
-    <string name="download_copy_to_content_uri_error_title">Kopieringsfejl</string>
-    <string name="download_copy_to_content_uri_error_body">Der opstod en fejl under kopiering af den downloadede fil.</string>
     <string name="notifications_loading">Indlæsning af notifikationer</string>
     <string name="notifications_empty">Din notifikationsliste er tom</string>
     <string name="notifications_title">Notifikationer</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -985,10 +985,6 @@
          the more button is pressed in a downloads item. It deletes the selected item from the downloads list
          and also from disk. -->
     <string name="download_context_delete">Eliminar</string>
-    <!-- This string is displayed is the downloads context menu that is displayed when
-     the more button is pressed in a downloads item. It creates a copy of the selected item
-     in the public Downloads folder so it may be used by other apps. -->
-    <string name="download_context_copy_to_content_uri">Compartir con otras aplicaciones</string>
     <!-- This string labels the Reset button that restores the default display settings values. -->
     <string name="display_options_reset">Restablecer los ajustes de visualización</string>
     <!-- This string labels the Reset button that restores the default privacy and security settings values. -->
@@ -1555,23 +1551,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_status_unavailable">No disponible</string>
     <!-- This string is displayed in the downloads panel, in the download status when an unknown error happened. -->
     <string name="download_status_unknown_error">Error desconocido</string>
-    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
-    <string name="download_copy_to_content_uri_confirm_title">¿Copiar archivo\?</string>
-    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
-    <string name="download_copy_to_content_uri_confirm_body">Se creará una copia del archivo en la carpeta de Descarga del sistema, donde podrá ser utilizada por otras aplicaciones.
-\n
-\n¿Deseas continuar\?</string>
-    <!-- This string is displayed in the title of the download error dialog. -->
-    <string name="download_copy_to_content_uri_success_title">Archivo copiado</string>
-    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
-    <string name="download_copy_to_content_uri_success_body">El archivo se copió con éxito y está disponible en las Descargas del sistema.</string>
-    <!-- This string is displayed in the title of the copy downloaded file error dialog. -->
-    <string name="download_copy_to_content_uri_error_title">Error durante la copia</string>
-    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
-    <string name="download_copy_to_content_uri_error_body">Se ha producido un error mientras se copiaba el archivo.</string>
-    <!-- This string is displayed in the body of the copy downloaded file error dialog.
-     '%1$s' will be replaced at runtime with the name of the downloaded file. -->
-    <string name="download_copy_to_content_uri_error_body_v1">Ha sucedido un error mientras se copiaba %1$s</string>
     <!-- This string is shown in the body of the error dialog displayed when the user is trying to download an environment in the external storage
     but hasn't granted the permission. -->
     <string name="environment_download_permission_error_body">Para descargar el entorno es necesario tener permiso de escritura en el almacenamiento externo.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1748,23 +1748,13 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_addon_install_cancel">Annuler</string>
     <string name="download_addon_install_confirm_install">Installer</string>
     <string name="download_addon_install_blocked">Installation de l\'extension locale bloquée</string>
-    <string name="download_copy_to_content_uri_confirm_title">Copier le fichier \?</string>
-    <string name="download_copy_to_content_uri_success_title">Copie réussie</string>
-    <string name="download_copy_to_content_uri_success_body">Le fichier a été copié avec succès et est disponible dans le répertoire Téléchargements du système.</string>
-    <string name="download_copy_to_content_uri_error_title">Échec de la copie</string>
-    <string name="download_context_copy_to_content_uri">Partager avec d\'autres applications</string>
     <string name="download_addon_install">Installer l\'extension</string>
     <string name="addons_experimental_section_title">Expérimental</string>
     <string name="web_apps_loading">Chargement des Applications Web</string>
     <string name="web_apps_dialog_cancel">Annuler</string>
     <string name="hamburger_menu_save_web_app">Enregistrer l\'application Web…</string>
     <string name="download_addon_install_blocked_body">Pour continuer, autorisez l\'installation de l\'extension locale dans les Options pour les développeurs.</string>
-    <string name="download_copy_to_content_uri_error_body">Une erreur est survenue lors de la copie du fichier téléchargé.</string>
     <string name="web_apps_dialog_body">Souhaitez-vous installer l\'application Web suivante \? Elle sera disponible dans la librairie.</string>
-    <string name="download_copy_to_content_uri_error_body_v1">Une erreur est survenue lors de la copie de %1$s</string>
-    <string name="download_copy_to_content_uri_confirm_body">Une copie du fichier va être créée dans le répertoire Téléchargements du système, accessible par d\'autres applications.
-\n
-\nSouhaitez-vous continuer \?</string>
     <string name="settings_language_portuguese">Portugais</string>
     <string name="deprecated_version_dialog_title">Mise à jour recommandée</string>
     <string name="deprecated_version_dialog_info_button">En savoir plus…</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -328,7 +328,6 @@
     <string name="history_context_add_bookmarks">Engadir aos marcadores</string>
     <string name="history_context_remove_bookmarks">Eliminar dos marcadores</string>
     <string name="download_context_delete">Borrar</string>
-    <string name="download_context_copy_to_content_uri">Compartir con outras aplicacións</string>
     <string name="display_options_reset">Restablecer configuración de display</string>
     <string name="privacy_options_reset">Restablecer configuración de privacidade e seguridade</string>
     <string name="privacy_options_saved_logins_list_header">Inicios de sesión gardados:</string>
@@ -476,13 +475,6 @@
     <string name="download_status_paused">Pausada</string>
     <string name="download_status_unavailable">Non dispoñible</string>
     <string name="download_status_unknown_error">Erro descoñecido</string>
-    <string name="download_copy_to_content_uri_confirm_title">¿Copiar arquivo?</string>
-    <string name="download_copy_to_content_uri_confirm_body">Crearase unha copia do arquivo na carpeta de Descargas del sistema, onde poderá ser utilizada por outras aplicacións.\n\n¿Desexas continuar?</string>
-    <string name="download_copy_to_content_uri_success_title">Ficheiro copiado</string>
-    <string name="download_copy_to_content_uri_success_body">O ficheiro copiouse con éxito e está dispoñible nas Descargas do sistema.</string>
-    <string name="download_copy_to_content_uri_error_title">Erro durante a copia</string>
-    <string name="download_copy_to_content_uri_error_body">Produciuse un erro mentras se copiaba o arquivo.</string>
-    <string name="download_copy_to_content_uri_error_body_v1">Produciuse un erro mentras se copiaba %1$s</string>
     <string name="environment_download_permission_error_body">É necesario ter permiso de escritura no almacenamento externo para descargar a contorna.</string>
     <string name="environment_error_title">Erro na contorna</string>
     <string name="autofill_dialog_save_title">Gardar este inicio de sesión\?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1623,7 +1623,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="settings_language_choose_language_voice_search_service_title">音声検索サービス</string>
     <string name="settings_language_choose_language_voice_search_service_description">音声検索に使用するサービスの優先順位を設定できます。</string>
     <string name="settings_language_galician">ガリシア語</string>
-    <string name="download_context_copy_to_content_uri">他のアプリと共有する</string>
     <string name="notifications_title">通知</string>
     <string name="web_apps_empty">ウェブアプリリストが空です</string>
     <string name="web_apps_loading">ウェブアプリを読み込んでいます</string>
@@ -1635,15 +1634,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_addon_install_confirm_install">インストール</string>
     <string name="download_addon_install_blocked">ローカルアドオンのインストールはブロックされています</string>
     <string name="download_addon_install_blocked_body">開発者オプションにローカルアドオンのインストールを許可する。</string>
-    <string name="download_copy_to_content_uri_confirm_title">ファイルをコピーしますか？</string>
-    <string name="download_copy_to_content_uri_success_title">コピーが成功しました</string>
-    <string name="download_copy_to_content_uri_confirm_body">このファイルのコピーをシステムのダウンロードフォルダーに保存します。その場合、他のアプリにもアクセス可能になります。
-\n
-\n続けますか？</string>
-    <string name="download_copy_to_content_uri_success_body">コピーが成功しました、ファイルはシステムのダンロードフォルダーに保存しました。</string>
-    <string name="download_copy_to_content_uri_error_title">コピーエラー</string>
-    <string name="download_copy_to_content_uri_error_body">ダウンロードしたファイルのコピー中にエラーが発生しました。</string>
-    <string name="download_copy_to_content_uri_error_body_v1">%1$sをコピー中にエラーが発生しました</string>
     <string name="voice_service_metkai">MeetKai</string>
     <string name="upload_button">アップロード</string>
     <string name="upload_list_empty">アップロードできるファイルがありません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1734,21 +1734,11 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="notifications_title">알림</string>
     <string name="notifications_empty">알림 목록이 비어있습니다</string>
     <string name="notifications_loading">알림을 로드 중 입니다</string>
-    <string name="download_context_copy_to_content_uri">다른 앱으로 공유</string>
     <string name="download_addon_install">애드온 설치</string>
     <string name="download_addon_install_cancel">취소</string>
     <string name="download_addon_install_confirm_install">설치</string>
     <string name="download_addon_install_blocked">애드온 설치 실패</string>
     <string name="download_addon_install_blocked_body">계속 진행하려면 개발자 옵션에서 애드온 설치를 허용해야 합니다.</string>
-    <string name="download_copy_to_content_uri_confirm_title">파일을 복사하시겠습니까\?</string>
-    <string name="download_copy_to_content_uri_confirm_body">이 파일을 시스템의 Downloads 폴더에 복사합니다. 이 폴더는 다른 앱으로부터의 접근이 가능합니다.
-\n
-\n계속 하시겠습니까\?</string>
-    <string name="download_copy_to_content_uri_success_title">복사 성공</string>
-    <string name="download_copy_to_content_uri_success_body">파일이 시스템의 Downloads 폴더에 성공적으로 복사됐습니다.</string>
-    <string name="download_copy_to_content_uri_error_title">복사 실패</string>
-    <string name="download_copy_to_content_uri_error_body">다운로드한 파일을 복사하는 중 오류가 발생했습니다.</string>
-    <string name="download_copy_to_content_uri_error_body_v1">%1$s을(를) 복사하는 중 오류가 발생했습니다</string>
     <string name="web_apps_title">웹 앱</string>
     <string name="web_apps_description">웹 앱에 추가할 페이지에 있을 때 웹 앱 저장... 버튼을 클릭하세요.</string>
     <string name="web_apps_empty">웹 앱 목록이 비어 있습니다</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -714,19 +714,12 @@
     <string name="notifications_title">Notificações</string>
     <string name="addons_experimental_section_title">Experimental</string>
     <string name="web_apps_title">Aplicativos Web</string>
-    <string name="download_context_copy_to_content_uri">Compartilhar com outros aplicativos</string>
     <string name="web_apps_empty">Sua lista de Aplicativos Web está vazia</string>
     <string name="web_apps_loading">Carregando Aplicativos Web</string>
     <string name="web_apps_dialog_title">Instalar Aplicativo Web</string>
     <string name="web_apps_description">Clique no botão Salvar Aplicativo Web... quando você estiver em uma página para adicioná-lo aos seus Aplicativos Web.</string>
     <string name="web_apps_saved_notification">Aplicativo Web adicionado!</string>
     <string name="download_addon_install_blocked">Instalação de complemento local bloqueada</string>
-    <string name="download_copy_to_content_uri_confirm_title">Copiar arquivo\?</string>
-    <string name="download_copy_to_content_uri_confirm_body">Isso criará uma cópia desse arquivo na pasta do sistema Downloads, onde ele pode ser acessado por outros aplicativos.
-\n
-\nDeseja continuar\?</string>
-    <string name="download_copy_to_content_uri_success_body">Este arquivo foi copiado com sucesso e está disponível na pasta Downloads.</string>
-    <string name="download_copy_to_content_uri_error_body_v1">Ocorreu um erro ao copiar %1$s</string>
     <string name="download_addon_install_confirm_install">Instalar</string>
     <string name="upload_button">Carregar</string>
     <string name="upload_list_empty">Não há arquivos disponíveis para carregar</string>
@@ -736,9 +729,6 @@
     <string name="download_addon_install">Instalar complemento</string>
     <string name="download_addon_install_cancel">Cancelar</string>
     <string name="download_addon_install_blocked_body">Permita a instalação de Complemento local nas Opções do Desenvolvedor para continuar.</string>
-    <string name="download_copy_to_content_uri_error_body">Ocorreu um erro ao copiar o arquivo baixado.</string>
-    <string name="download_copy_to_content_uri_success_title">Copiado com sucesso</string>
-    <string name="download_copy_to_content_uri_error_title">Erro de cópia</string>
     <string name="web_apps_dialog_body">Deseja instalar o seguinte Aplicativo Web\? Ele estará disponível na Biblioteca.</string>
     <string name="hamburger_menu_save_web_app">Salvar aplicativo Web…</string>
     <string name="hamburger_menu_toggle_passthrough">Passthrough</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -712,7 +712,6 @@
     <string name="web_apps_dialog_body">Pretende instalar a seguinte Aplicação Web\? Estará disponível de seguida na sua Biblioteca.</string>
     <string name="web_apps_title">Aplicações Web</string>
     <string name="addons_experimental_section_title">Experimental</string>
-    <string name="download_context_copy_to_content_uri">Partilhar com outras aplicações</string>
     <string name="web_apps_empty">A sua lista de Aplicações Web está Vazia</string>
     <string name="settings_language_portuguese">Português</string>
     <string name="web_apps_dialog_cancel">Cancelar</string>
@@ -725,13 +724,4 @@
     <string name="download_addon_install_confirm_install">Instalar</string>
     <string name="download_addon_install_blocked">Instalação de complemento local bloqueada</string>
     <string name="download_addon_install_blocked_body">Permita a instalação de Complemento local nas Opções do Programador para continuar.</string>
-    <string name="download_copy_to_content_uri_confirm_title">Copiar ficheiro\?</string>
-    <string name="download_copy_to_content_uri_confirm_body">Isso criará uma cópia desse ficheiro na pasta do sistema Downloads, onde ele pode ser acessado por outras apps.
-\n
-\nDeseja continuar\?</string>
-    <string name="download_copy_to_content_uri_success_title">Copiado com sucesso</string>
-    <string name="download_copy_to_content_uri_success_body">Este ficheiro foi copiado com sucesso e está disponível na pasta Downloads.</string>
-    <string name="download_copy_to_content_uri_error_title">Erro de cópia</string>
-    <string name="download_copy_to_content_uri_error_body">Ocorreu um erro ao copiar o ficheiro descarregado.</string>
-    <string name="download_copy_to_content_uri_error_body_v1">Ocorreu um erro ao copiar %1$s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1646,10 +1646,8 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="upload_button">Загрузить</string>
     <string name="web_apps_dialog_cancel">Отмена</string>
     <string name="web_apps_saved_notification">Веб-приложение добавлено!</string>
-    <string name="download_context_copy_to_content_uri">Дать доступ другим приложениям</string>
     <string name="web_apps_dialog_body">Вы желаете установить это веб-приложение\? Оно будет доступно в Библиотеке.</string>
     <string name="download_addon_install">Установить дополнение</string>
-    <string name="download_copy_to_content_uri_success_body">Файл успешно скопирован и доступен в системной папке «Загруки».</string>
     <string name="download_addon_install_blocked_body">Чтобы продолжить, разрешите установку локальных дополнений в Настройках разработчика.</string>
     <string name="permissions_dialog_remember_choice">Запомнить этот выбор</string>
     <string name="voice_service_huawei_asr">Huawei Automatic Speech Recognition</string>
@@ -1665,13 +1663,5 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_addon_install_cancel">Отмена</string>
     <string name="download_addon_install_confirm_install">Установить</string>
     <string name="download_addon_install_blocked">Установка локального дополнения заблокирована</string>
-    <string name="download_copy_to_content_uri_confirm_title">Копировать файл\?</string>
-    <string name="download_copy_to_content_uri_confirm_body">Будет создана копия этого файла в системной папке «Загрузки», где она будет доступна для других приложений.
-\n
-\nЖелаете продолжить\?</string>
-    <string name="download_copy_to_content_uri_success_title">Успешно скопировано</string>
-    <string name="download_copy_to_content_uri_error_title">Ошибка копирования</string>
-    <string name="download_copy_to_content_uri_error_body">При копировании загруженного файла возникла ошибка.</string>
-    <string name="download_copy_to_content_uri_error_body_v1">При копировании %1$s возникла ошибка</string>
     <string name="voice_service_metkai">MeetKai</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -1637,12 +1637,9 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="permissions_dialog_remember_choice">Kom ihåg detta beslut</string>
     <string name="upload_button">Ladda upp</string>
     <string name="web_apps_saved_notification">Webbapp har lagts till!</string>
-    <string name="download_context_copy_to_content_uri">Dela med andra appar</string>
     <string name="hamburger_menu_save_web_app">Spara Webbapp…</string>
-    <string name="download_copy_to_content_uri_error_body_v1">Ett fel uppstod under kopieringen av %1$s</string>
     <string name="download_addon_install_confirm_install">Installera</string>
     <string name="download_addon_install_blocked_body">Tillåt lokal tilläggsinstallation i utvecklaralternativ för att fortsätta.</string>
-    <string name="download_copy_to_content_uri_error_body">Ett fel uppstod när den nedladdade filen skulle kopieras.</string>
     <string name="addons_experimental_section_title">Experimentell</string>
     <string name="web_apps_title">Webbappar</string>
     <string name="web_apps_description">Klicka på knappen Spara webbapp... när du är på en sida för att lägga till den i dina webbappar.</string>
@@ -1656,13 +1653,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_addon_install">Installera tillägg</string>
     <string name="download_addon_install_cancel">Avbryt</string>
     <string name="download_addon_install_blocked">Lokal tilläggsinstallation blockerad</string>
-    <string name="download_copy_to_content_uri_confirm_title">Kopiera fil\?</string>
-    <string name="download_copy_to_content_uri_confirm_body">Detta skapar en kopia av den här filen i systemets nedladdningsmapp, där den kan nås av andra appar.
-\n
-\nVill du fortsätta\?</string>
-    <string name="download_copy_to_content_uri_success_title">Kopierades framgångsrikt</string>
-    <string name="download_copy_to_content_uri_success_body">Filen kopierades framgångsrikt och är tillgänglig i systemets nedladdningar.</string>
-    <string name="download_copy_to_content_uri_error_title">Kopieringsfel</string>
     <string name="security_options_permission_fine_location_warning">Wolvic kan bara få din ungefärliga plats. Detta kan ändras i systeminställningarna.</string>
     <string name="upload_list_empty">Inga filer tillgängliga för uppladdning</string>
     <string name="deprecated_version_dialog_title">Rekommenderad uppdatering</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2011,24 +2011,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="web_apps_saved_notification">网络应用程序已添加！</string>
     <string name="download_addon_install_confirm_install">安装</string>
     <string name="download_addon_install_blocked">封锁安装本地插件</string>
-    <string name="download_copy_to_content_uri_confirm_title">复制文件？</string>
-    <string name="download_copy_to_content_uri_success_title">复制成功</string>
-    <string name="download_copy_to_content_uri_success_body">文件成功复制到系统下载文件夹。</string>
-    <string name="download_copy_to_content_uri_error_title">复制错误</string>
-    <string name="download_copy_to_content_uri_error_body_v1">复制%1$s出错</string>
     <string name="upload_button">上载</string>
     <string name="addons_experimental_section_title">试验的</string>
-    <string name="download_context_copy_to_content_uri">于其他程序共用</string>
     <string name="web_apps_dialog_title_parameter">安装%1$s</string>
     <string name="web_apps_dialog_body">您想安装以下网络应用程序吗？这些程序将在资源库中找到。</string>
     <string name="hamburger_menu_save_web_app">保存网络应用程序…</string>
     <string name="download_addon_install">安装插件</string>
     <string name="download_addon_install_cancel">取消</string>
     <string name="download_addon_install_blocked_body">要继续安装请在开发者选项中选择允许本地插件安装。</string>
-    <string name="download_copy_to_content_uri_confirm_body">这样会将此份文件复制到系统下载文件夹中以备其他程序调用。
-\n
-\n您要继续吗？</string>
-    <string name="download_copy_to_content_uri_error_body">复制下载文件出错。</string>
     <string name="settings_language_portuguese">西班牙语</string>
     <string name="security_options_permission_fine_location_warning">Wolvic 只可以获取您的大致位置。 您可在系统设置菜单更改设置。</string>
     <string name="upload_list_empty">无可上载文档</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1378,11 +1378,6 @@
          and also from disk. -->
     <string name="download_context_delete">Delete</string>
 
-    <!-- This string is displayed is the downloads context menu that is displayed when
-         the more button is pressed in a downloads item. It creates a copy of the selected item
-         in the public Downloads folder so it may be used by other apps. -->
-    <string name="download_context_copy_to_content_uri">Share with other apps</string>
-
     <!-- This string is displayed as the title of the System Notifications List, which contains
          the notifications received by the system (similar to Android's Notification Center). -->
     <string name="notifications_title">Notifications</string>
@@ -2235,28 +2230,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the error dialog shown when downloaded addon installation is blocked. -->
     <string name="download_addon_install_blocked_body">Allow local addon installation in Developer Options to proceed.</string>
-
-    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
-    <string name="download_copy_to_content_uri_confirm_title">Copy file?</string>
-
-    <!-- This string is displayed in the confirmation dialog when a downloaded file is deleted from the downloads list. -->
-    <string name="download_copy_to_content_uri_confirm_body">This will create a copy of this file on the system\'s Downloads folder, where it can be accessed by other apps.\n\nDo you want to continue?</string>
-
-    <!-- This string is displayed in the title of the download error dialog. -->
-    <string name="download_copy_to_content_uri_success_title">Successfully copied</string>
-
-    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
-    <string name="download_copy_to_content_uri_success_body">The file was copied successfully and is available in the system\'s Downloads.</string>
-
-    <!-- This string is displayed in the title of the copy downloaded file error dialog. -->
-    <string name="download_copy_to_content_uri_error_title">Copy error</string>
-
-    <!-- This string is displayed in the body of the copy downloaded file error dialog. -->
-    <string name="download_copy_to_content_uri_error_body">An error occurred while copying the downloaded file.</string>
-
-    <!-- This string is displayed in the body of the copy downloaded file error dialog.
-         '%1$s' will be replaced at runtime with the name of the downloaded file. -->
-    <string name="download_copy_to_content_uri_error_body_v1">An error occurred while copying %1$s</string>
 
     <!-- This string is shown in the body of the error dialog displayed when the user is trying to download an environment in the external storage
     but hasn't granted the permission. -->


### PR DESCRIPTION
- Change the download folder into the public as it looks totally fine to do so in Meta Quest 2.
- Get rid of all the nasty code we have to copy files from Wolvic's storage data to system's as there's no need for that any more.
- Fix blob download notification, so that it can be shown as well.
- Fix the download filename when it contains '-' and we download again. e.g.: If the filename is my-download.png, when download again the filename will be m-1.png. This PR fixes it so that it can be my-download-1.png
- Fix #777, replace that custom implementation with the system's default (Formatter.formatFileSize()), so file sizes are displayed consistently everywhere in the application.

