### PR TITLE
Specific sufix for the remote envs's payload zip

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
@@ -223,10 +223,15 @@ public class EnvironmentUtils {
     @Nullable
     public static String getEnvironmentPayload(Environment env) {
         String payload = env.getPayload();
-        if (!DeviceType.isOculusBuild())
+        String colorSpace = "_rgb", format = "_ktx"; // default configuration
+        if (DeviceType.isOculusBuild())
+            colorSpace = "_srgb";
+        else if (DeviceType.isPicoXR())
+            format = "_jpg";
+        else
             return payload;
         int at = payload.lastIndexOf(".");
-        return payload.substring(0, at) + "_srgb" + payload.substring(at);
+        return payload.substring(0, at) + format + colorSpace + payload.substring(at);
     }
 
     /**


### PR DESCRIPTION
We need to consider devices with diffrerent capabilities in terms of color spaces and compression formats.

Ideally we want the proos.json to be as simple and device agnostic as  possible, so it should the app the one deciding which zip should be used for each device.