### PR TITLE
[Chromium] Invoke navigation methods

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -143,8 +143,7 @@ public class SessionImpl implements WSession {
     @NonNull
     @Override
     public String getDefaultUserAgent(int mode) {
-        // TODO: implement
-        return "";
+        return mSettings.getDefaultUserAgent(mode);
     }
 
     @Override

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SettingsImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SettingsImpl.java
@@ -4,10 +4,11 @@ import androidx.annotation.Nullable;
 
 import org.chromium.wolvic.SessionSettings;
 
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.api.WSessionSettings;
 
 public class SettingsImpl implements WSessionSettings {
-    SessionSettings mSessionSettings = new SessionSettings();
+    private SessionSettings mSessionSettings = new SessionSettings();
 
     // TODO: move these fields to the Chromium backend once they are supported.
     boolean mPrivateMode;
@@ -75,20 +76,8 @@ public class SettingsImpl implements WSessionSettings {
     }
 
     @Override
-    public void setUserAgentMode(int value) {
-        switch (value) {
-            case WSessionSettings.USER_AGENT_MODE_MOBILE:
-                mSessionSettings.setUserAgentMode(SessionSettings.UserAgentMode.MOBILE);
-                break;
-            case WSessionSettings.USER_AGENT_MODE_DESKTOP:
-                mSessionSettings.setUserAgentMode(SessionSettings.UserAgentMode.DESKTOP);
-                break;
-            case WSessionSettings.USER_AGENT_MODE_VR:
-                mSessionSettings.setUserAgentMode(SessionSettings.UserAgentMode.MOBILE_VR);
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid user agent mode: " + value);
-        }
+    public void setUserAgentMode(int mode) {
+        mSessionSettings.setUserAgentMode(toUserAgentMode(mode));
     }
 
     @Override
@@ -135,5 +124,21 @@ public class SettingsImpl implements WSessionSettings {
     @Override
     public String getUserAgentOverride() {
         return mSessionSettings.getUserAgentOverride();
+    }
+
+    public String getDefaultUserAgent(int mode) {
+        return mSessionSettings.getDefaultUserAgent(toUserAgentMode(mode)) + " Wolvic/" + BuildConfig.VERSION_NAME;
+    }
+
+    private SessionSettings.UserAgentMode toUserAgentMode(int mode) {
+        switch (mode) {
+            case WSessionSettings.USER_AGENT_MODE_MOBILE:
+                return SessionSettings.UserAgentMode.MOBILE;
+            case WSessionSettings.USER_AGENT_MODE_VR:
+                return SessionSettings.UserAgentMode.MOBILE_VR;
+            case WSessionSettings.USER_AGENT_MODE_DESKTOP:
+            default:
+                return SessionSettings.UserAgentMode.DESKTOP;
+        }
     }
 }

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -4,12 +4,15 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.browser.api.WSession;
+import com.igalia.wolvic.browser.api.WWebRequestError;
 
 import org.chromium.content_public.browser.LifecycleState;
 import org.chromium.content_public.browser.NavigationHandle;
 import org.chromium.content_public.browser.WebContents;
 import org.chromium.content_public.browser.WebContentsObserver;
 import org.chromium.url.GURL;
+
+import java.security.cert.X509Certificate;
 
 public class TabWebContentsObserver extends WebContentsObserver {
     private @NonNull SessionImpl mSession;
@@ -54,6 +57,26 @@ public class TabWebContentsObserver extends WebContentsObserver {
                 navigationHandle.hasUserGesture(), navigationHandle.isRendererInitiated()));
     }
 
+    /**
+     * Called when the navigation is committed. The commit can be an error page if the server
+     * responded with an error code or a successful document. See also:
+     * https://chromium.googlesource.com/chromium/src/+/main/docs/navigation.md#Navigation
+     * @param navigationHandle
+     */
+    @Override
+    public void didFinishNavigationInPrimaryMainFrame(NavigationHandle navigationHandle) {
+        WSession.NavigationDelegate delegate = mSession.getNavigationDelegate();
+        if (delegate == null)
+            return;
+
+        if (navigationHandle.isErrorPage()) {
+            didFailLoad(true, navigationHandle.errorCode(), navigationHandle.getUrl(), 0);
+            return;
+        }
+
+        delegate.onLocationChange(mSession, navigationHandle.getUrl().getSpec());
+    }
+
     @Override
     public void didStopLoading(GURL url, boolean isKnownValid) {
         @Nullable WSession.ProgressDelegate delegate = mSession.getProgressDelegate();
@@ -70,6 +93,29 @@ public class TabWebContentsObserver extends WebContentsObserver {
             delegate.onPageStop(mSession, false);
         }
         dispatchCanGoBackOrForward();
+
+        WSession.NavigationDelegate navigationDelegate = mSession.getNavigationDelegate();
+        if (navigationDelegate != null) {
+            navigationDelegate.onLoadError(mSession, failingUrl.getSpec(), new WWebRequestError() {
+                @Override
+                public int code() {
+                    return errorCode;
+                }
+
+                @Override
+                public int category() {
+                    // FIXME: can we improve this?.
+                    return ERROR_CATEGORY_UNKNOWN;
+                }
+
+                @Nullable
+                @Override
+                public X509Certificate certificate() {
+                    // FIXME: can we improve this?.
+                    return null;
+                }
+            });
+        }
     }
 
     private void dispatchCanGoBackOrForward() {

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -33,6 +33,27 @@ public class TabWebContentsObserver extends WebContentsObserver {
         dispatchCanGoBackOrForward();
     }
 
+    /**
+     *  Called when the browser process starts a navigation in the primary main frame. Called before
+     * initiating the network request. See also
+     * https://chromium.googlesource.com/chromium/src/+/main/docs/navigation.md#Navigation
+     * @param navigationHandle
+     */
+    @Override
+    public void didStartNavigationInPrimaryMainFrame(NavigationHandle navigationHandle) {
+        super.didStartNavigationInPrimaryMainFrame(navigationHandle);
+
+        WSession.NavigationDelegate delegate = mSession.getNavigationDelegate();
+        if (delegate == null)
+            return;
+
+        // FIXME: how to select different target windows? Does it make sense here?.
+        delegate.onLoadRequest(mSession, new WSession.NavigationDelegate.LoadRequest(
+                navigationHandle.getUrl().getSpec(), navigationHandle.getReferrerUrl().getSpec(),
+                WSession.NavigationDelegate.TARGET_WINDOW_CURRENT, navigationHandle.isRedirect(),
+                navigationHandle.hasUserGesture(), navigationHandle.isRendererInitiated()));
+    }
+
     @Override
     public void didStopLoading(GURL url, boolean isKnownValid) {
         @Nullable WSession.ProgressDelegate delegate = mSession.getProgressDelegate();


### PR DESCRIPTION
This sequence of commits properly invoke some methods that are required for Wolvic to work correctly. These methods are called from different events related to page load, for example onLoadRequest() or onLocationChange() which are critical, among other things to set the proper user agent.

After this change along with some new API on the chromium side, we are able to properly set the mobile, VR and desktop variants of the user agent. Also this fixes some other bugs, like for example the desktop mode not being properly activated, or the UA overrides not working at all.