### PR TITLE
[Chromium] Fix a crash when hiding keyboard

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
@@ -53,7 +53,8 @@ public class TextInputImpl implements WTextInput {
         @Override
         public boolean hideSoftInputFromWindow(
                 IBinder windowToken, int flags, ResultReceiver resultReceiver) {
-            mDelegate.hideSoftInput(mSession);
+            if (mDelegate != null)
+                mDelegate.hideSoftInput(mSession);
             return false;
         }
 


### PR DESCRIPTION
The TextInputImpl object creates an InputMethodManagerWrapper that notifies the delegate of TextInputImpl. That wrapper cannot be reset once set.

During session destruction, as when going back in browsing history for example, one of the first things happening is the disconnection of session delegates, meaning that the delegate of TextInputImpl will become null. This means that as soon as the wrapper is called from Chromium side, we'll get an insta crash because the delegate is no longer there.

We can avoid that by adding a null check for the delegate. Ideally we should be able to tell chromium not to use that wrapper anymore but it is not possible.

Fixes #916