### PR TITLE
Improve some UI user experience

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/settings/SingleEditSetting.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/settings/SingleEditSetting.java
@@ -31,6 +31,7 @@ public class SingleEditSetting extends RelativeLayout {
     protected TextView mButton;
     private OnClickListener mListener;
     protected int mHighlightedTextColor;
+    protected int mHintTextColor;
     private String mDefaultFirstValue;
     private AppCompatToggleButton mPasswordToggle;
 
@@ -47,6 +48,7 @@ public class SingleEditSetting extends RelativeLayout {
         mWidth = attributes.getDimension(R.styleable.EditSetting_android_width, 0.0f);
         mInputType = attributes.getInt(R.styleable.EditSetting_android_inputType, InputType.TYPE_NULL);
         mHighlightedTextColor = attributes.getColor(R.styleable.EditSetting_highlightedTextColor, 0);
+        mHintTextColor = attributes.getColor(R.styleable.EditSetting_hintTextColor, 0);
         initialize(context);
     }
 
@@ -63,6 +65,7 @@ public class SingleEditSetting extends RelativeLayout {
 
         mEdit1 = findViewById(R.id.editValue1);
         mEdit1.setHighlightedTextColor(mHighlightedTextColor);
+        mEdit1.setHintTextColor(mHintTextColor);
         mEdit1.setOnEditorActionListener(mInternalEditorActionListener);
 
         if (mMaxLength != 0) {

--- a/app/src/main/res/drawable/prompt_button_text_color.xml
+++ b/app/src/main/res/drawable/prompt_button_text_color.xml
@@ -3,7 +3,7 @@
     <item android:state_pressed="true"
           android:color="@color/void_color"/>
     <item android:state_hovered="true" android:state_pressed="false"
-          android:color="@color/fog"/>
+          android:color="@color/void_color"/>
     <item android:state_enabled="false"
           android:color="@color/iron" />
     <item android:color="@color/white"/>

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -73,6 +73,7 @@
                     android:width="300dp"
                     android:inputType="textWebEmailAddress"
                     app:description="@string/developer_options_homepage"
+                    app:hintTextColor="@color/iron_blur"
                     app:highlightedTextColor="@color/fog" />
 
                 <com.igalia.wolvic.ui.views.settings.SingleEditSetting
@@ -83,6 +84,7 @@
                     android:inputType="numberDecimal"
                     android:maxLength="4"
                     app:description="@string/developer_options_display_density"
+                    app:hintTextColor="@color/iron_blur"
                     app:highlightedTextColor="@color/fog" />
 
                 <com.igalia.wolvic.ui.views.settings.SingleEditSetting
@@ -93,6 +95,7 @@
                     android:inputType="number"
                     android:maxLength="4"
                     app:description="@string/developer_options_display_dpi"
+                    app:hintTextColor="@color/iron_blur"
                     app:highlightedTextColor="@color/fog" />
 
             </LinearLayout>

--- a/app/src/main/res/layout/options_edit_login.xml
+++ b/app/src/main/res/layout/options_edit_login.xml
@@ -82,6 +82,7 @@
                     android:width="300dp"
                     android:inputType="text|textNoSuggestions"
                     app:description="@string/login_edit_dialog_username_description"
+                    app:hintTextColor="@color/iron_blur"
                     app:highlightedTextColor="@color/fog" />
 
                 <com.igalia.wolvic.ui.views.settings.SingleEditSetting
@@ -91,6 +92,7 @@
                     android:width="300dp"
                     android:inputType="text|textPassword|textNoSuggestions"
                     app:description="@string/login_edit_dialog_password_description"
+                    app:hintTextColor="@color/iron_blur"
                     app:highlightedTextColor="@color/fog" />
 
                 <TextView

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -69,6 +69,7 @@
         <attr name="description" />
         <attr name="by" />
         <attr name="highlightedTextColor" />
+        <attr name="hintTextColor" />
         <attr name="android:width" />
         <attr name="android:maxLength" />
         <attr name="android:inputType" />


### PR DESCRIPTION
- Make hint text visible in SingleEditSetting

Enable HintTextColor configuration in SingleEditSetting, set the text color to grey so that it's visible to user.

e.g. It can be hard for user to learn that we will actually reset the value in Homepage edit setting when we delete all the text.

Before:
![com igalia wolvic-20230926-223849](https://github.com/Igalia/wolvic/assets/43995067/3da613fc-a4d6-40f8-84b4-e4d8044e730a)

After:
![com igalia wolvic-20230926-223556](https://github.com/Igalia/wolvic/assets/43995067/e6c76406-504f-4dfe-8402-c4d82cc547d4)

- Set the prompt button hovering text color to be void, so that users can still see text clearly when doing so.

Before:
![com igalia wolvic-20230926-223839](https://github.com/Igalia/wolvic/assets/43995067/31c4e93b-d7b8-4b49-a2b0-13dd908e630f)

After:
![com igalia wolvic-20230926-224000](https://github.com/Igalia/wolvic/assets/43995067/f4762c71-8289-421a-8587-8ae16cabeb13)

