### PR TITLE
Meta store fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -195,6 +195,7 @@ android {
         // Supported platforms
         oculusvr {
             dimension "platform"
+            targetSdkVersion build_versions.target_sdk_oculusvr
             externalNativeBuild {
                 cmake {
                     cppFlags "-DOCULUSVR" + getOpenXRFlags()

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
     <uses-permission android:name="${permissionToRemove}" tools:node="remove" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove"/>
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" tools:node="remove"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove"/>
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -190,6 +190,7 @@ def build_versions = [:]
 build_versions.min_sdk = 24
 build_versions.min_sdk_wave = 25
 build_versions.target_sdk = 33
+build_versions.target_sdk_oculusvr = 32
 build_versions.target_sdk_wave = 31
 build_versions.target_sdk_aosp = 29
 build_versions.target_sdk_spaces = 29


### PR DESCRIPTION
This fixes a couple of issues with meta packages
* Limit target sdk to v32 (the maximum allowed by the store)
* Do not request ACCESS_BACKGROUND_LOCATION (not allowed by the store)