### PR TITLE
Remove overlay extension support for Pico

### DIFF
--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -33,6 +33,9 @@ void OpenXRExtensions::Initialize() {
 #ifdef LYNX
     // Lynx incorrectly advertises this extension as supported but in reality it does not work.
     sSupportedExtensions.erase(XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME);
+#elif PICOXR
+    // Pico incorrectly advertises this extension as supported but it makes Wolvic not work.
+    sSupportedExtensions.erase(XR_EXTX_OVERLAY_EXTENSION_NAME);
 #endif
 
     // API layers.


### PR DESCRIPTION
Pico's runtime advertises XR_EXTX_overlay as supported. The reality is that it does
not likely do because it prevents Wolvic from properly starting. Let's disable it for now.