### PR TITLE
[OpenXR] Fix detection of generic input profiles as fallbacks

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -318,18 +318,6 @@ namespace crow {
       },
   };
 
-  const OpenXRInputMapping LynxR1 {
-      "/interaction_profiles/khr/simple_controller",
-      IS_6DOF,
-      "vr_controller_oculusgo.obj",
-      "vr_controller_oculusgo.obj",
-      device::LynxR1,
-      std::vector<OpenXRInputProfile> { "generic-button" },
-      std::vector<OpenXRButton> {
-          { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
-      },
-    };
-
     const OpenXRInputMapping LenovoVRX {
             "/interaction_profiles/oculus/touch_controller",
             IS_6DOF,
@@ -393,8 +381,8 @@ namespace crow {
             },
     };
 
-    const std::array<OpenXRInputMapping, 11> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4, Pico4E, Hvr6DOF, Hvr3DOF, LynxR1, LenovoVRX, MagicLeap2, KHRSimple
+    const std::array<OpenXRInputMapping, 10> OpenXRInputMappings {
+        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4, Pico4E, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, KHRSimple
     };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -88,8 +88,13 @@ XrResult OpenXRInputSource::Initialize()
         systemDoF = DoF::IS_6DOF;
     }
     for (auto& mapping: OpenXRInputMappings) {
-      if (deviceType != mapping.controllerType && mapping.controllerType != device::UnknownType)
+      // Always populate default/fall-back profiles
+      if (mapping.controllerType == device::UnknownType) {
+        mMappings.push_back(mapping);
         continue;
+      } else if (deviceType != mapping.controllerType) {
+        continue;
+      }
 
       if (systemDoF != mapping.systemDoF)
           continue;


### PR DESCRIPTION
After a filter was added to select input profiles based on 6DoF/3DoF support, we broke fallback profile detection for devices that don't have controllers but report 6DoF (LenovoA3, LynxR1); because our generic profile KHRSimple is 3DoF only.

This patch forces all generic profiles to be populated regardless, bypassing the 3DoF/6DoF filter. 

It also removes the LynxR1 specific profile since it is not needed now.