### PR TITLE
Some minor improvements for Find in page

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
@@ -270,6 +270,7 @@ public class NavigationURLBar extends FrameLayout {
             mViewModel.setIsFocused(false);
             mViewModel.getIsLoading().removeObserver(mIsLoadingObserver);
             mViewModel.getIsBookmarked().removeObserver(mIsBookmarkedObserver);
+            mViewModel.getIsFindInPage().removeObserver(mIsFindInPageObserver);
             mViewModel = null;
         }
     }
@@ -284,6 +285,7 @@ public class NavigationURLBar extends FrameLayout {
 
         mViewModel.getIsLoading().observe((VRBrowserActivity)getContext(), mIsLoadingObserver);
         mViewModel.getIsBookmarked().observe((VRBrowserActivity)getContext(), mIsBookmarkedObserver);
+        mViewModel.getIsFindInPage().observe((VRBrowserActivity)getContext(), mIsFindInPageObserver);
     }
 
     public void setSession(Session session) {
@@ -347,6 +349,14 @@ public class NavigationURLBar extends FrameLayout {
     };
 
     private Observer<ObservableBoolean> mIsBookmarkedObserver = aBoolean -> mBinding.bookmarkButton.clearFocus();
+
+    private Observer<ObservableBoolean> mIsFindInPageObserver = aBoolean -> {
+        if (aBoolean.get()) {
+            mBinding.findInPage.focus();
+        } else {
+            mBinding.findInPage.clear();
+        }
+    };
 
     public String getText() {
         return mBinding.urlEditText.getText().toString();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1285,6 +1285,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             @Override
             public void onFindInPage() {
                 hideMenu();
+                mAttachedWindow.hidePanel();
 
                 mViewModel.setIsFindInPage(true);
             }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -519,6 +519,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 setView(mLibrary, switchSurface);
                 mLibrary.selectPanel(panelType);
                 mLibrary.onShow();
+                mViewModel.setIsFindInPage(false);
                 mViewModel.setIsPanelVisible(true);
                 if (mRestoreFirstPaint == null && !isFirstPaintReady() && (mFirstDrawCallback != null) && (mSurface != null)) {
                     final Runnable firstDrawCallback = mFirstDrawCallback;


### PR DESCRIPTION
- Stop having findInPage and Panel opened at same time

  We shouldn't let user feel that we can search content in the library page through findInPage. So we close findInPage when we open the Library, and we close the panel when we open findInPage in the hamburger menu.

  We shall pay attention to this as well in https://github.com/Igalia/wolvic/pull/881 once this is merged

- Auto focus when findInPage opened; Clear text when hidden

We may want to keep findInPage opened even if the page changes (such as reloading/navigating to new page), to keep consistency with other browsers like Chrome.