### PR TITLE
[Chromium] Mute tabs when inactive

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -18,6 +18,8 @@ import com.igalia.wolvic.browser.api.WSessionSettings;
 import com.igalia.wolvic.browser.api.WSessionState;
 import com.igalia.wolvic.browser.api.WTextInput;
 
+import org.chromium.content_public.browser.WebContents;
+
 public class SessionImpl implements WSession {
     RuntimeImpl mRuntime;
     SettingsImpl mSettings;
@@ -92,10 +94,14 @@ public class SessionImpl implements WSession {
             return;
 
         assert mTab.getContentView() != null;
-        if (active)
-            mTab.getContentView().getWebContents().onShow();
-        else
-            mTab.getContentView().getWebContents().onHide();
+        WebContents webContents = mTab.getContentView().getWebContents();
+        if (active) {
+            webContents.onShow();
+        } else {
+            webContents.onHide();
+            webContents.suspendAllMediaPlayers();
+        }
+        webContents.setAudioMuted(!active);
     }
 
     @Override


### PR DESCRIPTION
In 50d4e199 we added support for notifying the web contents about the
visible status of some tabs. This allowed us to pause some media playback
when the tabs go to background. However that is not enough for all media
content. For that we need to call a couple of methods: 
suspendAllMediaPlayers() and setAudioMuted() to ensure that no playback
is performed.