### PR TITLE
Move hand mesh renderer instance to OpenXR backend

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -537,8 +537,8 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
       controller.modelToggle->ToggleAll(controller.mode == ControllerMode::Device);
 
     if (handMeshRenderer) {
-      handMeshRenderer->Update(controller, controllers->GetRoot(),
-                               controller.enabled && controller.mode == ControllerMode::Hand);
+      handMeshRenderer->Update(controller.index, controller.handJointTransforms, controllers->GetRoot(),
+                               controller.enabled && controller.mode == ControllerMode::Hand, controller.leftHanded);
     }
 
     if (controller.handActionEnabled && controller.handActionButtonTransform != nullptr) {
@@ -1724,7 +1724,7 @@ BrowserWorld::DrawWorld(device::Eye aEye) {
 #endif
       }
       assert(m.handMeshRenderer);
-      m.handMeshRenderer->Draw(controller, *camera);
+      m.handMeshRenderer->Draw(controller.index, *camera);
     }
   }
 

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -12,7 +12,6 @@
 #include "EngineSurfaceTexture.h"
 #include "ExternalBlitter.h"
 #include "ExternalVR.h"
-#include "HandMeshRenderer.h"
 #include "Skybox.h"
 #include "SplashAnimation.h"
 #include "Pointer.h"
@@ -210,7 +209,6 @@ struct BrowserWorld::State {
   double lastBatteryLevelUpdate = -1.0;
   bool reorientRequested = false;
   VRLayerPassthroughPtr layerPassthrough;
-  HandMeshRendererPtr handMeshRenderer = nullptr;
 #if HVR
   bool wasButtonAppPressed = false;
 #elif defined(OCULUSVR) && defined(STORE_BUILD)
@@ -536,10 +534,8 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
     if (controller.modelToggle)
       controller.modelToggle->ToggleAll(controller.mode == ControllerMode::Device);
 
-    if (handMeshRenderer) {
-      handMeshRenderer->Update(controller.index, controller.handJointTransforms, controllers->GetRoot(),
-                               controller.enabled && controller.mode == ControllerMode::Hand, controller.leftHanded);
-    }
+    device->UpdateHandMesh(controller.index, controller.handJointTransforms, controllers->GetRoot(),
+                           controller.enabled && controller.mode == ControllerMode::Hand, controller.leftHanded);
 
     if (controller.handActionEnabled && controller.handActionButtonTransform != nullptr) {
       // Layout the button between the thumb and index fingertips
@@ -1714,18 +1710,8 @@ BrowserWorld::DrawWorld(device::Eye aEye) {
 
   // Draw hand mesh if active
   for (Controller& controller: m.controllers->GetControllers()) {
-    if (controller.enabled && controller.mode == ControllerMode::Hand) {
-      if (!m.handMeshRenderer) {
-        // Lazily create the hand mesh rendering object
-#if defined(PICOXR) || defined(SPACES)
-        m.handMeshRenderer = HandMeshRendererSpheres::Create(m.create);
-#else
-        m.handMeshRenderer = HandMeshRendererSkinned::Create(m.create);
-#endif
-      }
-      assert(m.handMeshRenderer);
-      m.handMeshRenderer->Draw(controller.index, *camera);
-    }
+    if (controller.enabled && controller.mode == ControllerMode::Hand)
+      m.device->DrawHandMesh(controller.index, *camera);
   }
 
   // Draw controllers

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -111,6 +111,9 @@ public:
   void TogglePassthroughEnabled() { mIsPassthroughEnabled = !mIsPassthroughEnabled; }
   virtual bool usesPassthroughCompositorLayer() const { return false; }
   virtual int32_t GetHandTrackingJointIndex(const HandTrackingJoints aJoint) { return -1; };
+  virtual void UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
+                              const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) {};
+  virtual void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) {};
 
 protected:
   DeviceDelegate() {}

--- a/app/src/main/cpp/HandMeshRenderer.h
+++ b/app/src/main/cpp/HandMeshRenderer.h
@@ -19,8 +19,9 @@ protected:
     vrb::CreationContextWeak context;
 public:
     virtual ~HandMeshRenderer() = default;
-    virtual void Update(Controller&, const vrb::GroupPtr& aRoot, const bool aEnabled) = 0;
-    virtual void Draw(Controller&, const vrb::Camera&) { };
+    virtual void Update(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
+                        const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) = 0;
+    virtual void Draw(const uint32_t aControllerIndex, const vrb::Camera&) { };
 };
 
 class HandMeshRendererSpheres: public HandMeshRenderer {
@@ -31,7 +32,8 @@ protected:
 public:
     static HandMeshRendererPtr Create(vrb::CreationContextPtr&);
 private:
-    void Update(Controller&, const vrb::GroupPtr& aRoot, const bool aEnabled) override;
+    void Update(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
+                const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) override;
 };
 
 struct HandMeshSkinned;
@@ -45,10 +47,11 @@ protected:
 public:
     static HandMeshRendererPtr Create(vrb::CreationContextPtr&);
 private:
-    void Update(Controller&, const vrb::GroupPtr& aRoot, const bool aEnabled) override;
-    void Draw(Controller&, const vrb::Camera&) override;
-    bool LoadHandMeshFromAssets(Controller&, HandMeshSkinned&);
-    void UpdateHandModel(const Controller&);
+    void Update(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
+                const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) override;
+    void Draw(const uint32_t aControllerIndex, const vrb::Camera&) override;
+    bool LoadHandMeshFromAssets(const bool leftHanded, HandMeshSkinned&);
+    void UpdateHandModel(const uint32_t aControllerIndex);
 };
 
 };

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1423,14 +1423,16 @@ int32_t DeviceDelegateOpenXR::GetHandTrackingJointIndex(const HandTrackingJoints
 void
 DeviceDelegateOpenXR::UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
                const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) {
-  if (m.handMeshRenderer)
-    m.handMeshRenderer->Update(aControllerIndex, handJointTransforms, aRoot, aEnabled, leftHanded);
+  if (!m.handMeshRenderer)
+    return;
+  m.handMeshRenderer->Update(aControllerIndex, handJointTransforms, aRoot, aEnabled, leftHanded);
 }
 
 void
 DeviceDelegateOpenXR::DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera& aCamera) {
-  if (m.handMeshRenderer)
-    m.handMeshRenderer->Draw(aControllerIndex, aCamera);
+  if (!m.handMeshRenderer)
+    return;
+  m.handMeshRenderer->Draw(aControllerIndex, aCamera);
 }
 
 void

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -60,6 +60,9 @@ public:
   bool usesPassthroughCompositorLayer() const override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;
   int32_t GetHandTrackingJointIndex(const HandTrackingJoints aJoint) override;
+  void UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
+                      const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) override;
+  void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);


### PR DESCRIPTION
The upcoming introduction of XR_MSFT_hand_tracking_mesh extension will introduce a special case where OpenXR specific code will have to leak into common code to properly support the extension. Hence we decided to move the hand mesh rendering object to backend code directly and avoid the encapsulation problem.
    
For more info, see the discussions on [PR#821](https://github.com/Igalia/wolvic/pull/821).

This series depend on [PR#903](https://github.com/Igalia/wolvic/pull/903).