### PR TITLE
Cancel find in page on navigation

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1843,6 +1843,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.setIsMediaAvailable(false);
         mViewModel.setIsMediaPlaying(false);
         mViewModel.setIsWebApp(false);
+        mViewModel.setIsFindInPage(false);
 
         if (StringUtils.isEmpty(url)) {
             mViewModel.setIsBookmarked(false);


### PR DESCRIPTION
When the user clicks on a link on the page, we cancel the ongoing Find in Page.