### PR TITLE
[PicoXR] Request legacy external storage

### DIFF
--- a/app/src/picoxr/AndroidManifest.xml
+++ b/app/src/picoxr/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <!-- Required in Pico platform to avoid a crash during app resuming -->
     <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="replace"/>
 
-    <application>
+    <application android:requestLegacyExternalStorage="true">
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
             <intent-filter>


### PR DESCRIPTION
This allows Wolvic to have read access to the downloads. They were properly downloaded to the system downloads folder but could not be read by Wolvic in Pico devices. By requesting this legacy permission it works.