### PR TITLE
Open the feedback form in a new window

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -277,7 +277,12 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
         mBinding.navigationBarNavigation.userFeedbackButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
-            mWidgetManager.openNewTabForeground(getResources().getString(R.string.feedback_link, BuildConfig.VERSION_NAME, DeviceType.getType()));
+            String uri = getResources().getString(R.string.feedback_link, BuildConfig.VERSION_NAME, DeviceType.getType());
+            if (mWidgetManager.canOpenNewWindow()) {
+                mWidgetManager.openNewWindow(uri);
+            } else {
+                mWidgetManager.openNewTabForeground(uri);
+            }
         });
 
         mBinding.navigationBarNavigation.desktopModeButton.setOnClickListener(view -> {


### PR DESCRIPTION
Since we want to stop interrupting the video playing, we now open the feedback form web page in a new window, and if we already have the maximum possible window, we again open the feedback form in a new tab.

Another way to resolve #940