### PR TITLE
[Chromium] Remove views from container on releaseDisplay()

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -45,13 +45,6 @@ public class RuntimeImpl implements WRuntime {
         return mContext;
     }
 
-    public void addViewToBrowserContainer(View view) {
-        SettingsStore settings = SettingsStore.getInstance(mContext);
-        // using the default window size here, it will be updated later in onSurfaceChanged()
-        mContainerView.addView(view,
-                new ViewGroup.LayoutParams(settings.getWindowWidth(), settings.getWindowHeight()));
-    }
-
     @Override
     public WRuntimeSettings getSettings() {
         return mRuntimeSettings;

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -1,11 +1,13 @@
 package com.igalia.wolvic.browser.api.impl;
 
 import android.graphics.Matrix;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WContentBlocking;
 import com.igalia.wolvic.browser.api.WDisplay;
 import com.igalia.wolvic.browser.api.WMediaSession;
@@ -29,7 +31,6 @@ public class SessionImpl implements WSession {
     PromptDelegateImpl mPromptDelegate;
     SelectionActionDelegate mSelectionActionDelegate;
     WMediaSession.Delegate mMediaSessionDelegate;
-    DisplayImpl mDisplay;
     TextInputImpl mTextInput;
     PanZoomControllerImpl mPanZoomController;
     private String mInitialUri;
@@ -154,18 +155,20 @@ public class SessionImpl implements WSession {
     @NonNull
     @Override
     public WDisplay acquireDisplay() {
-        assert mDisplay == null;
-        mDisplay = new DisplayImpl(this, mTab.getCompositorView());
-        mRuntime.addViewToBrowserContainer(mTab.getCompositorView());
-        mRuntime.addViewToBrowserContainer(getContentView());
+        SettingsStore settings = SettingsStore.getInstance(mRuntime.getContext());
+        WDisplay display = new DisplayImpl(this, mTab.getCompositorView());
+        mRuntime.getContainerView().addView(mTab.getCompositorView(),
+                new ViewGroup.LayoutParams(settings.getWindowWidth(), settings.getWindowHeight()));
+        mRuntime.getContainerView().addView(getContentView(),
+                new ViewGroup.LayoutParams(settings.getWindowWidth(), settings.getWindowHeight()));
         getTextInput().setView(getContentView());
-        return mDisplay;
+        return display;
     }
 
     @Override
     public void releaseDisplay(@NonNull WDisplay display) {
-        assert mDisplay != null;
-        mDisplay = null;
+        mRuntime.getContainerView().removeView(mTab.getCompositorView());
+        mRuntime.getContainerView().removeView(getContentView());
         getTextInput().setView(null);
     }
 


### PR DESCRIPTION
Views are added to the container view on acquireDisplay(). Consequently those same views should be removed whenever releaseDisplay() is called.

This fixes a crash when switching tabs with Chromium:

E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.igalia.wolvic.dev, PID: 22807
    java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
        at android.view.ViewGroup.addViewInner(ViewGroup.java:5247)
        at android.view.ViewGroup.addView(ViewGroup.java:5076)
        at android.view.ViewGroup.addView(ViewGroup.java:5048)
        at com.igalia.wolvic.browser.api.impl.RuntimeImpl.addViewToBrowserContainer(RuntimeImpl.java:51)
        at com.igalia.wolvic.browser.api.impl.SessionImpl.acquireDisplay(SessionImpl.java:160)
        at com.igalia.wolvic.browser.engine.Session.surfaceChanged(Session.java:1804)

Fixes #795