### PR TITLE
Fix Pico4 hand-tracking after runtime upgrade (5.7.1)

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1533,7 +1533,7 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
 #if defined(PICOXR)
       // Due to unreliable hand-tracking orientation data on Pico devices running system
       // versions earlier than 5.7.1, we use the Spheres strategy.
-      if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0)
+      if (CompareBuildIdString(kPicoVersionHandTrackingUpdate))
         m.handMeshRenderer = HandMeshRendererSpheres::Create(create);
 #endif
     }

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -212,7 +212,6 @@ struct DeviceDelegateOpenXR::State {
 
     XrInstanceProperties instanceProperties{XR_TYPE_INSTANCE_PROPERTIES};
     CHECK_XRCMD(xrGetInstanceProperties(instance, &instanceProperties));
-    SetOpenXRRuntimeVersion(instanceProperties.runtimeVersion);
     VRB_LOG("OpenXR Instance Created: RuntimeName=%s RuntimeVersion=%s", instanceProperties.runtimeName,
             GetXrVersionString(instanceProperties.runtimeVersion).c_str());
 
@@ -1532,9 +1531,9 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
       m.input->SetHandMeshBufferSizes(m.handMeshProperties->indexCount, m.handMeshProperties->vertexCount);
     } else {
 #if defined(PICOXR)
-      // Due to unreliable hand-tracking orientation data on Pico devices running OpenXR runtime
-      // version earlier than 3.0.1, we use the Spheres strategy.
-      if (GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion)
+      // Due to unreliable hand-tracking orientation data on Pico devices running system
+      // versions earlier than 5.7.1, we use the Spheres strategy.
+      if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0)
         m.handMeshRenderer = HandMeshRendererSpheres::Create(create);
 #endif
     }

--- a/app/src/openxr/cpp/OpenXRGestureManager.cpp
+++ b/app/src/openxr/cpp/OpenXRGestureManager.cpp
@@ -17,11 +17,11 @@ bool
 OpenXRGestureManager::palmFacesHead(const vrb::Matrix &palm, const vrb::Matrix &head) const {
     // For the hand we take the Y axis because that corresponds to head's Z axis when
     // the hand is in upright position facing head (the gesture we want to detect).
-#ifdef PICOXR
-    // Axis are inverted in Pico
-    auto vectorPalm = palm.MultiplyDirection({0, 0, -1});
-#else
     auto vectorPalm = palm.MultiplyDirection({0, 1, 0});
+#ifdef PICOXR
+    // Axis are inverted in Pico with runtime versions prior to 3.0.1
+    if (GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion)
+        vectorPalm = palm.MultiplyDirection({0, 0, -1});
 #endif
     auto vectorHead = head.MultiplyDirection({0, 0, -1});
     return vectorPalm.Dot(vectorHead) > kPalmHeadThreshold;

--- a/app/src/openxr/cpp/OpenXRGestureManager.cpp
+++ b/app/src/openxr/cpp/OpenXRGestureManager.cpp
@@ -20,7 +20,7 @@ OpenXRGestureManager::palmFacesHead(const vrb::Matrix &palm, const vrb::Matrix &
     auto vectorPalm = palm.MultiplyDirection({0, 1, 0});
 #ifdef PICOXR
     // Axis are inverted in Pico system versions prior to 5.7.1
-    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0)
+    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate))
         vectorPalm = palm.MultiplyDirection({0, 0, -1});
 #endif
     auto vectorHead = head.MultiplyDirection({0, 0, -1});

