### PR TITLE
[Chromium] Set WebGL MSAA level on startup

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -159,6 +159,13 @@ public class RuntimeImpl implements WRuntime {
         mCallbacks.remove(callback);
     }
 
+    private void setupWebGLMSAA() {
+        String MSAALevelAsString = Integer.toString(mRuntimeSettings.getGlMsaaLevel());
+        if (mRuntimeSettings.getGlMsaaLevel() == 0)
+            CommandLine.getInstance().appendSwitchWithValue("webgl-antialiasing-mode", "none");
+        CommandLine.getInstance().appendSwitchWithValue("webgl-msaa-sample-count", MSAALevelAsString);
+    }
+
     private void initBrowserProcess(Context context) {
         assert isBrowserProcess() == true;
 
@@ -172,6 +179,7 @@ public class RuntimeImpl implements WRuntime {
         CommandLine.init(new String[] {});
         if (BuildConfig.DEBUG)
             CommandLine.getInstance().appendSwitchWithValue("enable-logging", "stderr");
+        setupWebGLMSAA();
         DeviceUtils.addDeviceSpecificUserAgentSwitch();
         LibraryLoader.getInstance().ensureInitialized();
 


### PR DESCRIPTION
Wolvic allows users to set the WebGL MSAA level (antialiasing). This setting was properly set on Gecko but not in Chromium. Up to a couple of new extra command line switches could be passed to the rendered from now on.