### PR TITLE
Fix a crash when drawing hands before updating mesh in HandMeshRenderSkinned

### DIFF
--- a/app/src/main/cpp/HandMeshRenderer.cpp
+++ b/app/src/main/cpp/HandMeshRenderer.cpp
@@ -543,6 +543,10 @@ void HandMeshRendererSkinned::Draw(const uint32_t aControllerIndex, const vrb::C
     const HandMeshGLState& state = m.handGLState.at(aControllerIndex);
     auto& mesh = m.handMeshState.at(aControllerIndex);
 
+    // Bail if we don't have valid hand joints info (e.g, from a previous call to Update())
+    if (mesh.jointTransforms.size() == 0)
+        return;
+
     assert(m.program);
     VRB_GL_CHECK(glUseProgram(m.program));
 


### PR DESCRIPTION
The order of calls to Update() and Draw() on a hand mesh renderer is controller by BrowserWorld, and is not deterministic. To protect against trying to Draw() before Update() has been called, we bail early on the Draw() call if there are no hand joint transforms.

Fixes https://github.com/Igalia/wolvic/issues/934
