### PR TITLE
Fix Youtube captions

### DIFF
--- a/app/src/main/assets/extensions/fxr_youtube/background.js
+++ b/app/src/main/assets/extensions/fxr_youtube/background.js
@@ -33,6 +33,12 @@ function redirect(details) {
     })
 
     if (found) {
+        // We should not add the app param to the timedtext requests (captions),
+        // otherwise they will fail.
+        if (uri.href.includes(".com/api/timedtext?")) {
+            return { };
+        }
+
         if (!uri.searchParams.has("app")) {
             uri.searchParams.append('app', 'desktop');
             return { redirectUrl: uri.href };


### PR DESCRIPTION
We shouldn't add/modify the Youtube timedtext API parameters (for captions), otherwise, it will stop working.

Resolve #717

Simple fix but takes a lot of time when debugging.