### PR TITLE
Add a variant for Pico in mainland China

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -383,8 +383,8 @@ android {
         if (abi == 'x64')
             variant.setIgnore(platform != 'noapi' && platform !='aosp');
 
-        // Create variants for China only for HVR platforms
-        if (store == 'mainlandChina' && !platform.startsWith('hvr'))
+        // Create variants for China only for HVR and Pico platforms
+        if (store == 'mainlandChina' && !(platform.startsWith('hvr') || platform.startsWith('picoxr')))
             variant.setIgnore(true);
 
         // Create variants for chromium/webkit, only when they are available


### PR DESCRIPTION
We create variants for mainland China for the HVR and Pico platforms.