### PR TITLE
Fix Language change issues when change language in Wolvic

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -7,6 +7,7 @@ package com.igalia.wolvic.ui.widgets;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import com.igalia.wolvic.input.Keyboard;
 import android.os.Handler;
@@ -542,6 +543,12 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     protected void onDismiss() {
         dismiss();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        setDefaultKeyboard();
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayLanguageOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayLanguageOptionsView.java
@@ -55,7 +55,7 @@ class DisplayLanguageOptionsView extends SettingsView {
         // Footer
         mBinding.footerLayout.setFooterButtonClickListener(mResetListener);
 
-        mBinding.languageRadio.setOptions(LocaleUtils.getSupportedLocalizedLanguages());
+        mBinding.languageRadio.setOptions(LocaleUtils.getSupportedLocalizedLanguagesStringArray(getContext()));
 
         String languageId = LocaleUtils.getDisplayLanguageId(getContext());
         mBinding.languageRadio.setOnCheckedChangeListener(mLanguageListener);

--- a/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
@@ -159,6 +159,7 @@ public class LocaleUtils {
         // We can't us stream here because an Android 24/25 bug the makes the stream implementation not top respect the order when iterating
         // https://android.googlesource.com/platform/libcore/+/7ae7ae73754c8b82a2e396098e35553d404c69ef%5E%21/#F0
         List<String> savedLanguageIds = SettingsStore.getInstance(aContext).getContentLocales();
+        getLanguages(aContext);
         List<Language> preferredLanguages = getLanguagesForIds(savedLanguageIds);
         preferredLanguages.forEach(language -> language.setPreferred(true));
 
@@ -238,7 +239,7 @@ public class LocaleUtils {
 
     public static Language getDisplayLanguage(@NonNull Context aContext) {
         String languageId = getDisplayLanguageId(aContext);
-        Language language = mSupportedLanguagesCache.get(languageId);
+        Language language = getSupportedLocalizedLanguages(aContext).get(languageId);
         if (language == null) {
             language = mSupportedLanguagesCache.get(FALLBACK_LANGUAGE_TAG);
         }
@@ -327,9 +328,9 @@ public class LocaleUtils {
     }
 
     @NonNull
-    public static String[] getSupportedLocalizedLanguages() {
+    public static String[] getSupportedLocalizedLanguagesStringArray(@NonNull Context context) {
         List<String> result = new ArrayList<>();
-        mSupportedLanguagesCache.forEach((id, language) -> {
+        getSupportedLocalizedLanguages(context).forEach((id, language) -> {
             result.add(language.getDisplayName());
         });
 


### PR DESCRIPTION
- Make keyboard also follow Wolvic's own language change. It's a follow up on #855 and continue addressing #845
- Fix language description unchanged in settings after languange change. We shouldn't abuse the cache since it can change at anytime.
![image](https://github.com/Igalia/wolvic/assets/43995067/89811a49-12c9-4b9b-8ec3-8cacb2dbffd9)
![image](https://github.com/Igalia/wolvic/assets/43995067/0586964a-a1f4-4da7-a918-2af147c33be2)

