### PR TITLE
Allow open new page without interrupting video playing

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1944,6 +1944,35 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mWindows.addTab(mWindows.getFocusedWindow(), uri);
     }
 
+    private boolean openNewTabNoInterrupt(@NonNull WindowWidget window, @NonNull String uri) {
+        if (window.getSession() == null || window.getSession().getActiveVideo() != null) {
+            return false;
+        }
+
+        mWindows.addTab(window, uri);
+        mWindows.focusWindow(window);
+        return true;
+    }
+    @Override
+    public void openNewPageNoInterrupt(@NonNull String uri) {
+        if (openNewTabNoInterrupt(mWindows.getFocusedWindow(), uri)) { return; }
+
+        // If we have video playing in current window, ensure we don't open a new tab
+        // in a window that has active video
+        if (mWindows.getWindowsCount() > 1) {
+            for (WindowWidget window : mWindows.getCurrentWindows()) {
+                if (openNewTabNoInterrupt(window, uri)) { return; }
+            }
+        }
+        // All the current opened Windows have video playing, so we have to open uri in a new window.
+        // If we have maximum window number, then open the uri as a new tab in current window.
+        if (canOpenNewWindow()) {
+            openNewWindow(uri);
+        } else {
+            openNewTabForeground(uri);
+        }
+    }
+
     @Override
     public WindowWidget getFocusedWindow() {
         return mWindows.getFocusedWindow();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -278,11 +278,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mBinding.navigationBarNavigation.userFeedbackButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
             String uri = getResources().getString(R.string.feedback_link, BuildConfig.VERSION_NAME, DeviceType.getType());
-            if (mWidgetManager.canOpenNewWindow()) {
-                mWidgetManager.openNewWindow(uri);
-            } else {
-                mWidgetManager.openNewTabForeground(uri);
-            }
+            mWidgetManager.openNewPageNoInterrupt(uri);
         });
 
         mBinding.navigationBarNavigation.desktopModeButton.setOnClickListener(view -> {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -107,6 +107,7 @@ public interface WidgetManagerDelegate {
     void openNewWindow(String uri);
     void openNewTab(@NonNull String uri);
     void openNewTabForeground(@NonNull String uri);
+    void openNewPageNoInterrupt(@NonNull String uri);
     WindowWidget getFocusedWindow();
     TrayWidget getTray();
     NavigationBarWidget getNavigationBar();


### PR DESCRIPTION
Continue addressing #940

Related to #958

If there's no video playing in the current window, we still open the new page in a new tab.

If we have video playing in current window, ensure we don't open a new tab in a window that has active video, but open it in the Window that has no video playing.

If all the current opened Windows have video playing, we have to open uri in a new window. If we have maximum window number, then open the uri as a new tab in current window.
