### PR TITLE
Replace Manifest's attributes instead of the whole node

### DIFF
--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:windowSoftInputMode="stateAlwaysHidden"
             android:resizeableActivity="false"
             android:supportsPictureInPicture="false"
-            tools:node="replace"
+            tools:replace="android:launchMode, android:configChanges"
             android:exported="true">
             <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
@@ -51,15 +51,6 @@
                 <category android:name="android.intent.category.INFO" />
                 <category android:name="com.oculus.intent.category.VR" android:value="vr_only"/>
             </intent-filter>
-            <!--
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.INFO" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-            </intent-filter>
-            -->
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
We want most of the main manifest's nodes to be merged with the flavor specific manifest.Due to the use of the ```tools:node="replace"``` we are missing some relevant elements from the main manifest in the merged one, like the ``ìntent-filter``` nodes to define the protocols to be handled by Wolvic. 

 Instead we should use ```tools:replace="..."``` to replace just the attributes we want to keep from the flavor specific manifest.

Fixes #1005