### PR TITLE
Fix white flashes in several (heavy) WebXR experiences while in immersive mode

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1763,7 +1763,7 @@ BrowserWorld::TickImmersive() {
               m.context->GetTimestamp());
   }
   // DeviceDelegate::StartFrame() might have failed and then we should discard the frame.
-  aDiscardFrame = aDiscardFrame && !m.device->ShouldRender();
+  aDiscardFrame = aDiscardFrame || !m.device->ShouldRender();
 
   if (state == ExternalVR::VRState::Rendering) {
     if (!aDiscardFrame) {

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -579,7 +579,7 @@ ExternalVR::WaitFrameResult() {
       return true; // Do not block to show loading screen until the first frame arrives.
     }
     // VRB_LOG("RequestFrame ABOUT TO WAIT FOR FRAME %llu %llu",m.browser.layerState[0].layer_stereo_immersive.frameId, m.lastFrameId);
-    const float kConditionTimeout = 0.1f;
+    const float kConditionTimeout = 0.25f;
     // Wait causes the current thread to block until the condition variable is notified or the timeout happens.
     // Waiting for the condition variable releases the mutex atomically. So GV can modify the browser data.
     if (!wait.DoWait(kConditionTimeout)) {


### PR DESCRIPTION
The culprit is a bug in a condition that resolves when a frame is discarded. Using a logical AND instead of OR when deciding if a discarded frame should render or not, is causing already discarded frames to become valid again.

There is a bonus patch in this series that improves stutter in heavy WebXR experiences. Right now we are using a timed wait of ~100ms when waiting for frame completion in gecko. Some heavy WebXR experiences can easily hit this limit, specially when loading resources, causing the frame to be discarded due to timeout. This causes unnecessary stutter, which can be avoided if we wait a bit more for the frame, at the expense of the frame rate. We propose increasing the frame waiting timeout to ~250ms.

A good (heavy) experience to test this is https://hubs.mozilla.com/E4e8oLx/hubs-demo-promenade.