### PR TITLE
[OpenXR] Use XR_FB_hand_tracking_aim to get trigger pinch status and factor on Quest

### DIFF
--- a/app/src/openxr/cpp/OpenXRGestureManager.h
+++ b/app/src/openxr/cpp/OpenXRGestureManager.h
@@ -23,9 +23,13 @@ virtual void populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLoc
 virtual bool hasAim() const = 0;
 virtual XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const = 0;
 virtual bool systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const = 0;
+virtual void getTriggerPinchStatusAndFactor(const HandJointsArray& handJoints, bool& isPinching, double& pinchFactor);
 
 protected:
 bool palmFacesHead(const vrb::Matrix& palm, const vrb::Matrix& head) const;
+
+private:
+double mSmoothIndexThumbDistance { 0 };
 };
 
 class OpenXRGestureManagerFBHandTrackingAim : public OpenXRGestureManager {
@@ -34,6 +38,7 @@ void populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) 
 bool hasAim() const override;
 XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
 bool systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const override;
+void getTriggerPinchStatusAndFactor(const HandJointsArray& handJoints, bool& isPinching, double& pinchFactor) override;
 
 XrHandTrackingAimStateFB mFBAimState;
 };

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -72,7 +72,6 @@ private:
     HandJointsArray mHandJoints;
     bool mHasHandJoints { false };
     bool mSupportsFBHandTrackingAim { false };
-    double mSmoothIndexThumbDistance { 0 };
     OpenXRGesturePtr mGestureManager;
 
     struct HandMeshMSFT {


### PR DESCRIPTION
We are currently using our own algorithm to detect trigger button state and pinching factor (a measure for distance between thumb and index finger-tips) when in hand-tracking mode. We are using this for all devices.

However, on Quest where XR_FB_hand_tracking_aim is supported, we can leverage that extension instead. Note that Pico also supports the extension, but unfortunately it doesn't give right values for pinching status and strength.

This is specially important now for Quest, where a recent system upgrade made the runtime hand-tracking more sensitive and our algorithm started detecting repeated button trigger (pinches). Using the extension data fixes these issues and is more future proof on these platforms.

As a bonus from this change, we move the pinch status and factor calculation code to the GestureManager.