### PR TITLE
Use red color when no search result for find in page

### DIFF
--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -217,7 +217,9 @@
                 android:layout_height="56dp"
                 android:padding="4dp"
                 app:visibleGone="@{viewmodel.isFindInPage}"
-                app:findInPageButtonsTint="@color/white" />
+                app:findInPageButtonsTint="@color/white"
+                app:findInPageResultCountTextColor="@color/white"
+                app:findInPageNoMatchesTextColor="@color/fire"/>
 
             <LinearLayout
                 android:id="@+id/endButtonsLayout"


### PR DESCRIPTION
Small improvement

To keep consistency with the Firefox Android

![com igalia wolvic-20230905-175752](https://github.com/Igalia/wolvic/assets/43995067/aae6951a-e5fd-4924-b2ea-64dfe8271f03)
![Screenshot_2023-09-05-17-00-03-774_org mozilla fi](https://github.com/Igalia/wolvic/assets/43995067/01de199f-03f7-4f51-a4a9-9de750e8251b)
