### PR TITLE
[NoAPI] Enable on screen rendering

### DIFF
--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
@@ -218,6 +218,7 @@ DeviceDelegateNoAPI::StartFrame(const FramePrediction aPrediction) {
   VRB_GL_CHECK(glEnable(GL_CULL_FACE));
   VRB_GL_CHECK(glEnable(GL_BLEND));
   VRB_GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+  mShouldRender = true;
   if (m.controller) {
     vrb::RenderContextPtr context = m.context.lock();
     if (context) {


### PR DESCRIPTION
We should set the mShouldRender attribute to true if we really want to render to the screen.

Fixes #619