### PR TITLE
Replace kAverageHeight with XR_REFERENCE_SPACE_TYPE_STAGE

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -10,6 +10,7 @@
 #include "vrb/MacroUtils.h"
 #include "DeviceDelegate.h"
 #include "JNIUtil.h"
+#include "OpenXRHelpers.h"
 #include <memory>
 
 class android_app;

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -12,11 +12,7 @@
 
 namespace crow {
 
-#if defined(HVR)
-  const vrb::Vector kAverageHeight(0.0f, 1.6f, 0.0f);
-#else
-  const vrb::Vector kAverageHeight(0.0f, 1.7f, 0.0f);
-#endif
+extern vrb::Vector kAverageHeight;
 
 inline std::string Fmt(const char* fmt, ...) {
     va_list vl;


### PR DESCRIPTION
We should not have to use kAverageHeight and those nasty tricks.

This is of course not ready as we have to test it and fix issues when we encounter them.

Reference: https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrReferenceSpaceType.html