### PR TITLE
Support using maven GV from the release channel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -643,13 +643,13 @@ dependencies {
     spacesImplementation fileTree(dir: "${project.rootDir}/third_party/spaces", include: ['*.aar'])
 
     // gecko
-    def branch = "nightly" // "nightly" or "beta"
+    def branch = "release" // "release", "nightly" or "beta"
     geckoImplementation deps.gecko_view."${branch}_x86_64"
     geckoImplementation deps.gecko_view."${branch}_arm64"
     configurations.all {
          resolutionStrategy.capabilitiesResolution.withCapability('org.mozilla.geckoview:geckoview') {
             def abi = getName().toLowerCase().contains('x64') ? 'x86_64' : 'arm64'
-            def candidate = "geckoview-${branch}-${abi}"
+            def candidate = branch == "release" ? "geckoview-${abi}" : "geckoview-${branch}-${abi}"
             select(candidates.find { it.id.module.contains(candidate) })
         }
     }

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view_release = "115.0.20230710165010"
+versions.gecko_view_release = "105.0.20221007134813"
 versions.gecko_view_nightly = "105.0.20220822095220"
 versions.gecko_view_beta = "104.0.20220816121120"
 versions.android_components = "105.0.8"

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,6 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
+versions.gecko_view_release = "115.0.20230710165010"
 versions.gecko_view_nightly = "105.0.20220822095220"
 versions.gecko_view_beta = "104.0.20220816121120"
 versions.android_components = "105.0.8"


### PR DESCRIPTION
We supported it at some point but it was broken for some time and we
eventually removed it. Now we can restore it. Release versions of Wolvic
must not use maven GeckoView versions because they don't include our
updates to the Wolvic-Gecko communication protocol, meaning that
for example WebXR won't work.

However we can still use it for super-quick bisects for example, or to test
2D browser features in advance without having to build Gecko.