### PR TITLE
Enable desktop mode as the User-Agent

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -431,7 +431,9 @@ public class SettingsStore {
 
     public void setUaMode(int mode) {
         int checkedMode = mode;
-        if ((mode != WSessionSettings.USER_AGENT_MODE_VR) && (mode != WSessionSettings.USER_AGENT_MODE_MOBILE)) {
+        if (mode != WSessionSettings.USER_AGENT_MODE_VR &&
+            mode != WSessionSettings.USER_AGENT_MODE_DESKTOP &&
+            mode != WSessionSettings.USER_AGENT_MODE_MOBILE) {
             Log.e(LOGTAG, "User agent mode: " + mode + " is not supported.");
             checkedMode = UA_MODE_DEFAULT;
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/HamburgerMenuAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/HamburgerMenuAdapter.java
@@ -107,6 +107,10 @@ public class HamburgerMenuAdapter extends RecyclerView.Adapter<RecyclerView.View
             mIcon = icon;
         }
 
+        public void setTitle(String title) {
+            mTitle = title;
+        }
+
         public static class Builder {
 
             @MenuItem.MenuItemType

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -315,14 +315,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         });
 
         mBinding.navigationBarNavigation.desktopModeButton.setOnClickListener(view -> {
-            final int defaultUaMode = SettingsStore.getInstance(mAppContext).getUaMode();
-            if (mHamburgerMenu != null) {
-                mHamburgerMenu.setUAMode(defaultUaMode);
-            }
-            if (mAttachedWindow.getSession() != null) {
-                mAttachedWindow.getSession().setUaMode(defaultUaMode, true);
-            }
-
+            switchUA();
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -1376,17 +1369,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
             @Override
             public void onSwitchMode() {
-                int uaMode = mAttachedWindow.getSession().getUaMode();
-                if (uaMode == WSessionSettings.USER_AGENT_MODE_DESKTOP) {
-                    final int defaultUaMode = SettingsStore.getInstance(mAppContext).getUaMode();
-                    mHamburgerMenu.setUAMode(defaultUaMode);
-                    mAttachedWindow.getSession().setUaMode(defaultUaMode, true);
-
-                } else {
-                    mHamburgerMenu.setUAMode(WSessionSettings.USER_AGENT_MODE_DESKTOP);
-                    mAttachedWindow.getSession().setUaMode(WSessionSettings.USER_AGENT_MODE_DESKTOP, true);
-                }
-
+                switchUA();
                 hideMenu();
             }
 
@@ -1422,6 +1405,27 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
     private void hideMenu() {
         if (mHamburgerMenu != null) {
             mHamburgerMenu.hide(UIWidget.REMOVE_WIDGET, false);
+        }
+    }
+
+    private void switchUA() {
+        int uaMode = mAttachedWindow.getSession().getUaMode();
+        final int defaultUaMode = SettingsStore.getInstance(mAppContext).getUaMode();
+        int uaModeToSwitch = defaultUaMode;
+        if (uaMode == WSessionSettings.USER_AGENT_MODE_DESKTOP) {
+            if (defaultUaMode == WSessionSettings.USER_AGENT_MODE_DESKTOP) {
+                // Let's switch to VR mode if the default mode is desktop
+                uaModeToSwitch = WSessionSettings.USER_AGENT_MODE_VR;
+            }
+        } else {
+            uaModeToSwitch = WSessionSettings.USER_AGENT_MODE_DESKTOP;
+        }
+
+        if (mHamburgerMenu != null) {
+            mHamburgerMenu.setUAMode(uaModeToSwitch);
+        }
+        if (mAttachedWindow.getSession() != null) {
+            mAttachedWindow.getSession().setUaMode(uaModeToSwitch, true);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
@@ -154,24 +154,28 @@ public class HamburgerMenuWidget extends UIWidget implements
         aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.context_menu_z_distance);
     }
 
+    private void updateUADisplay(int uaMode, @NonNull HamburgerMenuAdapter.MenuItem item) {
+        switch (uaMode) {
+            case WSessionSettings.USER_AGENT_MODE_DESKTOP: {
+                item.setIcon(R.drawable.ic_icon_ua_desktop);
+                item.setTitle(getContext().getString(R.string.hamburger_menu_switch_to_mobile));
+            }
+            break;
+
+            case WSessionSettings.USER_AGENT_MODE_MOBILE:
+            case WSessionSettings.USER_AGENT_MODE_VR: {
+                item.setIcon(R.drawable.ic_icon_ua_default);
+                item.setTitle(getContext().getString(R.string.hamburger_menu_switch_to_desktop));
+            }
+            break;
+        }
+    }
+
     public void setUAMode(int uaMode) {
         mCurrentUAMode = uaMode;
         HamburgerMenuAdapter.MenuItem item = getSwitchModeIndex();
         if (item != null) {
-            switch (uaMode) {
-                case WSessionSettings.USER_AGENT_MODE_DESKTOP: {
-                    item.setIcon(R.drawable.ic_icon_ua_desktop);
-                }
-                break;
-
-                case WSessionSettings.USER_AGENT_MODE_MOBILE:
-                case WSessionSettings.USER_AGENT_MODE_VR: {
-                    item.setIcon(R.drawable.ic_icon_ua_default);
-                }
-                break;
-
-            }
-
+            updateUADisplay(uaMode, item);
             mAdapter.notifyItemChanged(mItems.indexOf(item));
         }
     }
@@ -260,18 +264,7 @@ public class HamburgerMenuWidget extends UIWidget implements
                     .withId(SWITCH_ITEM_ID)
                     .withTitle(getContext().getString(R.string.hamburger_menu_switch_to_desktop))
                     .build();
-            switch (mCurrentUAMode) {
-                case WSessionSettings.USER_AGENT_MODE_DESKTOP: {
-                    item.setIcon(R.drawable.ic_icon_ua_desktop);
-                }
-                break;
-
-                case WSessionSettings.USER_AGENT_MODE_MOBILE:
-                case WSessionSettings.USER_AGENT_MODE_VR: {
-                    item.setIcon(R.drawable.ic_icon_ua_default);
-                }
-                break;
-            }
+            updateUADisplay(mCurrentUAMode, item);
             mItems.add(item);
         }
 

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1932,6 +1932,10 @@ the Select` button. When clicked it closes all the previously selected tabs -->
          it switches User Agent from desktop to mobile and vice versa -->
     <string name="hamburger_menu_switch_to_desktop">Desktop Mode</string>
 
+    <!-- This string is displayed inside the Hamburger menu at the right of the navigation bar. When clicked
+         it switches User Agent from mobile to desktop and vice versa -->
+    <string name="hamburger_menu_switch_to_mobile">Mobile Mode</string>
+
     <!-- This string is displayed in the tooltip that is displayed when the user hovers the hamburger menu icon -->
     <string name="hamburger_menu_tooltip">Menu</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1444,6 +1444,9 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <!-- This string is displayed inside the Hamburger menu at the right of the navigation bar. When clicked
          it switches User Agent from desktop to mobile and vice versa -->
     <string name="hamburger_menu_switch_to_desktop">桌面模式</string>
+    <!-- This string is displayed inside the Hamburger menu at the right of the navigation bar. When clicked
+         it switches User Agent from mobile to desktop and vice versa -->
+    <string name="hamburger_menu_switch_to_mobile">手机模式</string>
     <!-- This string is displayed in the tooltip that is displayed when the user hovers the hamburger menu icon -->
     <string name="hamburger_menu_tooltip">菜单</string>
     <!-- This string is displayed in the tooltip that is displayed when the user hovers the move icon -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1933,6 +1933,10 @@ the Select` button. When clicked it closes all the previously selected tabs -->
          it switches User Agent from desktop to mobile and vice versa -->
     <string name="hamburger_menu_switch_to_desktop">桌面版模式</string>
 
+    <!-- This string is displayed inside the Hamburger menu at the right of the navigation bar. When clicked
+         it switches User Agent from mobile to desktop and vice versa -->
+    <string name="hamburger_menu_switch_to_mobile">行動版模式</string>
+
     <!-- This string is displayed in the tooltip that is displayed when the user hovers the hamburger menu icon -->
     <string name="hamburger_menu_tooltip">選單</string>
 

--- a/app/src/main/res/values/options_values.xml
+++ b/app/src/main/res/values/options_values.xml
@@ -42,13 +42,11 @@
 
     <!-- Environments Options -->
     <string-array name="developer_options_ua_modes" translatable="false">
-        <item>@string/developer_options_ua_mobile</item>
         <item>@string/developer_options_ua_desktop</item>
-        <item>@string/developer_options_ua_vr</item>
+        <item>@string/developer_options_ua_mobile</item>
     </string-array>
 
     <integer-array name="developer_options_ua_mode_values" translatable="false">
-        <item>0</item>
         <item>1</item>
         <item>2</item>
     </integer-array>

--- a/app/src/main/res/values/options_values.xml
+++ b/app/src/main/res/values/options_values.xml
@@ -43,11 +43,13 @@
     <!-- Environments Options -->
     <string-array name="developer_options_ua_modes" translatable="false">
         <item>@string/developer_options_ua_mobile</item>
+        <item>@string/developer_options_ua_desktop</item>
         <item>@string/developer_options_ua_vr</item>
     </string-array>
 
     <integer-array name="developer_options_ua_mode_values" translatable="false">
         <item>0</item>
+        <item>1</item>
         <item>2</item>
     </integer-array>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2051,6 +2051,10 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="hamburger_menu_switch_to_desktop">Desktop Mode</string>
 
     <!-- This string is displayed inside the Hamburger menu at the right of the navigation bar. When clicked
+         it switches User Agent from mobile to desktop and vice versa -->
+    <string name="hamburger_menu_switch_to_mobile">Mobile Mode</string>
+
+    <!-- This string is displayed inside the Hamburger menu at the right of the navigation bar. When clicked
          it toogles Passthrough from enabled to disabled and vice versa -->
     <string name="hamburger_menu_toggle_passthrough">Passthrough</string>
 


### PR DESCRIPTION
If we set the desktop mode as the default user agent mode and we want to switch to mobile mode temporarily, we then use the VR user agent in this case.

Resolve #498

![com igalia wolvic-20230925-222625](https://github.com/Igalia/wolvic/assets/43995067/a3436f03-f002-4ad4-85c7-51d1655b417d)

I think we can keep the current behavior such that, in desktop mode, we have an additional button in the navigation bar that allows user to switch back to mobile mode easily, since some webXR apps require the browser to be in mobile mode:
![com igalia wolvic-20230925-222642](https://github.com/Igalia/wolvic/assets/43995067/55f3bb3b-0b75-4c8a-baa8-3618925519b7)
