### PR TITLE
[Chromium] Add null checks for TextInput delegate

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
@@ -31,14 +31,16 @@ public class TextInputImpl implements WTextInput {
         public void restartInput(View view) {
             // TODO : Chromium doesn't have an interface for the restarting reason, and we would
             //        consider to extend parameters if necessary.
-            mDelegate.restartInput(mSession, WSession.TextInputDelegate.RESTART_REASON_FOCUS);
+            if (mDelegate != null)
+                mDelegate.restartInput(mSession, WSession.TextInputDelegate.RESTART_REASON_FOCUS);
         }
 
         @Override
         public void showSoftInput(final View view, int flags, ResultReceiver resultReceiver) {
             EditorInfo outAttrs = new EditorInfo();
             view.onCreateInputConnection(outAttrs);
-            mDelegate.showSoftInput(mSession);
+            if (mDelegate != null)
+                mDelegate.showSoftInput(mSession);
 
             // We don't take content space for the keyboard, and we report back to the ImeAdapter
             // that the keyboard was always showing.
@@ -67,12 +69,15 @@ public class TextInputImpl implements WTextInput {
 
         @Override
         public void updateCursorAnchorInfo(View view, CursorAnchorInfo cursorAnchorInfo) {
-            mDelegate.updateCursorAnchorInfo(mSession, cursorAnchorInfo);
+            if (mDelegate != null)
+                mDelegate.updateCursorAnchorInfo(mSession, cursorAnchorInfo);
         }
 
         @Override
         public void updateExtractedText(
                 View view, int token, android.view.inputmethod.ExtractedText text) {
+            if (mDelegate == null)
+                return;
             ExtractedTextRequest request = new ExtractedTextRequest();
             request.token = token;
             mDelegate.updateExtractedText(mSession, request, text);


### PR DESCRIPTION
This is the exact same scenario as the one described in here https://github.com/Igalia/wolvic/pull/951#issue-1881592422 but for the TextInputImpl object. When the session is closed the delegate is released, so any potential event coming from Chromium will find that there is no delegate to notify.

Adding null checks to avoid doing any work in that case (and prevent crashes).

Fixes #1001