--- a/app/src/openxr/cpp/OpenXRGestureManager.cpp
+++ b/app/src/openxr/cpp/OpenXRGestureManager.cpp
@@ -19,8 +19,8 @@ OpenXRGestureManager::palmFacesHead(const vrb::Matrix &palm, const vrb::Matrix &
     // the hand is in upright position facing head (the gesture we want to detect).
     auto vectorPalm = palm.MultiplyDirection({0, 1, 0});
 #ifdef PICOXR
-    // Axis are inverted in Pico with runtime versions prior to 3.0.1
-    if (GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion)
+    // Axis are inverted in Pico system versions prior to 5.7.1
+    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0)
         vectorPalm = palm.MultiplyDirection({0, 0, -1});
 #endif
     auto vectorHead = head.MultiplyDirection({0, 0, -1});

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -8,6 +8,7 @@
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 #include <openxr/openxr_reflection.h>
+#include "SystemUtils.h"
 #include "vrb/Matrix.h"
 
 namespace crow {
@@ -18,16 +19,12 @@ namespace crow {
   const vrb::Vector kAverageHeight(0.0f, 1.7f, 0.0f);
 #endif
 
-const unsigned long kPicoHandTrackingRuntimeVersion = XR_MAKE_VERSION(3, 0, 1);
+// Hand tracking was thoroughly updated on Pico version 5.7.1
+static const std::string kPicoVersionHandTrackingUpdate = "5.7.1";
 
-static uint64_t openXRRuntimeVersion = 0;
-
-inline void SetOpenXRRuntimeVersion(const uint64_t version) {
-    openXRRuntimeVersion = version;
-}
-
-inline uint64_t GetOpenXRRuntimeVersion() {
-    return openXRRuntimeVersion;
+inline int CompareBuildIdString(const std::string str) {
+    char buildId[128];
+    return CompareSemanticVersionStrings(GetBuildIdString(buildId), str);
 }
 
 inline std::string Fmt(const char* fmt, ...) {

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -18,6 +18,18 @@ namespace crow {
   const vrb::Vector kAverageHeight(0.0f, 1.7f, 0.0f);
 #endif
 
+const unsigned long kPicoHandTrackingRuntimeVersion = XR_MAKE_VERSION(3, 0, 1);
+
+static uint64_t openXRRuntimeVersion = 0;
+
+inline void SetOpenXRRuntimeVersion(const uint64_t version) {
+    openXRRuntimeVersion = version;
+}
+
+inline uint64_t GetOpenXRRuntimeVersion() {
+    return openXRRuntimeVersion;
+}
+
 inline std::string Fmt(const char* fmt, ...) {
     va_list vl;
     va_start(vl, fmt);

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -22,7 +22,7 @@ namespace crow {
 // Hand tracking was thoroughly updated on Pico version 5.7.1
 static const std::string kPicoVersionHandTrackingUpdate = "5.7.1";
 
-inline int CompareBuildIdString(const std::string str) {
+inline bool CompareBuildIdString(const std::string str) {
     char buildId[128];
     return CompareSemanticVersionStrings(GetBuildIdString(buildId), str);
 }

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -7,7 +7,7 @@
 
 #if defined(PICOXR)
     // Pico system version prior to 5.7.1 doesn't provide palm joint info :( so we use the wrist instead.
-#define HAND_JOINT_FOR_AIM ((CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0) ? XR_HAND_JOINT_WRIST_EXT : XR_HAND_JOINT_PALM_EXT)
+#define HAND_JOINT_FOR_AIM (CompareBuildIdString(kPicoVersionHandTrackingUpdate) ? XR_HAND_JOINT_WRIST_EXT : XR_HAND_JOINT_PALM_EXT)
 #else
 #define HAND_JOINT_FOR_AIM XR_HAND_JOINT_PALM_EXT
 #endif
@@ -633,7 +633,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     // Scale joints according to their radius (for rendering). This is currently only
     // relevant on Pico with system version earlier than 5.7.1, where we are using spheres
     // to render the hands instead of a proper hand model due to incorrect joint orientation.
-    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0) {
+    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate)) {
         for (int i = 0; i < mHandJoints.size(); i++) {
             if (IsHandJointPositionValid((XrHandJointEXT) i, mHandJoints)) {
                 float radius = mHandJoints[i].radius;
@@ -708,7 +708,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     }
 #elif defined(PICOXR)
     // On Pico, this only affects system versions earlier than 5.7.1
-    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0) {
+    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate)) {
         float correctionAngle = -M_PI_2;
         pointerTransform
             .PostMultiplyInPlace(vrb::Matrix::Rotation(vrb::Vector(0.0, 1.0, 0.0),correctionAngle)

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -6,8 +6,8 @@
 #include "SystemUtils.h"
 
 #if defined(PICOXR)
-    // Pico runtime prior to 3.0.1 doesn't provide palm joint info :( so we use the wrist instead.
-#define HAND_JOINT_FOR_AIM ((GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion) ? XR_HAND_JOINT_WRIST_EXT : XR_HAND_JOINT_PALM_EXT)
+    // Pico system version prior to 5.7.1 doesn't provide palm joint info :( so we use the wrist instead.
+#define HAND_JOINT_FOR_AIM ((CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0) ? XR_HAND_JOINT_WRIST_EXT : XR_HAND_JOINT_PALM_EXT)
 #else
 #define HAND_JOINT_FOR_AIM XR_HAND_JOINT_PALM_EXT
 #endif
@@ -631,9 +631,9 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
 
 #if defined(PICOXR)
     // Scale joints according to their radius (for rendering). This is currently only
-    // relevant on Pico with runtime version earlier than 3.0.1, where we are using spheres
+    // relevant on Pico with system version earlier than 5.7.1, where we are using spheres
     // to render the hands instead of a proper hand model due to incorrect joint orientation.
-    if (GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion) {
+    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0) {
         for (int i = 0; i < mHandJoints.size(); i++) {
             if (IsHandJointPositionValid((XrHandJointEXT) i, mHandJoints)) {
                 float radius = mHandJoints[i].radius;
@@ -707,8 +707,8 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
         pointerTransform = pointerTransform.PostMultiply(correctionMatrix);
     }
 #elif defined(PICOXR)
-    // On Pico, this only affects runtime versions earlier than 3.0.1
-    if (GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion) {
+    // On Pico, this only affects system versions earlier than 5.7.1
+    if (CompareBuildIdString(kPicoVersionHandTrackingUpdate) < 0) {
         float correctionAngle = -M_PI_2;
         pointerTransform
             .PostMultiplyInPlace(vrb::Matrix::Rotation(vrb::Vector(0.0, 1.0, 0.0),correctionAngle)

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -6,8 +6,8 @@
 #include "SystemUtils.h"
 
 #if defined(PICOXR)
-    // Pico runtime doesn't provide palm joint info :( so we use the wrist instead.
-#define HAND_JOINT_FOR_AIM XR_HAND_JOINT_WRIST_EXT
+    // Pico runtime prior to 3.0.1 doesn't provide palm joint info :( so we use the wrist instead.
+#define HAND_JOINT_FOR_AIM ((GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion) ? XR_HAND_JOINT_WRIST_EXT : XR_HAND_JOINT_PALM_EXT)
 #else
 #define HAND_JOINT_FOR_AIM XR_HAND_JOINT_PALM_EXT
 #endif
@@ -629,16 +629,18 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     bool hasAim = mGestureManager->hasAim();
     bool systemGestureDetected = mGestureManager->systemGestureDetected(jointTransforms[HAND_JOINT_FOR_AIM], head);
 
-    // Scale joints according to their radius (for rendering). This is only
-    // relevant for devices where we are using spheres to render the hands
-    // instead of a proper hand model.
-#if defined(PICOXR) || defined(SPACES)
-    for (int i = 0; i < mHandJoints.size(); i++) {
-        if (IsHandJointPositionValid((XrHandJointEXT) i, mHandJoints)) {
-            float radius = mHandJoints[i].radius;
-            vrb::Matrix scale = vrb::Matrix::Identity().ScaleInPlace(
-                    vrb::Vector(radius, radius, radius));
-            jointTransforms[i].PostMultiplyInPlace(scale);
+#if defined(PICOXR)
+    // Scale joints according to their radius (for rendering). This is currently only
+    // relevant on Pico with runtime version earlier than 3.0.1, where we are using spheres
+    // to render the hands instead of a proper hand model due to incorrect joint orientation.
+    if (GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion) {
+        for (int i = 0; i < mHandJoints.size(); i++) {
+            if (IsHandJointPositionValid((XrHandJointEXT) i, mHandJoints)) {
+                float radius = mHandJoints[i].radius;
+                vrb::Matrix scale = vrb::Matrix::Identity().ScaleInPlace(
+                        vrb::Vector(radius, radius, radius));
+                jointTransforms[i].PostMultiplyInPlace(scale);
+            }
         }
     }
 #endif
@@ -705,10 +707,13 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
         pointerTransform = pointerTransform.PostMultiply(correctionMatrix);
     }
 #elif defined(PICOXR)
-    float correctionAngle = -M_PI_2;
-    pointerTransform
-        .PostMultiplyInPlace(vrb::Matrix::Rotation(vrb::Vector(0.0, 1.0, 0.0),correctionAngle)
-        .PostMultiply(vrb::Matrix::Rotation(vrb::Vector(0.0, 0.0, 1.0), correctionAngle)));
+    // On Pico, this only affects runtime versions earlier than 3.0.1
+    if (GetOpenXRRuntimeVersion() < kPicoHandTrackingRuntimeVersion) {
+        float correctionAngle = -M_PI_2;
+        pointerTransform
+            .PostMultiplyInPlace(vrb::Matrix::Rotation(vrb::Vector(0.0, 1.0, 0.0),correctionAngle)
+            .PostMultiply(vrb::Matrix::Rotation(vrb::Vector(0.0, 0.0, 1.0), correctionAngle)));
+    }
 #endif
 
     if (renderMode == device::RenderMode::StandAlone)


### PR DESCRIPTION
The new runtime version improved hand-tracking data significantly, so we can now use the skinned hand mesh rendering strategy instead of the joint spheres.

We can also remove all Pico-specific corrections we had for beam angle and action button positioning.

For users still on earlier versions, we keep the current hand tracking behavior and rendering, and use runtime checks against the OpenXR runtime version to switch to the old code.
