### PR TITLE
[Chromium] Fix aim pose for WebXR

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -669,7 +669,13 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     // Pose transforms.
     bool isPoseActive { false };
     XrSpaceLocation poseLocation { XR_TYPE_SPACE_LOCATION };
-    if (XR_FAILED(GetPoseState(mPointerAction,  mPointerSpace, localSpace, frameState, isPoseActive, poseLocation))) {
+#ifdef CHROMIUM
+    // Chromium's WebXR code expects aim space to be based on the grip space.
+    XrSpace baseSpace = renderMode == device::RenderMode::StandAlone ? localSpace : mGripSpace;
+#else
+    XrSpace baseSpace = localSpace;
+#endif
+    if (XR_FAILED(GetPoseState(mPointerAction,  mPointerSpace, baseSpace, frameState, isPoseActive, poseLocation))) {
         delegate.SetEnabled(mIndex, false);
         return;
     }


### PR DESCRIPTION
Blink's WebXR code expects aim space to be based on grip space. The current
code for Gecko computes it from the base space though. Change it so that for
Chromium backend we use the grip space as the base space for computing
the aim pose.