### PR TITLE
Fix WiFi Icon when starting Wolvic with no WiFi

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -143,6 +143,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
         mWifiSSID = getContext().getString(R.string.tray_wifi_no_connection);
 
         updateTime();
+        OnConnectivityChanged(ConnectivityReceiver.isNetworkAvailable(getContext()));
 
         if (DeviceType.getType() == DeviceType.OculusQuest) {
             mTrayViewModel.setLeftControllerIcon(R.drawable.ic_icon_statusbar_leftcontroller);


### PR DESCRIPTION
Check the WiFi status on start as well.

Since onConnectivityChange will only be called when there is a change in network status, and WiFi icon is assumed to be connected by default. We should manually check the network status when starts.

Resolve #964