### PR TITLE
Remove KIOSK_MODE_ALWAYS leftovers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,6 @@ android {
         buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "false"
         buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "false"
-        buildConfigField "Boolean", "KIOSK_MODE_ALWAYS", "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -827,18 +827,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             openInKioskMode = extras.getBoolean("kiosk", false);
         }
 
-        // In some variants Wolvic will always open in kiosk mode.
-        if (BuildConfig.KIOSK_MODE_ALWAYS) {
-            openInKioskMode = true;
-            if (targetUri == null) {
-                // If we don't have a target URI we will load the default homepage in kiosk mode,
-                // unless we are already showing a website in kiosk mode.
-                WindowWidget window = mWindows.getFocusedWindow();
-                if (window == null || !window.isKioskMode() || window.isCurrentUriBlank())
-                    targetUri = Uri.parse(getString(R.string.homepage_url));
-            }
-        }
-
         // If there is a target URI we open it
         if (targetUri != null) {
             Log.d(LOGTAG, "Loading URI from intent: " + targetUri);


### PR DESCRIPTION
We used to have a build option to start Wolvic always in kiosk mode for some flavors (China builds). Recent changes removed the configurations in which that option could be true, so in practice it's always false.

That's why we don't really need it. Therefore it should be deleted.