### PR TITLE
[Chromium] Implement Session::setActive() & Session::setFocused()

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -87,12 +87,22 @@ public class SessionImpl implements WSession {
 
     @Override
     public void setActive(boolean active) {
-        // TODO: Implement
+        if (mTab == null)
+            return;
+
+        assert mTab.getContentView() != null;
+        if (active)
+            mTab.getContentView().getWebContents().onShow();
+        else
+            mTab.getContentView().getWebContents().onHide();
     }
 
     @Override
     public void setFocused(boolean focused) {
-        // TODO: Implement
+        if (mTab == null)
+            return;
+        assert mTab.getContentView() != null;
+        mTab.getContentView().getWebContents().setFocus(focused);
     }
 
     @Override


### PR DESCRIPTION
These methods are generally called when switching tabs. This allows the
web engine to perform several tasks to avoid wasting resources with tabs
that are not visible. For example, it pauses the playback of media.