### PR TITLE
Enable custom URIs on Meta

### DIFF
--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -51,6 +51,15 @@
                 <category android:name="android.intent.category.INFO" />
                 <category android:name="com.oculus.intent.category.VR" android:value="vr_only"/>
             </intent-filter>
+            <!-- Used for the special wolvic:// links -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="wolvic"
+                    android:host="com.igalia.wolvic" />
+            </intent-filter>
             <!--
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
This PR enables support on Meta for custom URIs that start with `wolvic://com.igalia.wolvic`

This functionality was accidentally removed on Meta.

It can be tested from the command line with:

    adb shell am start -a android.intent.action.VIEW -d  "wolvic://com.igalia.wolvic/?url=wikipedia.org"