### PR TITLE
Ensure valid user agent mode

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SettingsImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SettingsImpl.java
@@ -2,10 +2,10 @@ package com.igalia.wolvic.browser.api.impl;
 
 import androidx.annotation.Nullable;
 
-import org.chromium.wolvic.SessionSettings;
-
 import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.api.WSessionSettings;
+
+import org.chromium.wolvic.SessionSettings;
 
 public class SettingsImpl implements WSessionSettings {
     private SessionSettings mSessionSettings = new SessionSettings();
@@ -137,8 +137,9 @@ public class SettingsImpl implements WSessionSettings {
             case WSessionSettings.USER_AGENT_MODE_VR:
                 return SessionSettings.UserAgentMode.MOBILE_VR;
             case WSessionSettings.USER_AGENT_MODE_DESKTOP:
-            default:
                 return SessionSettings.UserAgentMode.DESKTOP;
+            default:
+                throw new IllegalStateException("Invalid user agent mode: " + mode);
         }
     }
 }


### PR DESCRIPTION
The Wsettings user agent mode is not defined as an enumeration, but 
as an interger value. The toUserAgentMode can receive any value and 
the current code defaults to Desktop in case of an invalid one.

This PR launches an Exception in case of an invalid user agent mode 
interger value, so that we can detect early any problem that a fake 
Desktok value could hide.