### PR TITLE
[Chromium] Enable logging

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WResult;
 import com.igalia.wolvic.browser.api.WRuntime;
@@ -169,6 +170,8 @@ public class RuntimeImpl implements WRuntime {
         PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX);
 
         CommandLine.init(new String[] {});
+        if (BuildConfig.DEBUG)
+            CommandLine.getInstance().appendSwitchWithValue("enable-logging", "stderr");
         DeviceUtils.addDeviceSpecificUserAgentSwitch();
         LibraryLoader.getInstance().ensureInitialized();
 


### PR DESCRIPTION
Enabling chromium logging in debug builds. At this stage it's very useful. We can restrict it even more (by using "vmodule") but so far I was not able to successfully enable verbose logging (VLOG & DVLOG). Messages created with LOG() should be visible.