### PR TITLE
[Chromium] SessionFinder: fix a startup crash

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
@@ -258,7 +258,10 @@ public class NavigationURLBar extends FrameLayout {
 
     private void bindFindInPageSession() {
         if (mSession == null) { return; }
-        mFindInPage.bind(mSession.getWSession().getSessionFinder());
+        WSession.SessionFinder finder = mSession.getWSession().getSessionFinder();
+        // FIXME: finder should be NonNull but we haven't implemented it for Chromium yet.
+        if (finder == null) { return; };
+        mFindInPage.bind(finder);
         mFindInPage.start();
     }
 


### PR DESCRIPTION
The recently added SessionFinder that looks for text in the page does not have implementation for the chromium backend. The current code does not handle well the case of finder being a null pointer as it is not supposed to happen. Added a temporary workaround to keep the chromium port working until we don't implement it.