### PR TITLE
Copy search engine list from upstream and add yandex when Russian

### DIFF
--- a/app/src/main/assets/search/list.json
+++ b/app/src/main/assets/search/list.json
@@ -1,0 +1,923 @@
+{
+  "default": {
+    "searchDefault": "Google",
+    "searchOrder": ["Google", "Bing"],
+    "visibleDefaultEngines": [
+      "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia"
+    ]
+  },
+  "regionOverrides": {
+    "US": {
+      "google-b-m": "google-b-1-m"
+    }
+  },
+  "locales": {
+    "ach": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia"
+        ]
+      }
+    },
+    "an": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-an"
+        ]
+      }
+    },
+    "ar": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-ar"
+        ]
+      }
+    },
+    "as": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-as"
+        ]
+      }
+    },
+    "ast": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-ast"
+        ]
+      }
+    },
+    "az": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "azerdict", "wikipedia-az"
+        ]
+      }
+    },
+    "be": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-be"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-be"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-be"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-be"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-be"
+        ]
+      }
+    },
+    "bg": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "pazaruvaj", "wikipedia-bg"
+        ]
+      }
+    },
+    "bn": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-bn"
+        ]
+      }
+    },
+    "bn-BD": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-bn"
+        ]
+      }
+    },
+    "bn-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "rediff", "wikipedia-bn"
+        ]
+      }
+    },
+    "br": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-br"
+        ]
+      }
+    },
+    "bs": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-bs"
+        ]
+      }
+    },
+    "ca": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-ca"
+        ]
+      }
+    },
+    "cak": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "amazondotcom", "ddg", "wikipedia-es"
+        ]
+      }
+    },
+    "cs": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "mapy-cz", "seznam-cz", "wikipedia-cz"
+        ]
+      }
+    },
+    "cy": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "wikipedia-cy"
+        ]
+      }
+    },
+    "da": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "amazon-co-uk", "ddg", "wikipedia-da"
+        ]
+      }
+    },
+    "de": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-de", "ddg", "ecosia", "qwant", "wikipedia-de", "ebay-de"
+        ]
+      }
+    },
+    "de-AT": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-de", "ddg", "ecosia", "qwant", "wikipedia-de", "ebay-at"
+        ]
+      }
+    },
+    "dsb": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-de", "ddg", "wikipedia-dsb", "ebay-de"
+        ]
+      }
+    },
+    "el": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "skroutz", "wikipedia-el"
+        ]
+      }
+    },
+    "en-AU": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-au", "ddg", "wikipedia", "ebay-au"
+        ]
+      }
+    },
+    "en-CA": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-ca", "ddg", "wikipedia", "ebay-ca"
+        ]
+      }
+    },
+    "en-IE": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "qwant", "wikipedia", "ebay-ie"
+        ]
+      }
+    },
+    "en-GB": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "qwant", "wikipedia", "ebay-co-uk"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazon-co-uk", "ddg", "qwant", "wikipedia"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazon-co-uk", "ddg", "qwant", "wikipedia"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazon-co-uk", "ddg", "qwant", "wikipedia"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazon-co-uk", "ddg", "qwant", "wikipedia"
+        ]
+      }
+    },
+    "en-US": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "ebay", "wikipedia"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazondotcom", "ddg", "wikipedia"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazondotcom", "ddg", "wikipedia"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazondotcom", "ddg", "wikipedia"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "amazondotcom", "ddg", "wikipedia"
+        ]
+      }
+    },
+    "en-ZA": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia"
+        ]
+      }
+    },
+    "eo": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "reta-vortaro", "wikipedia-eo"
+        ]
+      }
+    },
+    "es-AR": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "mercadolibre-ar", "wikipedia-es"
+        ]
+      }
+    },
+    "es-CL": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "mercadolibre-cl", "wikipedia-es"
+        ]
+      }
+    },
+    "es-ES": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-es", "amazon-es", "ebay-es"
+        ]
+      }
+    },
+    "es-MX": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "mercadolibre-mx", "wikipedia-es"
+        ]
+      }
+    },
+    "et": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "amazon-co-uk", "ddg", "wikipedia-et"
+        ]
+      }
+    },
+    "eu": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "elebila", "wikipedia-eu"
+        ]
+      }
+    },
+    "fa": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-fa"
+        ]
+      }
+    },
+    "ff": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-fr", "ddg", "wikipedia-fr"
+        ]
+      }
+    },
+    "fi": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "amazondotcom", "ddg", "wikipedia-fi"
+        ]
+      }
+    },
+    "fr-BE": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "qwant", "wikipedia-fr", "ebay-befr"
+        ]
+      }
+    },
+    "fr-CA": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-ca", "ddg", "wikipedia-fr", "ebay-ca"
+        ]
+      }
+    },
+    "fr-FR": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "qwant", "wikipedia-fr", "amazon-fr", "ebay-fr"
+        ]
+      }
+    },
+    "fr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "qwant", "wikipedia-fr"
+        ]
+      }
+    },
+    "fy-NL": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-fy-NL"
+        ]
+      }
+    },
+    "ga-IE": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "amazon-co-uk", "ddg", "wikipedia-ga-IE"
+        ]
+      }
+    },
+    "gd": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "faclair-beag", "wikipedia-gd"
+        ]
+      }
+    },
+    "gl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-gl"
+        ]
+      }
+    },
+    "gn": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-gn"
+        ]
+      }
+    },
+    "gu-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-gu"
+        ]
+      }
+    },
+    "he": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-he"
+        ]
+      }
+    },
+    "hi-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-hi"
+        ]
+      }
+    },
+    "hr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "wikipedia-hr"
+        ]
+      }
+    },
+    "hsb": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-de", "ddg", "wikipedia-hsb", "ebay-de"
+        ]
+      }
+    },
+    "hu": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "sztaki-en-hu", "vatera", "wikipedia-hu"
+        ]
+      }
+    },
+    "hy-AM": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-hy-AM"
+        ]
+      }
+    },
+    "ia": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-ia"
+        ]
+      }
+    },
+    "id": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-id"
+        ]
+      }
+    },
+    "is": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "leit-is", "wikipedia-is"
+        ]
+      }
+    },
+    "it": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-it", "amazon-it", "ebay-it"
+        ]
+      }
+    },
+    "ja": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "amazon-jp", "bing", "ddg", "wikipedia-ja", "yahoo-jp"
+        ]
+      }
+    },
+    "ka": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-ka"
+        ]
+      }
+    },
+    "kab": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-kab"
+        ]
+      }
+    },
+    "kk": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-kk"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-kk"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-kk"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-kk"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "bing", "ddg", "wikipedia-kk"
+        ]
+      }
+    },
+    "km": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-km"
+        ]
+      }
+    },
+    "kn": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-kn", "wiktionary-kn"
+        ]
+      }
+    },
+    "ko": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "danawa-kr", "daum-kr"
+        ]
+      }
+    },
+    "lij": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-it", "ddg", "wikipedia-lij", "ebay-it"
+        ]
+      }
+    },
+    "lo": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-lo"
+        ]
+      }
+    },
+    "lt": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-lt"
+        ]
+      }
+    },
+    "ltg": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-co-uk", "wikipedia-ltg"
+        ]
+      }
+    },
+    "lv": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "salidzinilv", "wikipedia-lv"
+        ]
+      }
+    },
+    "mai": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-hi"
+        ]
+      }
+    },
+    "meh": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-es"
+        ]
+      }
+    },
+    "mix": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-es"
+        ]
+      }
+    },
+    "ml": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-ml"
+        ]
+      }
+    },
+    "mr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "rediff", "wikipedia-mr"
+        ]
+      }
+    },
+    "ms": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-ms"
+        ]
+      }
+    },
+    "my": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-my"
+        ]
+      }
+    },
+    "nb-NO": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "gulesider-mobile-NO", "wikipedia-NO"
+        ]
+      }
+    },
+    "ne-NP": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-ne"
+        ]
+      }
+    },
+    "nl-NL": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-nl", "amazon-nl", "ebay-nl"
+        ]
+      }
+    },
+    "nl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-nl"
+        ]
+      }
+    },
+    "nn-NO": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "gulesider-mobile-NO", "wikipedia-NN"
+        ]
+      }
+    },
+    "oc": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-oc", "wiktionary-oc"
+        ]
+      }
+    },
+    "or": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-or", "wiktionary-or"
+        ]
+      }
+    },
+    "pa-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-pa"
+        ]
+      }
+    },
+    "pl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-pl", "ebay-pl"
+        ]
+      }
+    },
+    "pt-BR": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-pt"
+        ]
+      }
+    },
+    "pt-PT": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-pt"
+        ]
+      }
+    },
+    "rm": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "leo_ende_de", "pledarigrond", "wikipedia-rm"
+        ]
+      }
+    },
+    "ro": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-ro"
+        ]
+      }
+    },
+    "ru": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-ru", "yandex-ru"
+        ]
+      }
+    },
+    "sk": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "slovnik-sk", "wikipedia-sk"
+        ]
+      }
+    },
+    "sl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "ceneje", "odpiralni", "wikipedia-sl"
+        ]
+      }
+    },
+    "son": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "bing", "amazon-fr", "wikipedia-fr"
+        ]
+      }
+    },
+    "sq": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "wikipedia-sq"
+        ]
+      }
+    },
+    "sr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-sr"
+        ]
+      }
+    },
+    "sv-SE": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "prisjakt-sv-SE", "ddg", "wikipedia-sv-SE", "amazon-se", "ebay-ch"
+        ]
+      }
+    },
+    "ta": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-ta", "wiktionary-ta"
+        ]
+      }
+    },
+    "te": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-te", "wiktionary-te"
+        ]
+      }
+    },
+    "th": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-th"
+        ]
+      }
+    },
+    "tl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg"
+        ]
+      }
+    },
+    "tr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-tr"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-tr"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-tr"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-tr"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-com-nocodes", "ddg", "wikipedia-tr"
+        ]
+      }
+    },
+    "trs": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-es"
+        ]
+      }
+    },
+    "uk": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "ddg", "wikipedia-uk"
+        ]
+      }
+    },
+    "ur": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazon-in", "ddg", "wikipedia-ur"
+        ]
+      }
+    },
+    "uz": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "amazondotcom", "ddg", "wikipedia-uz"
+        ]
+      }
+    },
+    "vi": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "coccoc", "ddg", "wikipedia-vi"
+        ]
+      }
+    },
+    "wo": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-wo"
+        ]
+      }
+    },
+    "xh": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia"
+        ]
+      }
+    },
+    "zam": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-es"
+        ]
+      }
+    },
+    "zh-CN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "baidu", "bing", "ddg", "wikipedia-zh-CN"
+        ]
+      },
+      "CN": {
+        "searchDefault": "百度"
+      }
+    },
+    "zh-TW": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google-b-m", "bing", "ddg", "wikipedia-zh-TW"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This should of course be done upstream, but considering that the change won't get into Wolvic until they release and we upgrade the Android Component version, let's just make a copy of that from upstream and do our customization locally.

Resolves #922