### PR TITLE
[OpenXR] Add generic controller input mapping for LenovoA3

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -330,6 +330,20 @@ namespace crow {
       },
     };
 
+  // LenovoA3 doesn't have physical controllers, but the input mapping is needed for hand-tracking,
+  // which for the moment emulates controllers.
+  const OpenXRInputMapping LenovoA3 {
+      "/interaction_profiles/khr/simple_controller",
+      IS_6DOF,
+      "vr_controller_oculusgo.obj",
+      "vr_controller_oculusgo.obj",
+      device::LenovoA3,
+      std::vector<OpenXRInputProfile> { "generic-button" },
+      std::vector<OpenXRButton> {
+          { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
+      },
+    };
+
     const OpenXRInputMapping LenovoVRX {
             "/interaction_profiles/oculus/touch_controller",
             IS_6DOF,
@@ -393,8 +407,8 @@ namespace crow {
             },
     };
 
-    const std::array<OpenXRInputMapping, 11> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4, Pico4E, Hvr6DOF, Hvr3DOF, LynxR1, LenovoVRX, MagicLeap2, KHRSimple
+    const std::array<OpenXRInputMapping, 12> OpenXRInputMappings {
+        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4, Pico4E, Hvr6DOF, Hvr3DOF, LynxR1, LenovoA3, LenovoVRX, MagicLeap2, KHRSimple
     };
 
 } // namespace crow


### PR DESCRIPTION
Even though the LenovoA3 doesn't feature controllers, an active input mapping is required because we emulate hand-tracking from controllers for the moment.