### PR TITLE
[Chromium] Pass the correct URL to onPageStart

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -26,7 +26,7 @@ public class TabWebContentsObserver extends WebContentsObserver {
     public void didStartLoading(GURL url) {
         @Nullable WSession.ProgressDelegate delegate = mSession.getProgressDelegate();
         if (delegate != null) {
-            delegate.onPageStart(mSession, url.toString());
+            delegate.onPageStart(mSession, url.getSpec());
         }
         dispatchCanGoBackOrForward();
     }


### PR DESCRIPTION
The current code was using url.toString() but that's wrong because that returns a
string representation of the GURL object. Instead the code should use the URL spec