### PR TITLE
[HVR] Do not request the WiFi SSID for mainland China packages

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -35,6 +35,7 @@ import androidx.databinding.ObservableBoolean;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.VRBrowserApplication;
@@ -853,12 +854,19 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
                 if (level != mLastWifiLevel && updateWifiIcon(level)) {
                     mLastWifiLevel = level;
                 }
-                WifiInfo currentWifi = wifiManager.getConnectionInfo();
-                if(currentWifi != null) {
-                    mWifiSSID = currentWifi.getSSID().replaceAll("\"", "");
-
+                // Getting the SSID, even if it's just to show it to the user, is considered
+                // "recollection of personal information" by Huawei store in Mainland China so avoid
+                // getting it.
+                if (BuildConfig.FLAVOR_store.toLowerCase().contains("mainlandChina") && DeviceType.isHVRBuild()) {
+                    mWifiSSID = getContext().getString(R.string.tray_wifi_unavailable_ssid);
                 } else {
-                    mWifiSSID = getContext().getString(R.string.tray_wifi_no_connection);
+                    WifiInfo currentWifi = wifiManager.getConnectionInfo();
+                    if (currentWifi != null) {
+                        mWifiSSID = currentWifi.getSSID().replaceAll("\"", "");
+
+                    } else {
+                        mWifiSSID = getContext().getString(R.string.tray_wifi_no_connection);
+                    }
                 }
             }
         }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2042,4 +2042,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="keyboardview_keycode_cancel">取消</string>
     <string name="keyboardview_keycode_mode_change">模式转变</string>
     <string name="keyboardview_keycode_enter">回车键</string>
+
+    <string name="tray_wifi_unavailable_ssid">未知的SSID</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2162,4 +2162,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     '%1$s' Will be replaced at runtime with headset battery level. -->
     <string name="tray_status_headset">頭盔: %1$s</string>
 
+    <!-- Shown in the tray wifi icon popup when SSID cannot be retrieved -->
+    <string name="tray_wifi_unavailable_ssid">未知的SSID</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2461,4 +2461,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <!-- Description of the Enter button in a KeyboardView. [CHAR LIMIT=NONE] -->
     <string name="keyboardview_keycode_enter">Enter</string>
 
+    <!-- Shown in the tray wifi icon popup when SSID cannot be retrieved -->
+    <string name="tray_wifi_unavailable_ssid">Unknown SSID</string>
+
 </resources>


### PR DESCRIPTION
Requesting the SSID is considered a way to "collect user private information" even if we only use it to show the WiFi SSID to the user in the tray (we don't actually call home with those values nor anything).

We can prevent that call from happening for that specific context (HVR builds for mainland China).