### PR TITLE
Reorganize Libraries and add search UI in panels

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1150,7 +1150,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             // We shouldn't divide the scale factor when we pass the motion event to the web engine
             if (widget instanceof WindowWidget) {
                 WindowWidget windowWidget = (WindowWidget) widget;
-                if (!windowWidget.isLibraryVisible()) {
+                if (windowWidget.isInWebPage()) {
                     scale = 1.0f;
                 }
             }

--- a/app/src/common/shared/com/igalia/wolvic/addons/views/AddonsPanel.java
+++ b/app/src/common/shared/com/igalia/wolvic/addons/views/AddonsPanel.java
@@ -1,0 +1,149 @@
+package com.igalia.wolvic.addons.views;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+
+import com.igalia.wolvic.BuildConfig;
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserActivity;
+import com.igalia.wolvic.VRBrowserApplication;
+import com.igalia.wolvic.databinding.LibraryBinding;
+import com.igalia.wolvic.ui.delegates.LibraryNavigationDelegate;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+
+import java.util.concurrent.Executor;
+
+public class AddonsPanel extends FrameLayout {
+
+    private LibraryBinding mBinding;
+    protected WidgetManagerDelegate mWidgetManager;
+    protected Executor mUIThreadExecutor;
+    private AddonsView mAddonsView;
+
+    public AddonsPanel(@NonNull Context context) {
+        super(context);
+        initialize();
+    }
+
+    public AddonsPanel(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        initialize();
+    }
+
+    public AddonsPanel(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initialize();
+    }
+
+    protected void initialize() {
+        mWidgetManager = ((VRBrowserActivity) getContext());
+        mUIThreadExecutor = ((VRBrowserApplication) getContext().getApplicationContext()).getExecutors().mainThread();
+
+        mAddonsView = new AddonsView(getContext(), this);
+
+        updateUI();
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.library, this, true);
+        mBinding.searchBar.setVisibility(View.GONE);
+        mBinding.buttons.setVisibility(View.GONE);
+        mBinding.setLifecycleOwner((VRBrowserActivity) getContext());
+        mBinding.setSupportsSystemNotifications(BuildConfig.SUPPORTS_SYSTEM_NOTIFICATIONS);
+        mBinding.setDelegate(new LibraryNavigationDelegate() {
+            @Override
+            public void onClose(@NonNull View view) {
+                requestFocus();
+                mWidgetManager.getFocusedWindow().hideAddonsPanel();
+            }
+
+            @Override
+            public void onBack(@NonNull View view) {
+                requestFocus();
+                mAddonsView.onBack();
+                mBinding.setCanGoBack(mAddonsView.canGoBack());
+            }
+
+            @Override
+            public void onButtonClick(@NonNull View view) {
+                requestFocus();
+                selectTab();
+            }
+        });
+        mBinding.executePendingBindings();
+
+        selectTab();
+
+        setOnTouchListener((v, event) -> {
+            v.requestFocusFromTouch();
+            return false;
+        });
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        if (mBinding != null) {
+            mBinding.tabcontent.removeAllViews();
+        }
+
+        mAddonsView.updateUI();
+
+        updateUI();
+    }
+
+    public void onShow() {
+        if (mAddonsView != null) {
+            mAddonsView.onShow();
+            mBinding.searchBar.setQuery("", false);
+            mBinding.searchBar.clearFocus();
+        }
+    }
+
+    public void onHide() {
+        if (mAddonsView != null) {
+            mAddonsView.onHide();
+        }
+    }
+
+    public boolean onBack() {
+        if (mAddonsView != null) {
+            return mAddonsView.onBack();
+        }
+
+        return false;
+    }
+
+    public void onDestroy() {
+        mAddonsView.onDestroy();
+    }
+
+    private void selectTab() {
+        mBinding.setCanGoBack(mAddonsView.canGoBack());
+        mBinding.tabcontent.addView(mAddonsView);
+        mAddonsView.onShow();
+    }
+
+    public void onViewUpdated(@NonNull String title) {
+        if (mBinding != null) {
+            mBinding.title.setText(title);
+            mBinding.setCanGoBack(mAddonsView.canGoBack());
+        }
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/addons/views/AddonsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/addons/views/AddonsView.java
@@ -12,7 +12,6 @@ import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.addons.adapters.AddonsViewAdapter;
 import com.igalia.wolvic.addons.delegates.AddonsDelegate;
 import com.igalia.wolvic.databinding.AddonsBinding;
-import com.igalia.wolvic.ui.views.library.LibraryPanel;
 import com.igalia.wolvic.ui.views.library.LibraryView;
 import com.igalia.wolvic.utils.SystemUtils;
 
@@ -25,6 +24,7 @@ public class AddonsView extends LibraryView implements AddonsDelegate {
 
     private AddonsBinding mBinding;
     private AddonsViewAdapter mAdapter;
+    private AddonsPanel mAddonsPanel;
 
     public AddonsView(@NonNull Context context) {
         super(context);
@@ -32,9 +32,9 @@ public class AddonsView extends LibraryView implements AddonsDelegate {
         initialize();
     }
 
-    public AddonsView(@NonNull Context context, @NonNull LibraryPanel rootPanel) {
-        super(context, rootPanel);
-
+    public AddonsView(@NonNull Context context, @NonNull AddonsPanel panel) {
+        super(context);
+        mAddonsPanel = panel;
         initialize();
     }
 
@@ -79,12 +79,12 @@ public class AddonsView extends LibraryView implements AddonsDelegate {
         updateLayout();
 
         if (mBinding.pager.getCurrentItem() == AddonsViewAdapter.ADDONS_LEVEL_0) {
-            if (mRootPanel != null) {
-                mRootPanel.onViewUpdated(getContext().getString(R.string.addons_title));
+            if (mAddonsPanel != null) {
+                mAddonsPanel.onViewUpdated(getContext().getString(R.string.addons_title));
             }
         } else {
-            if (mRootPanel != null) {
-                mRootPanel.onViewUpdated(ExtensionsKt.translateName(mAdapter.getCurrentAddon(), getContext()));
+            if (mAddonsPanel != null) {
+                mAddonsPanel.onViewUpdated(ExtensionsKt.translateName(mAdapter.getCurrentAddon(), getContext()));
             }
         }
     }
@@ -144,8 +144,8 @@ public class AddonsView extends LibraryView implements AddonsDelegate {
         mAdapter.setCurrentAddon(null);
         mAdapter.setCurrentItem(AddonsViewAdapter.ADDONS_LIST);
         mBinding.pager.setCurrentItem(AddonsViewAdapter.ADDONS_LEVEL_0);
-        if (mRootPanel != null) {
-            mRootPanel.onViewUpdated(getContext().getString(R.string.addons_title));
+        if (mAddonsPanel != null) {
+            mAddonsPanel.onViewUpdated(getContext().getString(R.string.addons_title));
         }
     }
 
@@ -154,8 +154,8 @@ public class AddonsView extends LibraryView implements AddonsDelegate {
         mAdapter.setCurrentAddon(addon);
         mAdapter.setCurrentItem(AddonsViewAdapter.ADDON_OPTIONS);
         mBinding.pager.setCurrentItem(AddonsViewAdapter.ADDONS_LEVEL_1);
-        if (mRootPanel != null) {
-            mRootPanel.onViewUpdated(ExtensionsKt.translateName(addon, getContext()));
+        if (mAddonsPanel != null) {
+            mAddonsPanel.onViewUpdated(ExtensionsKt.translateName(addon, getContext()));
         }
     }
 
@@ -164,8 +164,8 @@ public class AddonsView extends LibraryView implements AddonsDelegate {
         mAdapter.setCurrentAddon(addon);
         mAdapter.setCurrentItem(AddonsViewAdapter.ADDON_OPTIONS_DETAILS);
         mBinding.pager.setCurrentItem(page);
-        if (mRootPanel != null) {
-            mRootPanel.onViewUpdated(ExtensionsKt.translateName(addon, getContext()));
+        if (mAddonsPanel != null) {
+            mAddonsPanel.onViewUpdated(ExtensionsKt.translateName(addon, getContext()));
         }
     }
 
@@ -174,8 +174,8 @@ public class AddonsView extends LibraryView implements AddonsDelegate {
         mAdapter.setCurrentAddon(addon);
         mAdapter.setCurrentItem(AddonsViewAdapter.ADDON_OPTIONS_PERMISSIONS);
         mBinding.pager.setCurrentItem(AddonsViewAdapter.ADDONS_LEVEL_2);
-        if (mRootPanel != null) {
-            mRootPanel.onViewUpdated(ExtensionsKt.translateName(addon, getContext()));
+        if (mAddonsPanel != null) {
+            mAddonsPanel.onViewUpdated(ExtensionsKt.translateName(addon, getContext()));
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/WebAppsStore.java
@@ -70,6 +70,17 @@ public class WebAppsStore implements SharedPreferences.OnSharedPreferenceChangeL
         SettingsStore.getInstance(mContext).setWebAppsData(json);
     }
 
+    public void updateWebAppOpenTime(@NonNull String id) {
+        WebApp existingWebApp = mWebApps.get(id);
+        if (existingWebApp == null) {
+            return;
+        }
+
+        existingWebApp.setLastOpenTime();
+        saveWebAppsListToStorage();
+        notifyListeners();
+    }
+
     /**
      * @return {@code true} if the map did not contain the specified Web app (so it was added),
      * and {@code false} if the Web app was already in the list (so it was updated).

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/WebApp.java
@@ -25,6 +25,7 @@ import mozilla.components.concept.engine.manifest.WebAppManifestParser;
  */
 public class WebApp {
     @NonNull private String mIdentity;
+    @NonNull private long mLastOpenTime;
     private WebAppManifest mManifest;
     private OptionalInt mHashCode = OptionalInt.empty();
 
@@ -54,6 +55,7 @@ public class WebApp {
             String id = manifest.optString("id");
             URL identityUrl = new URL(startUrl.getProtocol(), startUrl.getHost(), startUrl.getPort(), id);
             mIdentity = identityUrl.toString();
+            mLastOpenTime = 0;
         } else {
             // Since Identity is used to uniquely identify the Web application,
             // we treat its absence as an error.
@@ -64,6 +66,16 @@ public class WebApp {
     @NonNull
     public String getId() {
         return mIdentity;
+    }
+
+    @NonNull
+    public long getLastOpenTime() {
+        return mLastOpenTime;
+    }
+
+    @NonNull
+    public void setLastOpenTime() {
+        mLastOpenTime = System.currentTimeMillis();
     }
 
     public String getName() {
@@ -105,6 +117,7 @@ public class WebApp {
 
     public void copyFrom(WebApp webApp) {
         mIdentity = webApp.mIdentity;
+        mLastOpenTime = webApp.mLastOpenTime;
         mManifest = webApp.mManifest;
         mHashCode = OptionalInt.empty();
     }
@@ -133,6 +146,7 @@ public class WebApp {
     public String toString() {
         return "WebApp{" +
                 "mIdentity='" + mIdentity + '\'' +
+                ", mLastOpenTime='" + mLastOpenTime + '\'' +
                 ", mName='" + getName() + '\'' +
                 ", mShortName='" + getShortName() + '\'' +
                 ", mScope='" + getScope() + '\'' +

--- a/app/src/common/shared/com/igalia/wolvic/ui/callbacks/DownloadsContextMenuCallback.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/callbacks/DownloadsContextMenuCallback.java
@@ -1,6 +1,6 @@
 package com.igalia.wolvic.ui.callbacks;
 
-import com.igalia.wolvic.ui.widgets.menus.library.DownloadsContextMenuWidget;
+import com.igalia.wolvic.ui.widgets.menus.DownloadsContextMenuWidget;
 
 public interface DownloadsContextMenuCallback extends LibraryContextMenuCallback {
     void onDelete(DownloadsContextMenuWidget.DownloadsContextMenuItem item);

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
@@ -49,6 +49,9 @@ public class WindowViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isActiveWindow;
     private MediatorLiveData<ObservableBoolean> isTitleBarVisible;
     private MutableLiveData<ObservableBoolean> isLibraryVisible;
+    private MutableLiveData<ObservableBoolean> isDownloadsVisible;
+    private MutableLiveData<ObservableBoolean> isWebAppsVisible;
+    private MutableLiveData<ObservableBoolean> isAddonsVisible;
     private MutableLiveData<ObservableBoolean> isLoading;
     private MutableLiveData<ObservableBoolean> isMicrophoneEnabled;
     private MutableLiveData<ObservableBoolean> isBookmarked;
@@ -129,6 +132,9 @@ public class WindowViewModel extends AndroidViewModel {
         isTitleBarVisible.setValue(new ObservableBoolean(true));
 
         isLibraryVisible = new MutableLiveData<>(new ObservableBoolean(false));
+        isDownloadsVisible = new MutableLiveData<>(new ObservableBoolean(false));
+        isWebAppsVisible = new MutableLiveData<>(new ObservableBoolean(false));
+        isAddonsVisible = new MutableLiveData<>(new ObservableBoolean(false));
 
         isLoading = new MutableLiveData<>(new ObservableBoolean(false));
         isMicrophoneEnabled = new MutableLiveData<>(new ObservableBoolean(true));
@@ -152,6 +158,9 @@ public class WindowViewModel extends AndroidViewModel {
         isInsecureVisible.addSource(isInsecure, mIsInsecureVisibleObserver);
         isInsecureVisible.addSource(isPrivateSession, mIsInsecureVisibleObserver);
         isInsecureVisible.addSource(isLibraryVisible, mIsInsecureVisibleObserver);
+        isInsecureVisible.addSource(isDownloadsVisible, mIsInsecureVisibleObserver);
+        isInsecureVisible.addSource(isWebAppsVisible, mIsInsecureVisibleObserver);
+        isInsecureVisible.addSource(isAddonsVisible, mIsInsecureVisibleObserver);
         isInsecureVisible.setValue(new ObservableBoolean(false));
 
         isMediaAvailable = new MutableLiveData<>(new ObservableBoolean(false));
@@ -173,6 +182,9 @@ public class WindowViewModel extends AndroidViewModel {
         isUrlBarButtonsVisible.addSource(isPopUpAvailable, mIsUrlBarButtonsVisibleObserver);
         isUrlBarButtonsVisible.addSource(isWebXRUsed, mIsUrlBarButtonsVisibleObserver);
         isUrlBarButtonsVisible.addSource(isLibraryVisible, mIsUrlBarButtonsVisibleObserver);
+        isUrlBarButtonsVisible.addSource(isDownloadsVisible, mIsUrlBarButtonsVisibleObserver);
+        isUrlBarButtonsVisible.addSource(isWebAppsVisible, mIsUrlBarButtonsVisibleObserver);
+        isUrlBarButtonsVisible.addSource(isAddonsVisible, mIsUrlBarButtonsVisibleObserver);
         isUrlBarButtonsVisible.addSource(isFocused, mIsUrlBarButtonsVisibleObserver);
         isUrlBarButtonsVisible.setValue(new ObservableBoolean(false));
 
@@ -231,6 +243,15 @@ public class WindowViewModel extends AndroidViewModel {
             if (isLibraryVisible.getValue().get()) {
                 url = getApplication().getString(R.string.url_library_title);
 
+            } else if (isDownloadsVisible.getValue().get()) {
+                url = getApplication().getString(R.string.url_downloads_title);
+
+            } else if (isWebAppsVisible.getValue().get()) {
+                url = getApplication().getString(R.string.url_downloads_title);
+
+            } else if (isAddonsVisible.getValue().get()) {
+                url = getApplication().getString(R.string.url_addons_title);
+
             } else {
                 if (UrlUtils.isPrivateAboutPage(getApplication(), url) ||
                         (UrlUtils.isDataUri(url) && isPrivateSession.getValue().get())) {
@@ -261,6 +282,9 @@ public class WindowViewModel extends AndroidViewModel {
                         UrlUtils.isFileUri(aUrl) ||
                         UrlUtils.isHomeUri(getApplication(), aUrl) ||
                         isLibraryVisible.getValue().get() ||
+                        isDownloadsVisible.getValue().get() ||
+                        isWebAppsVisible.getValue().get() ||
+                        isAddonsVisible.getValue().get() ||
                         UrlUtils.isBlankUri(getApplication(), aUrl)) {
                     isInsecureVisible.postValue(new ObservableBoolean(false));
 
@@ -282,6 +306,9 @@ public class WindowViewModel extends AndroidViewModel {
                     (UrlUtils.isDataUri(url) && isPrivateSession.getValue().get()) ||
                     UrlUtils.isHomeUri(getApplication(), aUrl.toString()) ||
                     isLibraryVisible.getValue().get() ||
+                    isDownloadsVisible.getValue().get() ||
+                    isWebAppsVisible.getValue().get() ||
+                    isAddonsVisible.getValue().get() ||
                     UrlUtils.isBlankUri(getApplication(), aUrl.toString())) {
                 navigationBarUrl.postValue("");
 
@@ -298,6 +325,9 @@ public class WindowViewModel extends AndroidViewModel {
             isUrlBarButtonsVisible.postValue(new ObservableBoolean(
                     !isFocused.getValue().get() &&
                             !isLibraryVisible.getValue().get() &&
+                            !isDownloadsVisible.getValue().get() &&
+                            !isWebAppsVisible.getValue().get() &&
+                            !isAddonsVisible.getValue().get() &&
                             !UrlUtils.isContentFeed(getApplication(), aUrl) &&
                             !UrlUtils.isPrivateAboutPage(getApplication(), aUrl) &&
                             (URLUtil.isHttpUrl(aUrl) || URLUtil.isHttpsUrl(aUrl)) &&
@@ -317,6 +347,9 @@ public class WindowViewModel extends AndroidViewModel {
         public void onChanged(ObservableBoolean o) {
             isUrlBarIconsVisible.postValue(new ObservableBoolean(
                     !isLibraryVisible.getValue().get() &&
+                            !isDownloadsVisible.getValue().get() &&
+                            !isWebAppsVisible.getValue().get() &&
+                            !isAddonsVisible.getValue().get() &&
                             (isLoading.getValue().get() ||
                                     isInsecureVisible.getValue().get())
             ));
@@ -429,6 +462,15 @@ public class WindowViewModel extends AndroidViewModel {
     private String getHintValue() {
         if (isLibraryVisible.getValue().get()) {
             return getApplication().getString(R.string.url_library_title);
+
+        } else if (isDownloadsVisible.getValue().get()) {
+            return getApplication().getString(R.string.url_downloads_title);
+
+        } else if (isWebAppsVisible.getValue().get()) {
+            return getApplication().getString(R.string.url_webapps_title);
+
+        } else if (isAddonsVisible.getValue().get()) {
+            return getApplication().getString(R.string.url_addons_title);
 
         } else {
             return getApplication().getString(R.string.search_placeholder);
@@ -568,6 +610,21 @@ public class WindowViewModel extends AndroidViewModel {
         this.url.postValue(this.getUrl().getValue());
     }
 
+    public void setIsDownloadsVisible(boolean isDownloadsVisible) {
+        this.isDownloadsVisible.postValue(new ObservableBoolean(isDownloadsVisible));
+        this.url.postValue(this.getUrl().getValue());
+    }
+
+    public void setIsWebAppsVisible(boolean isWebAppsVisible) {
+        this.isWebAppsVisible.postValue(new ObservableBoolean(isWebAppsVisible));
+        this.url.postValue(this.getUrl().getValue());
+    }
+
+    public void setIsAddonsVisible(boolean isAddonsVisible) {
+        this.isAddonsVisible.postValue(new ObservableBoolean(isAddonsVisible));
+        this.url.postValue(this.getUrl().getValue());
+    }
+
     public void setIsPanelVisible(boolean isVisible) {
         setIsLibraryVisible(isVisible);
     }
@@ -575,6 +632,21 @@ public class WindowViewModel extends AndroidViewModel {
     @NonNull
     public MutableLiveData<ObservableBoolean> getIsLibraryVisible() {
         return isLibraryVisible;
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsDownloadsVisible() {
+        return isDownloadsVisible;
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsWebAppsVisible() {
+        return isWebAppsVisible;
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsAddonsVisible() {
+        return isAddonsVisible;
     }
 
     @NonNull
@@ -637,7 +709,7 @@ public class WindowViewModel extends AndroidViewModel {
     }
 
     public void setIsFindInPage(boolean isFindInPage) {
-        this.isFindInPage.postValue(new ObservableBoolean(isFindInPage));
+        this.isFindInPage.setValue(new ObservableBoolean(isFindInPage));
     }
 
     @NonNull

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/downloads/DownloadsPanel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/downloads/DownloadsPanel.java
@@ -1,0 +1,178 @@
+package com.igalia.wolvic.ui.views.downloads;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.SearchView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+
+import com.igalia.wolvic.BuildConfig;
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserActivity;
+import com.igalia.wolvic.VRBrowserApplication;
+import com.igalia.wolvic.addons.views.AddonsView;
+import com.igalia.wolvic.databinding.LibraryBinding;
+import com.igalia.wolvic.ui.delegates.LibraryNavigationDelegate;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+import com.igalia.wolvic.ui.widgets.Windows;
+
+import java.util.concurrent.Executor;
+
+public class DownloadsPanel extends FrameLayout {
+
+    private LibraryBinding mBinding;
+    protected WidgetManagerDelegate mWidgetManager;
+    protected Executor mUIThreadExecutor;
+    private DownloadsView mDownloadsView;
+
+    public DownloadsPanel(@NonNull Context context) {
+        super(context);
+        initialize();
+    }
+
+    public DownloadsPanel(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        initialize();
+    }
+
+    public DownloadsPanel(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initialize();
+    }
+
+    protected void initialize() {
+        mWidgetManager = ((VRBrowserActivity) getContext());
+        mUIThreadExecutor = ((VRBrowserApplication) getContext().getApplicationContext()).getExecutors().mainThread();
+
+        mDownloadsView = new DownloadsView(getContext(), this);
+
+        updateUI();
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.library, this, true);
+        mBinding.searchBar.setIconifiedByDefault(false);
+        mBinding.searchBar.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String s) {
+                mDownloadsView.updateSearchFilter(s.toLowerCase());
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String s) {
+                if (s.isEmpty()) {
+                    mDownloadsView.updateSearchFilter(s.toLowerCase());
+                    return true;
+                }
+                return false;
+            }
+        });
+        mBinding.searchBar.setOnCloseListener(() -> {
+            mDownloadsView.updateSearchFilter("");
+            return true;
+        });
+        mBinding.buttons.setVisibility(View.GONE);
+        mBinding.setLifecycleOwner((VRBrowserActivity) getContext());
+        mBinding.setSupportsSystemNotifications(BuildConfig.SUPPORTS_SYSTEM_NOTIFICATIONS);
+        mBinding.setDelegate(new LibraryNavigationDelegate() {
+            @Override
+            public void onClose(@NonNull View view) {
+                requestFocus();
+                mWidgetManager.getFocusedWindow().hideDownloadsPanel();
+            }
+
+            @Override
+            public void onBack(@NonNull View view) {
+                requestFocus();
+                mDownloadsView.onBack();
+                mBinding.setCanGoBack(mDownloadsView.canGoBack());
+            }
+
+            @Override
+            public void onButtonClick(@NonNull View view) {
+                requestFocus();
+                selectTab();
+            }
+        });
+        mBinding.executePendingBindings();
+
+        selectTab();
+
+        setOnTouchListener((v, event) -> {
+            v.requestFocusFromTouch();
+            return false;
+        });
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        if (mBinding != null) {
+            mBinding.tabcontent.removeAllViews();
+        }
+
+        mDownloadsView.updateUI();
+
+        updateUI();
+    }
+
+    public void onShow() {
+        if (mDownloadsView == null) {
+            return;
+        }
+
+        mDownloadsView.onShow();        
+    }
+
+    public void onHide() {
+        if (mDownloadsView == null) {
+            return;
+        }
+
+        mDownloadsView.onHide();
+        mBinding.searchBar.setQuery("", false);
+        mBinding.searchBar.clearFocus();
+    }
+
+    public boolean onBack() {
+        if (mDownloadsView == null) {
+            return false;
+        }
+
+        return mDownloadsView.onBack();
+    }
+
+    public void onDestroy() {
+        mDownloadsView.onDestroy();
+    }
+
+    private void selectTab() {
+        mBinding.setCanGoBack(mDownloadsView.canGoBack());
+        mBinding.tabcontent.addView(mDownloadsView);
+        mDownloadsView.onShow();
+    }
+
+    public void onViewUpdated(@NonNull String title) {
+        if (mBinding == null) {
+            return;
+        }
+
+        mBinding.title.setText(title);
+        mBinding.setCanGoBack(mDownloadsView.canGoBack());
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/downloads/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/downloads/DownloadsView.java
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package com.igalia.wolvic.ui.views.library;
+package com.igalia.wolvic.ui.views.downloads;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -33,11 +33,13 @@ import com.igalia.wolvic.ui.callbacks.DownloadItemCallback;
 import com.igalia.wolvic.ui.callbacks.DownloadsCallback;
 import com.igalia.wolvic.ui.callbacks.DownloadsContextMenuCallback;
 import com.igalia.wolvic.ui.viewmodel.DownloadsViewModel;
+import com.igalia.wolvic.ui.views.library.LibraryPanel;
+import com.igalia.wolvic.ui.views.library.LibraryView;
 import com.igalia.wolvic.ui.widgets.UIWidget;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 import com.igalia.wolvic.ui.widgets.WindowWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.PromptDialogWidget;
-import com.igalia.wolvic.ui.widgets.menus.library.DownloadsContextMenuWidget;
+import com.igalia.wolvic.ui.widgets.menus.DownloadsContextMenuWidget;
 import com.igalia.wolvic.ui.widgets.menus.library.LibraryContextMenuWidget;
 import com.igalia.wolvic.ui.widgets.menus.library.SortingContextMenuWidget;
 import com.igalia.wolvic.utils.SystemUtils;
@@ -58,9 +60,11 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
     private DownloadsManager mDownloadsManager;
     private Comparator<Download> mSortingComparator;
     private DownloadsViewModel mViewModel;
+    private DownloadsPanel mDownloadsPanel;
 
-    public DownloadsView(Context aContext, @NonNull LibraryPanel delegate) {
-        super(aContext, delegate);
+    public DownloadsView(Context aContext, @NonNull DownloadsPanel delegate) {
+        super(aContext);
+        mDownloadsPanel = delegate;
         initialize();
     }
 
@@ -118,6 +122,12 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
     }
 
     @Override
+    public void updateSearchFilter(String s) {
+        super.updateSearchFilter(s);
+        onDownloadsUpdate(mDownloadsManager.getDownloads());
+    };
+
+    @Override
     public void onDestroy() {
         mBinding.downloadsList.removeOnScrollListener(mScrollListener);
     }
@@ -127,8 +137,8 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         mDownloadsManager.addListener(this);
         onDownloadsUpdate(mDownloadsManager.getDownloads());
         updateLayout();
-        if (mRootPanel != null) {
-            mRootPanel.onViewUpdated(getContext().getString(R.string.downloads_title));
+        if (mDownloadsPanel != null) {
+            mDownloadsPanel.onViewUpdated(getContext().getString(R.string.downloads_title));
         }
     }
 
@@ -174,7 +184,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                 SessionStore.get().getActiveSession().loadUri(item.getOutputFileUriAsString());
 
                 WindowWidget window = mWidgetManager.getFocusedWindow();
-                window.hidePanel();
+                window.hideDownloadsPanel();
             }
         }
 
@@ -341,8 +351,8 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         float ratio = WidgetPlacement.viewToWidgetRatio(getContext(), window);
 
         Rect offsetViewBounds = new Rect();
-        mRootPanel.getDrawingRect(offsetViewBounds);
-        mRootPanel.offsetDescendantRectToMyCoords(view, offsetViewBounds);
+        mDownloadsPanel.getDrawingRect(offsetViewBounds);
+        mDownloadsPanel.offsetDescendantRectToMyCoords(view, offsetViewBounds);
 
         SortingContextMenuWidget menu = new SortingContextMenuWidget(getContext());
         menu.setItemDelegate(item -> {
@@ -432,7 +442,14 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         } else {
             mViewModel.setIsEmpty(false);
             mViewModel.setIsLoading(false);
-            List<Download> sorted = downloads.stream().sorted(mSortingComparator).collect(Collectors.toList());
+            List<Download> sorted = downloads.stream()
+                    .filter(value -> {
+                        if (value.getTitle() != null && !mSearchFilter.isEmpty()) {
+                            return value.getTitle().toLowerCase().contains(mSearchFilter);
+                        }
+                        return true;
+                    })
+                    .sorted(mSortingComparator).collect(Collectors.toList());
             mDownloadsAdapter.setDownloadsList(sorted);
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/BookmarksView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/BookmarksView.java
@@ -146,6 +146,13 @@ public class BookmarksView extends LibraryView implements BookmarksStore.Bookmar
     }
 
     @Override
+    public void updateSearchFilter(String s) {
+        super.updateSearchFilter(s);
+        mBookmarkAdapter.setSearchFilter(s);
+        updateBookmarks();
+    };
+
+    @Override
     public void onShow() {
         updateLayout();
         mBinding.bookmarksList.smoothScrollToPosition(0);

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/HistoryView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/HistoryView.java
@@ -151,6 +151,12 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
     }
 
     @Override
+    public void updateSearchFilter(String s) {
+        super.updateSearchFilter(s);
+        updateHistory();
+    };
+
+    @Override
     public void onDestroy() {
         SessionStore.get().getHistoryStore().removeListener(this);
 
@@ -385,6 +391,13 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
                     .sorted(Comparator.comparing(VisitInfo::getVisitTime)
                             .reversed())
                     .filter(distinctByUrl(VisitInfo::getUrl))
+                    .filter(value -> {
+                        if (value.getTitle() != null && !mSearchFilter.isEmpty()) {
+                            return value.getTitle().toLowerCase().contains(mSearchFilter) ||
+                                    value.getUrl().toLowerCase().contains(mSearchFilter);
+                        }
+                        return true;
+                    })
                     .collect(Collectors.toList());
 
             addSection(orderedItems, getResources().getString(R.string.history_section_today), Long.MAX_VALUE, todayLimit);

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryView.java
@@ -23,6 +23,7 @@ import com.igalia.wolvic.utils.ViewUtils;
 import java.util.concurrent.Executor;
 
 public abstract class LibraryView extends FrameLayout {
+    protected String mSearchFilter = "";
 
     protected WidgetManagerDelegate mWidgetManager;
     protected LibraryContextMenuWidget mContextMenu;
@@ -45,6 +46,10 @@ public abstract class LibraryView extends FrameLayout {
     }
 
     public void updateUI() {};
+
+    public void updateSearchFilter(String s) {
+        mSearchFilter = s;
+    };
 
     public void onDestroy() {};
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/webapps/WebAppsPanel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/webapps/WebAppsPanel.java
@@ -1,0 +1,176 @@
+package com.igalia.wolvic.ui.views.webapps;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.SearchView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+
+import com.igalia.wolvic.BuildConfig;
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserActivity;
+import com.igalia.wolvic.VRBrowserApplication;
+import com.igalia.wolvic.databinding.LibraryBinding;
+import com.igalia.wolvic.ui.delegates.LibraryNavigationDelegate;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+
+import java.util.concurrent.Executor;
+
+public class WebAppsPanel extends FrameLayout {
+
+    private LibraryBinding mBinding;
+    protected WidgetManagerDelegate mWidgetManager;
+    protected Executor mUIThreadExecutor;
+    private WebAppsView mWebAppsView;
+
+    public WebAppsPanel(@NonNull Context context) {
+        super(context);
+        initialize();
+    }
+
+    public WebAppsPanel(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        initialize();
+    }
+
+    public WebAppsPanel(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initialize();
+    }
+
+    protected void initialize() {
+        mWidgetManager = ((VRBrowserActivity) getContext());
+        mUIThreadExecutor = ((VRBrowserApplication) getContext().getApplicationContext()).getExecutors().mainThread();
+
+        mWebAppsView = new WebAppsView(getContext(), this);
+
+        updateUI();
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.library, this, true);
+        mBinding.searchBar.setIconifiedByDefault(false);
+        mBinding.searchBar.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String s) {
+                mWebAppsView.updateSearchFilter(s.toLowerCase());
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String s) {
+                if (s.isEmpty()) {
+                    mWebAppsView.updateSearchFilter(s.toLowerCase());
+                    return true;
+                }
+                return false;
+            }
+        });
+        mBinding.searchBar.setOnCloseListener(() -> {
+            mWebAppsView.updateSearchFilter("");
+            return true;
+        });
+        mBinding.buttons.setVisibility(View.GONE);
+        mBinding.setLifecycleOwner((VRBrowserActivity) getContext());
+        mBinding.setSupportsSystemNotifications(BuildConfig.SUPPORTS_SYSTEM_NOTIFICATIONS);
+        mBinding.setDelegate(new LibraryNavigationDelegate() {
+            @Override
+            public void onClose(@NonNull View view) {
+                requestFocus();
+                mWidgetManager.getFocusedWindow().hideWebAppsPanel();
+            }
+
+            @Override
+            public void onBack(@NonNull View view) {
+                requestFocus();
+                mWebAppsView.onBack();
+                mBinding.setCanGoBack(mWebAppsView.canGoBack());
+            }
+
+            @Override
+            public void onButtonClick(@NonNull View view) {
+                requestFocus();
+                selectTab();
+            }
+        });
+        mBinding.executePendingBindings();
+
+        selectTab();
+
+        setOnTouchListener((v, event) -> {
+            v.requestFocusFromTouch();
+            return false;
+        });
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        if (mBinding != null) {
+            mBinding.tabcontent.removeAllViews();
+        }
+
+        mWebAppsView.updateUI();
+
+        updateUI();
+    }
+
+    public void onShow() {
+        if (mWebAppsView == null) {
+            return;
+        }
+
+        mWebAppsView.onShow();
+        mBinding.searchBar.setQuery("", false);
+        mBinding.searchBar.clearFocus();
+    }
+
+    public void onHide() {
+        if (mWebAppsView == null) {
+            return;
+        }
+
+        mWebAppsView.onHide();
+    }
+
+    public boolean onBack() {
+        if (mWebAppsView == null) {
+            return false;
+        }
+
+        return mWebAppsView.onBack();
+    }
+
+    public void onDestroy() {
+        mWebAppsView.onDestroy();
+    }
+
+    private void selectTab() {
+        mBinding.setCanGoBack(mWebAppsView.canGoBack());
+        mBinding.tabcontent.addView(mWebAppsView);
+        mWebAppsView.onShow();
+    }
+
+    public void onViewUpdated(@NonNull String title) {
+        if (mBinding == null) {
+            return;
+        }
+
+        mBinding.title.setText(title);
+        mBinding.setCanGoBack(mWebAppsView.canGoBack());
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1301,6 +1301,16 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         }
     }
 
+    @Override
+    public void onDownloadsClicked() {
+        onLibraryClicked();
+    }
+
+    @Override
+    public void onWebAppsClicked() {
+        onLibraryClicked();
+    }
+
     private void finishWidgetResize() {
         mWidgetManager.finishWidgetResize(mAttachedWindow);
     }
@@ -1335,7 +1345,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             @Override
             public void onFindInPage() {
                 hideMenu();
-                mAttachedWindow.hidePanel();
+                mAttachedWindow.hideAllPanel();
 
                 mViewModel.setIsFindInPage(true);
             }
@@ -1379,11 +1389,11 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             public void onAddons() {
                 hideMenu();
 
-                if (!mAttachedWindow.isLibraryVisible()) {
-                    mAttachedWindow.switchPanel(Windows.ADDONS);
+                if (!mAttachedWindow.isAddonsVisible()) {
+                    mAttachedWindow.switchAddonsPanel();
 
                 } else if (mAttachedWindow.getSelectedPanel() != Windows.ADDONS) {
-                    mAttachedWindow.showPanel(Windows.ADDONS);
+                    mAttachedWindow.showAddonsPanel();
                 }
             }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayListener.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayListener.java
@@ -5,4 +5,6 @@ public interface TrayListener {
     default void onAddWindowClicked() {}
     default void onTabsClicked() {}
     default void onLibraryClicked() {}
+    default void onDownloadsClicked() {}
+    default void onWebAppsClicked() {}
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -376,6 +376,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         WindowWidget rightWindow = getRightWindow();
 
         aWindow.hidePanel();
+        aWindow.hideDownloadsPanel();
+        aWindow.hideWebAppsPanel();
 
         if (leftWindow == aWindow) {
             removeWindow(leftWindow);
@@ -601,10 +603,35 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         }
     }
 
+    private void closeAllPanelsInFocusedWindowIfNeeded() {
+        closeLibraryPanelInFocusedWindowIfNeeded();
+        closeDownloadsPanelInFocusedWindowIfNeeded();
+        closeWebAppsPanelInFocusedWindowIfNeeded();
+        closeAddonsPanelInFocusedWindowIfNeeded();
+    }
+
     private void closeLibraryPanelInFocusedWindowIfNeeded() {
         if (!mFocusedWindow.isLibraryVisible())
             return;
         mFocusedWindow.switchPanel(NONE);
+    }
+
+    private void closeDownloadsPanelInFocusedWindowIfNeeded() {
+        if (!mFocusedWindow.isDownloadsVisible())
+            return;
+        mFocusedWindow.switchDownloadsPanel();
+    }
+
+    private void closeWebAppsPanelInFocusedWindowIfNeeded() {
+        if (!mFocusedWindow.isWebAppsVisible())
+            return;
+        mFocusedWindow.switchWebAppsPanel();
+    }
+
+    private void closeAddonsPanelInFocusedWindowIfNeeded() {
+        if (!mFocusedWindow.isAddonsVisible())
+            return;
+        mFocusedWindow.switchAddonsPanel();
     }
 
     public void enterPrivateMode() {
@@ -617,7 +644,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             mRegularWindowPlacement = mFocusedWindow.getWindowPlacement();
             // Make sure we close the library before entering private mode. Otherwise we would
             // get a EGL crash in Gecko.
-            closeLibraryPanelInFocusedWindowIfNeeded();
+            closeAllPanelsInFocusedWindowIfNeeded();
         } else {
             mRegularWindowPlacement = WindowPlacement.FRONT;
         }
@@ -662,7 +689,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             mPrivateWindowPlacement = mFocusedWindow.getWindowPlacement();
             // Make sure we close the library before exiting private mode. Otherwise we would
             // get a EGL crash in Gecko.
-            closeLibraryPanelInFocusedWindowIfNeeded();
+            closeAllPanelsInFocusedWindowIfNeeded();
         } else {
             mPrivateWindowPlacement = WindowPlacement.FRONT;
         }
@@ -1168,12 +1195,17 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
     @Override
     public void onLibraryClicked() {
-        if (mDownloadsManager.isDownloading()) {
-            mFocusedWindow.switchPanel(Windows.DOWNLOADS);
+        mFocusedWindow.switchPanel(Windows.NONE);
+    }
 
-        } else {
-            mFocusedWindow.switchPanel(Windows.NONE);
-        }
+    @Override
+    public void onDownloadsClicked() {
+        mFocusedWindow.switchDownloadsPanel();
+    }
+
+    @Override
+    public void onWebAppsClicked() {
+        mFocusedWindow.switchWebAppsPanel();
     }
 
     @Override
@@ -1694,7 +1726,7 @@ public void selectTab(@NonNull Session aTab) {
     }
 
     public boolean isSessionFocused(@NonNull Session session) {
-        return mRegularWindows.stream().anyMatch(window -> window.getSession() == session && !window.isLibraryVisible() && session.isPrivateMode() == mPrivateMode) ||
-                mPrivateWindows.stream().anyMatch(window -> window.getSession() == session && !window.isLibraryVisible() && session.isPrivateMode() == mPrivateMode );
+        return mRegularWindows.stream().anyMatch(window -> window.getSession() == session && !window.isLibraryVisible() && !window.isDownloadsVisible() && !window.isWebAppsVisible() && session.isPrivateMode() == mPrivateMode) ||
+                mPrivateWindows.stream().anyMatch(window -> window.getSession() == session && !window.isLibraryVisible() && !window.isDownloadsVisible() && !window.isWebAppsVisible() && session.isPrivateMode() == mPrivateMode );
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/DownloadsContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/DownloadsContextMenuWidget.java
@@ -1,4 +1,4 @@
-package com.igalia.wolvic.ui.widgets.menus.library;
+package com.igalia.wolvic.ui.widgets.menus;
 
 import android.content.Context;
 
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.ui.callbacks.DownloadsContextMenuCallback;
+import com.igalia.wolvic.ui.widgets.menus.library.LibraryContextMenuWidget;
 
 import java.util.EnumSet;
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
@@ -199,7 +199,7 @@ public class HamburgerMenuWidget extends UIWidget implements
 
             final Session activeSession = SessionStore.get().getActiveSession();
             String url = activeSession.getCurrentUri();
-            boolean showAddons = (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) && !mWidgetManager.getFocusedWindow().isLibraryVisible();
+            boolean showAddons = (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) && !mWidgetManager.getFocusedWindow().isAddonsVisible();
             final SessionState tab = ComponentsAdapter.get().getSessionStateForSession(activeSession);
             if (tab != null && showAddons) {
                 final List<WebExtensionState> extensions = ComponentsAdapter.get().getSortedEnabledExtensions();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/LibraryContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/library/LibraryContextMenuWidget.java
@@ -40,10 +40,10 @@ public abstract class LibraryContextMenuWidget extends MenuWidget {
 
     }
 
-    ArrayList<MenuItem> mItems;
+    protected ArrayList<MenuItem> mItems;
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    Optional<LibraryContextMenuCallback> mItemDelegate;
-    LibraryContextMenuItem mItem;
+    protected Optional<LibraryContextMenuCallback> mItemDelegate;
+    protected LibraryContextMenuItem mItem;
 
     protected LibraryContextMenuWidget(Context aContext, LibraryContextMenuItem item, EnumSet<Action> additionalActions) {
         super(aContext, R.layout.library_menu);

--- a/app/src/main/res/drawable/ic_icon_webapps_clip.xml
+++ b/app/src/main/res/drawable/ic_icon_webapps_clip.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clip xmlns:android="http://schemas.android.com/apk/res/android"
+      android:drawable="@drawable/ic_icon_webapps"
+      android:clipOrientation="horizontal"
+      android:gravity="start" />

--- a/app/src/main/res/drawable/tray_background_left_round.xml
+++ b/app/src/main/res/drawable/tray_background_left_round.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:topLeftRadius="10dp"/>
+            <solid android:color="@color/asphalt"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/tray_background_right_round.xml
+++ b/app/src/main/res/drawable/tray_background_right_round.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:topRightRadius="10dp" android:bottomRightRadius="10dp" />
+            <solid android:color="@color/asphalt"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/library.xml
+++ b/app/src/main/res/layout/library.xml
@@ -11,9 +11,6 @@
             name="supportsSystemNotifications"
             type="boolean" />
     </data>
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
@@ -34,23 +31,8 @@
                         android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
                         style="@style/libraryButtonMiddleTheme"
-                        android:src="@drawable/ic_icon_webapps"
-                        android:id="@+id/web_apps"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
-                    <com.igalia.wolvic.ui.views.UIButton
-                        style="@style/libraryButtonMiddleTheme"
                         android:src="@drawable/ic_icon_history"
                         android:id="@+id/history"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
-                    <com.igalia.wolvic.ui.views.UIButton
-                        style="@style/libraryButtonMiddleTheme"
-                        android:src="@drawable/ic_icon_downloads"
-                        android:id="@+id/downloads"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
-                    <com.igalia.wolvic.ui.views.UIButton
-                        style="@style/libraryButtonMiddleTheme"
-                        android:src="@drawable/ic_icon_addons"
-                        android:id="@+id/addons"
                         android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
                         style="@style/libraryButtonMiddleTheme"
@@ -69,17 +51,17 @@
                 android:layout_alignParentEnd="true"
                 android:padding="20dp"
                 android:background="@drawable/library_panel_background">
-                <RelativeLayout
+                <LinearLayout
                     android:id="@+id/header"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="10dp"
-                    android:layout_alignParentTop="true">
+                    android:layout_alignParentTop="true"
+                    android:orientation="horizontal">
 
                     <com.igalia.wolvic.ui.views.UIButton
                         android:id="@+id/backButton"
                         style="?attr/navigationBarButtonStyle"
-                        android:layout_alignParentStart="true"
                         android:src="@drawable/ic_icon_back"
                         android:tint="@color/midnight"
                         android:onClick="@{(view) -> delegate != null ? delegate.onBack(view) : void}"
@@ -87,10 +69,8 @@
 
                     <TextView
                         android:id="@+id/title"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_centerVertical="true"
-                        android:layout_centerHorizontal="true"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
                         android:gravity="center_horizontal"
                         android:textAlignment="gravity"
                         android:paddingStart="15dp"
@@ -99,14 +79,24 @@
                         android:textSize="@dimen/text_biggest_size"
                         android:textStyle="bold" />
 
-                    <com.igalia.wolvic.ui.views.UIButton
-                        android:id="@+id/closeButton"
-                        style="?attr/navigationBarButtonStyle"
-                        android:layout_alignParentEnd="true"
-                        android:src="@drawable/ic_icon_exit"
-                        android:tint="@color/midnight"
-                        android:onClick="@{(view) ->  delegate != null ? delegate.onClose(view) : void}" />
-                </RelativeLayout>
+                    <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+                        <SearchView
+                            android:id="@+id/search_bar"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="50dp"/>
+
+                        <com.igalia.wolvic.ui.views.UIButton
+                            android:id="@+id/closeButton"
+                            style="?attr/navigationBarButtonStyle"
+                            android:layout_alignParentEnd="true"
+                            android:src="@drawable/ic_icon_exit"
+                            android:tint="@color/midnight"
+                            android:onClick="@{(view) ->  delegate != null ? delegate.onClose(view) : void}" />
+                    </RelativeLayout>
+                </LinearLayout>
                 <FrameLayout
                     android:id="@+id/tabcontent"
                     android:layout_width="match_parent"
@@ -115,5 +105,4 @@
                     android:layout_alignParentBottom="true" />
             </RelativeLayout>
         </RelativeLayout>
-    </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -228,8 +228,8 @@
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/microphoneButton"
                     style="@style/urlBarIconTheme"
-                    android:layout_width="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
-                    android:background="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
+                    android:layout_width="@{(viewmodel.isLibraryVisible || viewmodel.isDownloadsVisible || viewmodel.isWebAppsVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
+                    android:background="@{(viewmodel.isLibraryVisible || viewmodel.isDownloadsVisible || viewmodel.isWebAppsVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
                     android:src="@drawable/ic_icon_microphone"
                     android:tint="@color/fog"
                     android:tooltipText="@string/voice_search_tooltip"
@@ -239,13 +239,13 @@
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/webAppButton"
                     style="@style/urlBarIconTheme"
-                    android:layout_width="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
-                    android:background="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
+                    android:layout_width="@{(viewmodel.isLibraryVisible || viewmodel.isDownloadsVisible || viewmodel.isWebAppsVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
+                    android:background="@{(viewmodel.isLibraryVisible || viewmodel.isDownloadsVisible || viewmodel.isWebAppsVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
                     android:src="@drawable/ic_web_app_registration"
                     android:tint="@color/fog"
                     android:tooltipText="@string/hamburger_menu_save_web_app"
                     app:privateMode="@{viewmodel.isPrivateSession}"
-                    app:visibleGone="@{viewmodel.isWebApp &amp;&amp; !(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}" />
+                    app:visibleGone="@{viewmodel.isWebApp &amp;&amp; !(viewmodel.isLibraryVisible || viewmodel.isDownloadsVisible || viewmodel.isWebAppsVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}" />
 
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/bookmarkButton"
@@ -254,7 +254,7 @@
                     android:tint="@color/fog"
                     android:tooltipText="@{viewmodel.isBookmarked ? @string/remove_bookmark_tooltip : @string/bookmark_tooltip}"
                     app:privateMode="@{viewmodel.isPrivateSession}"
-                    app:visibleGone="@{!(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}"
+                    app:visibleGone="@{!(viewmodel.isLibraryVisible || viewmodel.isDownloadsVisible || viewmodel.isWebAppsVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}"
                     tools:src="@drawable/ic_icon_bookmarked" />
 
                 <com.igalia.wolvic.ui.views.UIButton

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -12,17 +12,19 @@
     </data>
 
     <RelativeLayout
-        android:layout_width="@dimen/tray_width"
-        android:layout_height="@dimen/tray_height"
-        android:gravity="top|center_horizontal">
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="top|center_horizontal"
+        android:minWidth="@dimen/tray_width"
+        android:minHeight="@dimen/tray_height">
 
         <RelativeLayout
             android:id="@+id/status_bar"
             android:layout_width="wrap_content"
-            android:layout_height="20dp"
+            android:layout_height="28dp"
             android:layout_alignStart="@+id/tray_buttons"
             android:layout_alignEnd="@+id/tray_buttons"
-            android:background="@drawable/tray_background_top"
+            android:background="@drawable/tray_background_left_round"
             android:paddingStart="10dp"
             android:paddingEnd="10dp">
             <LinearLayout
@@ -58,22 +60,23 @@
                 android:layout_width="12dp"
                 android:layout_height="12dp"
                 android:layout_toEndOf="@+id/time"
+                android:layout_marginStart="6dp"
                 android:layout_centerVertical="true">
                 <ImageView
                     android:id="@+id/wifi_icon_background"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@{traymodel.wifiConnected ? @drawable/ic_icon_statusbar_wifi_list : @drawable/ic_icon_statusbar_nowifi}"
-                    android:tint="@color/iron"
-                    android:scaleType="fitCenter"/>
+                    android:scaleType="fitCenter"
+                    app:tint="@color/iron" />
                 <ImageView
                     android:id="@+id/wifi_icon"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/ic_icon_statusbar_wifi_list"
-                    android:tint="@color/concrete"
                     android:scaleType="fitCenter"
-                    app:visibleGone="@{traymodel.wifiConnected}"/>
+                    app:tint="@color/concrete"
+                    app:visibleGone="@{traymodel.wifiConnected}" />
             </FrameLayout>
             <LinearLayout
                 android:id="@+id/left_controller"
@@ -88,8 +91,8 @@
                     android:layout_width="12dp"
                     android:layout_height="12dp"
                     android:src="@{traymodel.leftControllerIcon}"
-                    android:tint="@color/concrete"
-                    android:scaleType="fitCenter"/>
+                    android:scaleType="fitCenter"
+                    app:tint="@color/concrete" />
                 <ImageView
                     android:id="@+id/left_controller_battery_indicator"
                     android:layout_width="5dp"
@@ -110,8 +113,8 @@
                     android:layout_width="12dp"
                     android:layout_height="12dp"
                     android:src="@{traymodel.rightControllerIcon}"
-                    android:tint="@color/concrete"
-                    android:scaleType="fitCenter"/>
+                    android:scaleType="fitCenter"
+                    app:tint="@color/concrete" />
                 <ImageView
                     android:id="@+id/right_controller_battery_indicator"
                     android:layout_width="5dp"
@@ -131,8 +134,8 @@
                     android:layout_width="12dp"
                     android:layout_height="12dp"
                     android:src="@{traymodel.headsetIcon}"
-                    android:tint="@color/concrete"
-                    android:scaleType="fitCenter"/>
+                    android:scaleType="fitCenter"
+                    app:tint="@color/concrete" />
                 <ImageView
                     android:id="@+id/headset_battery_indicator"
                     android:layout_width="5dp"
@@ -172,30 +175,31 @@
                 app:regularModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_unchecked_start : @drawable/tray_background_unchecked_middle}"
                 app:privateModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_start_private : @drawable/tray_background_middle_private}"
                 app:activeModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_checked_start : @drawable/tray_background_checked_middle}"/>
-
             <com.igalia.wolvic.ui.views.UIButton
-                android:id="@+id/privateButton"
+                android:id="@+id/libraryButton"
                 style="@style/trayButtonMiddleTheme"
-                android:tooltipText="@{viewmodel.isPrivateSession? @string/private_browsing_exit_tooltip : @string/private_browsing_enter_tooltip}"
+                android:tooltipText="@{viewmodel.isLibraryVisible ? @string/close_library_tooltip : @string/open_library_tooltip}"
                 app:tooltipDensity="@dimen/tray_tooltip_density"
                 app:tooltipPosition="bottom"
                 app:tooltipLayout="@layout/tooltip_tray"
-                android:src="@{viewmodel.isPrivateSession ? @drawable/ic_icon_tray_private_browsing_on_v2 : @drawable/ic_icon_tray_private_browsing_v2}"
-                app:privateMode="@{viewmodel.isPrivateSession}"/>
+                android:src="@drawable/ic_icon_library"
+                app:clipDrawable="@drawable/ic_icon_library_clip"
+                app:activeMode="@{viewmodel.isLibraryVisible}"/>
 
             <RelativeLayout
                 android:layout_width="40dp"
                 android:layout_height="40dp">
                 <com.igalia.wolvic.ui.views.UIButton
-                    android:id="@+id/libraryButton"
+                    android:id="@+id/downloadsButton"
                     style="@style/trayButtonMiddleTheme"
-                    android:tooltipText="@{viewmodel.isLibraryVisible ? @string/close_library_tooltip : @string/open_library_tooltip}"
+                    android:tooltipText="@{viewmodel.isDownloadsVisible ? @string/close_downloads_tooltip : @string/open_downloads_tooltip}"
                     app:tooltipDensity="@dimen/tray_tooltip_density"
                     app:tooltipPosition="bottom"
                     app:tooltipLayout="@layout/tooltip_tray"
-                    android:src="@drawable/ic_icon_library"
-                    app:clipDrawable="@drawable/ic_icon_library_clip"
-                    app:activeMode="@{viewmodel.isLibraryVisible}"/>
+                    android:src="@drawable/ic_icon_downloads"
+                    app:clipDrawable="@drawable/ic_icon_downloads_clip"
+                    app:activeMode="@{viewmodel.isDownloadsVisible}"/>
+
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="12dp"
                     android:layout_height="12dp"
@@ -216,14 +220,90 @@
             </RelativeLayout>
 
             <com.igalia.wolvic.ui.views.UIButton
+                android:id="@+id/privateButton"
+                style="@style/trayButtonMiddleTheme"
+                android:tooltipText="@{viewmodel.isPrivateSession? @string/private_browsing_exit_tooltip : @string/private_browsing_enter_tooltip}"
+                app:tooltipDensity="@dimen/tray_tooltip_density"
+                app:tooltipPosition="bottom"
+                app:tooltipLayout="@layout/tooltip_tray"
+                android:src="@{viewmodel.isPrivateSession ? @drawable/ic_icon_tray_private_browsing_on_v2 : @drawable/ic_icon_tray_private_browsing_v2}"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
+
+            <com.igalia.wolvic.ui.views.UIButton
                 android:id="@+id/settingsButton"
-                style="@style/trayButtonEndTheme"
+                style="@style/trayButtonMiddleTheme"
                 android:tooltipText="@string/settings_tooltip"
                 app:tooltipDensity="@dimen/tray_tooltip_density"
                 app:tooltipPosition="bottom"
                 app:tooltipLayout="@layout/tooltip_tray"
-                android:src="@drawable/ic_icon_tray_settings_v3"/>
+                android:src="@drawable/ic_icon_tray_settings_v3" />
         </LinearLayout>
 
+        <View
+            android:layout_width="1dp"
+            android:layout_height="0dp"
+            android:layout_alignTop="@id/status_bar"
+            android:layout_alignBottom="@id/tray_buttons"
+            android:layout_gravity="center_vertical"
+            android:layout_toLeftOf="@id/trayAppsButtonContainer"
+            android:background="@color/iron" />
+
+        <LinearLayout
+            android:id="@+id/trayAppsButtonContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignTop="@id/status_bar"
+            android:layout_toRightOf="@id/status_bar"
+            android:layout_alignBottom="@id/tray_buttons"
+            android:layout_marginTop="-2px"
+            android:gravity="top"
+            android:background="@drawable/tray_background_right_round"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:id="@+id/trayAppsButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/tray_background_bottom"
+                android:layout_gravity="start|bottom"
+                android:orientation="horizontal">
+
+                <com.igalia.wolvic.ui.views.UIButton
+                    android:id="@+id/webApp1"
+                    style="@style/trayButtonMiddleTheme"
+                    app:tintColorList="@color/black"
+                    app:tooltipDensity="@dimen/tray_tooltip_density"
+                    app:tooltipPosition="bottom"
+                    app:tooltipLayout="@layout/tooltip_tray" />
+
+                <com.igalia.wolvic.ui.views.UIButton
+                    android:id="@+id/webApp2"
+                    style="@style/trayButtonMiddleTheme"
+                    app:tintColorList="@color/black"
+                    app:tooltipDensity="@dimen/tray_tooltip_density"
+                    app:tooltipPosition="bottom"
+                    app:tooltipLayout="@layout/tooltip_tray" />
+
+                <com.igalia.wolvic.ui.views.UIButton
+                    android:id="@+id/webApp3"
+                    style="@style/trayButtonMiddleTheme"
+                    app:tintColorList="@color/black"
+                    app:tooltipDensity="@dimen/tray_tooltip_density"
+                    app:tooltipPosition="bottom"
+                    app:tooltipLayout="@layout/tooltip_tray" />
+            </LinearLayout>
+
+            <com.igalia.wolvic.ui.views.UIButton
+                android:id="@+id/webAppsButton"
+                style="@style/trayButtonEndTheme"
+                android:tooltipText="@{viewmodel.isWebAppsVisible ? @string/close_webapps_tooltip : @string/open_webapps_tooltip}"
+                app:tooltipDensity="@dimen/tray_tooltip_density"
+                app:tooltipPosition="bottom"
+                app:tooltipLayout="@layout/tooltip_tray"
+                android:layout_gravity="start|bottom"
+                android:src="@drawable/ic_icon_webapps"
+                app:clipDrawable="@drawable/ic_icon_webapps_clip"
+                app:activeMode="@{viewmodel.isWebAppsVisible}"/>
+        </LinearLayout>
     </RelativeLayout>
 </layout>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1695,6 +1695,14 @@
          tray and the Downloads view is closed. The button it labels, when pressed, closes the Downloads view. -->
     <string name="close_downloads_tooltip">Close Downloads</string>
 
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, opens a list view of the user's web apps. -->
+    <string name="open_webapps_tooltip">Open Web Apps</string>
+
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, closes the Web Apps view. -->
+    <string name="close_webapps_tooltip">Close Web Apps</string>
+
     <!-- This string is for the tooltip that appears when the user hovers over the 'Library' icon in the
          tray and the Library view is closed. The button it labels, when pressed, opens the library panel. -->
     <string name="open_library_tooltip">Open Library</string>
@@ -1821,6 +1829,9 @@
 
     <!-- This string is displayed in the URL bar when the user is in the downloads panel -->
     <string name="url_downloads_title">Downloads</string>
+
+    <!-- This string is displayed in the URL bar when the user is in the web apps panel -->
+    <string name="url_webapps_title">Web Apps</string>
 
     <!-- This string is displayed in the URL bar when the user is in the addons panel -->
     <string name="url_addons_title">Addons</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1261,6 +1261,12 @@
     <!-- This string is for the tooltip that appears when the user hovers over the 'Downloads' icon in the
          tray and the Downloads view is closed. The button it labels, when pressed, closes the Downloads view. -->
     <string name="close_downloads_tooltip">关闭下载项</string>
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, opens a list view of the user's web apps. -->
+    <string name="open_webapps_tooltip">打开网页应用</string>
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, closes the Web Apps view. -->
+    <string name="close_webapps_tooltip">关闭网页应用</string>
     <!-- This string is for the tooltip that appears when the user hovers over the 'Library' icon in the
          tray and the Library view is closed. The button it labels, when pressed, opens the library panel. -->
     <string name="open_library_tooltip">打开“我的足迹”</string>
@@ -1362,6 +1368,8 @@
     <string name="url_history_title">历史记录</string>
     <!-- This string is displayed in the URL bar when the user is in the downloads panel -->
     <string name="url_downloads_title">下载项</string>
+    <!-- This string is displayed in the URL bar when the user is in the web apps panel -->
+    <string name="url_webapps_title">网页应用</string>
     <!-- This string is displayed in the URL bar when the user is in the addons panel -->
     <string name="url_addons_title">附加组件</string>
     <!-- This string is displayed in the URL bar when the user is in the Library panel -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1696,6 +1696,14 @@
          tray and the Downloads view is closed. The button it labels, when pressed, closes the Downloads view. -->
     <string name="close_downloads_tooltip">關閉下載項目</string>
 
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, opens a list view of the user's web apps. -->
+    <string name="open_webapps_tooltip">開啟網頁應用</string>
+
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, closes the Web Apps view. -->
+    <string name="close_webapps_tooltip">關閉網頁應用</string>
+
     <!-- This string is for the tooltip that appears when the user hovers over the 'Library' icon in the
          tray and the Library view is closed. The button it labels, when pressed, opens the library panel. -->
     <string name="open_library_tooltip">開啟收藏庫</string>
@@ -1822,6 +1830,9 @@
 
     <!-- This string is displayed in the URL bar when the user is in the downloads panel -->
     <string name="url_downloads_title">下載項目</string>
+
+    <!-- This string is displayed in the URL bar when the user is in the web apps panel -->
+    <string name="url_webapps_title">網頁應用</string>
 
     <!-- This string is displayed in the URL bar when the user is in the addons panel -->
     <string name="url_addons_title">附加元件</string>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -129,8 +129,8 @@
     <!-- Tray -->
     <item name="tray_world_y" format="float" type="dimen">0.25</item>
     <item name="tray_world_z" format="float" type="dimen">-2.5</item>
-    <item name="tray_world_width" format="float" type="dimen">1.2</item>
-    <dimen name="tray_width">204dp</dimen>
+    <item name="tray_world_width" format="float" type="dimen">2</item>
+    <dimen name="tray_width">408dp</dimen>
     <dimen name="tray_height">66dp</dimen>
     <!-- The density of the tray tooltips is the default one. -->
     <item name="tray_tooltip_density" format="float" type="dimen">1.0</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1821,6 +1821,14 @@
          tray and the Downloads view is closed. The button it labels, when pressed, closes the Downloads view. -->
     <string name="close_downloads_tooltip">Close Downloads</string>
 
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, opens a list view of the user's web apps. -->
+    <string name="open_webapps_tooltip">Open Web Apps</string>
+
+    <!-- This string is for the tooltip that appears when the user hovers over the 'Web Apps' icon in the
+         tray and the Web Apps view is closed. The button it labels, when pressed, closes the Web Apps view. -->
+    <string name="close_webapps_tooltip">Close Web Apps</string>
+
     <!-- This string is for the tooltip that appears when the user hovers over the 'Library' icon in the
          tray and the Library view is closed. The button it labels, when pressed, opens the library panel. -->
     <string name="open_library_tooltip">Open Library</string>
@@ -1949,6 +1957,9 @@
 
     <!-- This string is displayed in the URL bar when the user is in the downloads panel -->
     <string name="url_downloads_title">Downloads</string>
+
+    <!-- This string is displayed in the URL bar when the user is in the web apps panel -->
+    <string name="url_webapps_title">Web Apps</string>
 
     <!-- This string is displayed in the URL bar when the user is in the addons panel -->
     <string name="url_addons_title">Addons</string>


### PR DESCRIPTION
This PR is a part of the Library reorganizing Q2-Q3 Planning

Create a separate location in the UI for each functionality
- (Library) Bookmarks/History
- Downloads
- Add-ons
- Web Apps

Add launchers in the UI to open each of those locations
- (Library) Bookmarks/History, Downloads and Web Apps from the tray
- Add-ons from Hamburger Menu

Add Search UI in:
- Bookmarks
- History
- Downloads
- Web Apps

![com igalia wolvic-20230902-193924](https://github.com/Igalia/wolvic/assets/43995067/25413f2b-595e-4780-97c2-d15883849195)


