### PR TITLE
[HVR] Make PlatformActivity inherit form Activity again

### DIFF
--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -5,7 +5,7 @@
 
 package com.igalia.wolvic;
 
-import androidx.activity.ComponentActivity;
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -45,7 +45,7 @@ import org.json.JSONObject;
 
 import java.util.Calendar;
 
-public abstract class PlatformActivity extends ComponentActivity implements SurfaceHolder.Callback, WidgetManagerDelegate {
+public abstract class PlatformActivity extends Activity implements SurfaceHolder.Callback, WidgetManagerDelegate {
     public static final String TAG = "PlatformActivity";
     private HVRLocationManager mLocationManager;
     private SharedPreferences mPrefs;


### PR DESCRIPTION
The recent dependency upgrade broke the HVR backend because the HVR PlatformActivity
does not properly implement the more modern lifetime APIs. Switch it back to Activity to
get it working till we don't migrate it.