### PR TITLE
New approach to handle remote environments 

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/Download.java
@@ -160,6 +160,10 @@ public class Download {
         return mLastModified;
     }
 
+    public boolean inProgress() {
+        return mStatus == RUNNING || mStatus == PAUSED || mStatus == PENDING;
+    }
+
     public double getProgress() {
         if (mSizeBytes != -1) {
             return mDownloadedBytes*100.0/mSizeBytes;

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadJob.java
@@ -153,6 +153,10 @@ public class DownloadJob {
         return mOutputPath;
     }
 
+    public void setOutputPath(String outputPath) {
+        mOutputPath = outputPath;
+    }
+
     @Nullable
     public InputStream getInputStream() {
         return inputStream;

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -326,7 +326,11 @@ public class DownloadsManager {
         }
         if (c.moveToFirst()) {
             notifyDownloadsUpdate();
-            notifyDownloadCompleted(Download.from(c));
+            Download download = Download.from(c);
+            if (download.getStatus() == Download.SUCCESSFUL)
+                notifyDownloadCompleted(download);
+            else
+                notifyDownloadError("Failed to download URI, missing input stream: ", download.getUri());
         }
         c.close();
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -735,10 +735,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
     @Override
     public void onDownloadsUpdate(@NonNull List<Download> downloads) {
-        long inProgressNum = downloads.stream().filter(item ->
-                item.getStatus() == Download.RUNNING ||
-                        item.getStatus() == Download.PAUSED ||
-                        item.getStatus() == Download.PENDING).count();
+        long inProgressNum = downloads.stream().filter(item -> item.inProgress()).count();
         mTrayViewModel.setDownloadsNumber((int)inProgressNum);
         if (inProgressNum == 0) {
             mBinding.libraryButton.setLevel(0);

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
@@ -101,6 +101,7 @@ public class EnvironmentUtils {
      * Check wether or not an external environment is ready to be used. Checks is the ouput directory exists
      * and if it contains 6 items. We make an assumption that those items are the right images and that they
      * follow the naming convention.
+     * right images and that they follow the naming convention.
      * @param context An activity context.
      * @param envId The environment id. This maps to the Remote properties JSON "value" environment property.
      * @return true is the environment is ready, false otherwise
@@ -215,23 +216,20 @@ public class EnvironmentUtils {
     }
 
     /**
-     * Returns the URL to the environment's payload, with the SRGB suffix for the devices requiring this
-     * compressed texture format.
+     * Returns the URL to the environment's payload, with the '_alt' suffix for the devices requiring an
+     * alternative compressed texture format (only JPG and PNG are allowed as alternative to KTX).
      * @param env An Environment data structure
      * @return The appropriated URL to the environment's payload .
      */
     @Nullable
     public static String getEnvironmentPayload(Environment env) {
-        String payload = env.getPayload();
-        String colorSpace = "_rgb", format = "_ktx"; // default configuration
-        if (DeviceType.isOculusBuild())
-            colorSpace = "_srgb";
-        else if (DeviceType.isPicoXR())
-            format = "_jpg";
-        else
-            return payload;
-        int at = payload.lastIndexOf(".");
-        return payload.substring(0, at) + format + colorSpace + payload.substring(at);
+        if (DeviceType.isPicoXR() || DeviceType.isOculusBuild()) {
+            String payload = env.getPayload();
+            String format = DeviceType.isOculusBuild() ? "_ktx" : "_misc"; // PicoXR doesn't support 'ktx'
+            int at = payload.lastIndexOf(".");
+            return payload.substring(0, at) + format + "_srgb" + payload.substring(at);
+        }
+        return env.getPayload(); // default is 'rgb' and 'ktx'
     }
 
     /**

--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentsManager.java
@@ -1,12 +1,12 @@
 package com.igalia.wolvic.utils;
 
-import android.app.DownloadManager;
 import android.content.Context;
 import android.content.SharedPreferences;
-import androidx.preference.PreferenceManager;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
@@ -17,7 +17,6 @@ import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.zip.UnzipCallback;
 import com.igalia.wolvic.utils.zip.UnzipTask;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +26,8 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
         default void onEnvironmentSetSuccess(@NonNull String envId) {}
         default void onEnvironmentSetError(@NonNull String error) {}
     }
+
+    static final String LOGTAG = SystemUtils.createLogtag(EnvironmentsManager.class);
 
     private WidgetManagerDelegate mApplicationDelegate;
     private Context mContext;
@@ -81,7 +82,6 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
                 SettingsStore.getInstance(mContext).setEnvironment(envId);
                 mListeners.forEach(environmentListener -> environmentListener.onEnvironmentSetSuccess(envId));
                 mApplicationDelegate.updateEnvironment();
-
             } else {
                 downloadEnvironment(envId);
             }
@@ -116,19 +116,29 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
         final Environment environment = EnvironmentUtils.getExternalEnvironmentById(mContext, envId);
         final String payload = EnvironmentUtils.getEnvironmentPayload(environment);
         if (environment != null) {
-            // Check if the env is being downloaded
-            boolean isDownloading = mDownloadManager.getDownloads().stream()
-                    .filter(item ->
-                            item.getStatus() == DownloadManager.STATUS_RUNNING &&
-                                    item.getStatus() == DownloadManager.STATUS_PAUSED &&
-                                    item.getStatus() == DownloadManager.STATUS_PENDING &&
-                                    item.getUri().equals(payload))
-                    .findFirst().orElse(null) != null;
+            // Check if the env is being downloaded or has been already downloaded.
+            // The download item will be removed in 2 situations:
+            //   1- the user selects another env before the download is completed (see setOrDownloadEnvironment)
+            //   2- when the unzip task is completed successfully.
+            Download envItem = mDownloadManager.getDownloads().stream()
+                    .filter(item -> item.getUri().equals(payload))
+                    .findFirst().orElse(null);
 
-            if (!isDownloading) {
-                // If the env is not being downloaded, start downloading it
+            if (envItem == null) {
+                // If the env has not been downloaded, start downloading it
+                String outputPath = mContext.getExternalFilesDir(null).getAbsolutePath();
                 DownloadJob job = DownloadJob.create(payload);
+                job.setOutputPath(outputPath + "/" + job.getFilename());
                 mDownloadManager.startDownload(job);
+            } else if (envItem.getStatus() == Download.SUCCESSFUL) {
+                Log.w(LOGTAG, "The unzip task failed for unknown reasons");
+                mEnvDownloadId = -1;
+                mDownloadManager.removeDownload(envItem.getId(), true);
+            } else  {
+                // The 'downloadEnvironment' method is called either by 'setOrDownloadEnvironment' when the user changes the selected
+                // option in the radiobuttons widget (this cause the download item to be removed) or by the 'setOrDownloadEnvironment'
+                // method during the java initialization invoked by the VRBrowser native code.
+                Log.w(LOGTAG, "Download is still in progress; we shouldn't reach this code.");
             }
         }
     }
@@ -146,12 +156,15 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
 
     @Override
     public void onDownloadCompleted(@NonNull Download download) {
+        assert download.getStatus() == Download.SUCCESSFUL;
+        if (download.getOutputFile() == null) {
+            Log.w(LOGTAG, "Failed to download URI, missing input stream: " + download.getUri());
+            return;
+        }
         Environment env = EnvironmentUtils.getExternalEnvironmentByPayload(mContext, download.getUri());
         if (env != null) {
             mEnvDownloadId = -1;
 
-            // We don't want the download to be left in the downloads list, so we just remove it when the download is done.
-            mDownloadManager.removeDownload(download.getId(), false);
             UnzipTask unzip = new UnzipTask(mContext);
             unzip.addListener(new UnzipCallback() {
                 @Override
@@ -166,14 +179,14 @@ public class EnvironmentsManager implements DownloadsManager.DownloadsListener, 
 
                 @Override
                 public void onUnzipFinish(@NonNull String zipFile, @NonNull String outputPath) {
-                    // Delete the zip file when the unzipping is done.
-                    File file = new File(zipFile);
-                    file.delete();
+                    // We don't want the download to be left in the downloads list, but we wait until the unzip task is completed to remove it.
+                    mDownloadManager.removeDownload(download.getId(), true);
 
                     // the environment is ready, call native to update the current env.
                     SettingsStore.getInstance(mContext).setEnvironment(env.getValue());
                     mListeners.forEach(environmentListener -> environmentListener.onEnvironmentSetSuccess(env.getValue()));
                     mApplicationDelegate.updateEnvironment();
+
                 }
 
                 @Override

--- a/app/src/common/shared/com/igalia/wolvic/utils/zip/UnzipTask.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/zip/UnzipTask.java
@@ -72,7 +72,7 @@ public class UnzipTask {
             }
 
             if (!mUnzipMonitor.isCancelAllTasks()) {
-                notifyFinish(mZipPath);
+                notifyFinish(outputPath);
 
             } else {
                 notifyCancelled();

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1883,18 +1883,13 @@ BrowserWorld::CreateSkyBox(const std::string& aBasePath, const std::string& aExt
   // meantime.
   const std::string extension = aExtension.empty() ? ".png" : aExtension;
   GLenum glFormat = GL_SRGB8_ALPHA8;
+#elif defined(OPENXR) && defined(OCULUSVR)
+  const std::string extension = aExtension.empty() ? ".ktx" : aExtension;
+  GLenum glFormat = extension == ".ktx" ? GL_COMPRESSED_SRGB8_ETC2 : GL_SRGB8_ALPHA8;
 #else
   const std::string extension = aExtension.empty() ? ".ktx" : aExtension;
-  GLenum glFormat = GL_RGBA8;
+  GLenum glFormat = extension == ".ktx" ? GL_COMPRESSED_RGB8_ETC2 : GL_RGBA8;
 #endif
-
-  if (extension == ".ktx") {
-#if defined(OPENXR) && defined(OCULUSVR)
-    glFormat =  GL_COMPRESSED_SRGB8_ETC2;
-#else
-    glFormat =  GL_COMPRESSED_RGB8_ETC2;
-#endif
-  }
   const int32_t size = 1024;
   if (m.skybox) {
     m.skybox->SetVisible(true);

--- a/app/src/main/cpp/Skybox.cpp
+++ b/app/src/main/cpp/Skybox.cpp
@@ -253,10 +253,18 @@ FileDoesNotExist (const std::string& aName) {
 
 std::string
 Skybox::ValidateCustomSkyboxAndFindFileExtension(const std::string& aBasePath) {
+#if defined(PICOXR) || (defined(OPENXR) && defined(OCULUSVR))
+  const std::string& colorSpace = "_srgb";
+#else
+  const std::string& colorSpace = "";
+#endif
+  auto path = [&](const std::string& name, const std::string& extension) {
+      return aBasePath + "/" + name + colorSpace + extension;
+  };
   for (const std::string& ext: sFileExt) {
      int32_t fileCount = 0;
      for (const std::string& baseName: sBaseNameList) {
-       const std::string file = aBasePath + "/" + baseName + ext;
+       const std::string file = path(baseName, ext);
        if (FileDoesNotExist(file)) {
          if (fileCount > 0) {
            VRB_ERROR("Custom skybox file missing: %s", file.c_str());


### PR DESCRIPTION
The code that validates and figures our the extension of the remote envs files was not considering that some may have the "srgb_ suffix. This PR fixes that, allowing Wolvic to auto-detect the format to be used. We are also setting the correct colorspace for the Oculus devices in case of needing to handle a skybox texture not using 'ktx' as compression format.

Finally, this PR introduces some changes in the environments download logic to make it more robust, ensuring the downloaded file is removed only after the ZIP is extracted, or in case of an unexpected error in the intermediate steps.

