### PR TITLE
Upgrade R8 to version 8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath "org.mozilla.telemetry:glean-gradle-plugin:53.2.0"
         classpath "com.android.tools.build:gradle:$versions.android_gradle_plugin"
+        classpath 'com.android.tools:r8:8.2.33'
         classpath "$deps.kotlin.plugin"
         classpath 'com.huawei.agconnect:agcp:1.6.5.300'
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -205,5 +205,6 @@ def addRepos(RepositoryHandler handler) {
     handler.mavenCentral()
     handler.maven { url 'https://maven.mozilla.org/maven2' }
     handler.maven { url 'https://developer.huawei.com/repo/' }
+    handler.maven { url 'https://storage.googleapis.com/r8-releases/raw' }
 }
 ext.addRepos = this.&addRepos


### PR DESCRIPTION
R8 is the tool used to minimize (shrink + optimize) the Java code. We normally just run it for release packages as it slows down the build significantly. Whenever the Chromium backend is used, that minimization was failing because R8 was unable to parse some proguard rules provided by Chromium.

The problem is that the code that parses those rules was added in R8 8.2. The latest available version in the maven repositories we use is 8.1, so we have to add a new repo to get that.