### PR TITLE
Only pass valid URIs to loadUri

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -266,6 +266,12 @@ public class UrlUtils {
             TelemetryService.urlBarEvent(false);
         }
 
+        try {
+            URI uri = parseUri(url);
+            if (uri.getScheme() == null)
+                return "http://" + uri.toString();
+        } catch (URISyntaxException e) {
+        }
         return url;
     }
 


### PR DESCRIPTION
GeckoView's GeckoSession has traditionally accepted scheme-less strings
as valid URIs (like igalia.com, wikipedia.org...). However that is no longer
the case for newer versions. We should ensure that this kind of URIs get
their scheme. From now on we'd be adding "http://" to them, after all
most of websites redirect to the secure version anyway.