### PR TITLE
[OpenXR] Cleanup swapchain destruction

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -83,7 +83,6 @@ struct DeviceDelegateOpenXR::State {
   OpenXRLayerCubePtr cubeLayer;
   OpenXRLayerEquirectPtr equirectLayer;
   std::vector<OpenXRLayerPtr> uiLayers;
-  OpenXRSwapChainPtr crearColorSwapChain;
   device::RenderMode renderMode = device::RenderMode::StandAlone;
   vrb::CameraEyePtr cameras[2];
   FramePrediction framePrediction = FramePrediction::NO_FRAME_AHEAD;
@@ -678,15 +677,12 @@ struct DeviceDelegateOpenXR::State {
   }
 
   void Shutdown() {
-    // Release swapChains
-    for (OpenXRSwapChainPtr swapChain: eyeSwapChains) {
-      swapChain->Destroy();
-    }
-
-    if (passthroughLayer != nullptr) {
-        passthroughLayer->Destroy();
-        passthroughLayer = nullptr;
-    }
+    // Release swapChains before destroying the instance. Note that layers are backed by swapchains.
+    eyeSwapChains.clear();
+    uiLayers.clear();
+    cubeLayer.reset();
+    equirectLayer.reset();
+    passthroughLayer.reset();
 
     // Release spaces
     if (viewSpace != XR_NULL_HANDLE) {


### PR DESCRIPTION
Swapchains must be destroyed before destroying the XrInstance. We can find them in the views and in multiple UI layers, including quads, cylinders, skybox or passthrough layers. We were relying on smart pointers to properly destruct the layers. That was happening, however it was done too late, i.e., after destroying the XrInstance.

That's why we explicitly have to destroy the layers before destroying the XrInstance so that they in turn are able to destroy the swapchains on time.

This fixes a long lasting error on app shutdown:
Error [GENERAL | xrDestroySwapchain | OpenXR-Loader] : No active XrInstance handle.

Fixes #546