### PR TITLE
Properly emulate controller primary action with hand tracking

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -672,7 +672,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     bool triggerButtonPressed = indexPinching && !systemGestureDetected && hasAim;
     delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_TRIGGER,
                             device::kImmersiveButtonTrigger, triggerButtonPressed,
-                            triggerButtonPressed, 1.0);
+                            pinchFactor > 0, pinchFactor);
     if (isHandActionEnabled) {
         delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_APP, -1, indexPinching, indexPinching, 1.0);
     } else if (hasAim) {


### PR DESCRIPTION
So far the value of the primary action button when emulating the controller was permanently set to 1.0. That's wrong, we should use the computed distance between the pinching fingers instead.

Apart from that we're also fixing the value of touched. We should consider that it's "touched" whenever the pinching action starts.

Fixes #480