### PR TITLE
Use geckoview-nightly by default

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -707,7 +707,7 @@ dependencies {
     }
 
     // gecko
-    def branch = "release" // "release", "nightly" or "beta"
+    def branch = "nightly" // "release", "nightly" or "beta"
     geckoImplementation deps.gecko_view."${branch}_x86_64"
     geckoImplementation deps.gecko_view."${branch}_arm64"
     configurations.all {


### PR DESCRIPTION
We need to use the "nightly" Gecko module so it can be replaced by the script substitute-local-geckoview.gradle

See https://github.com/Igalia/wolvic/issues/890