### PR TITLE
Use the the system's DeviceType for the generic input profile

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -262,6 +262,7 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
     case device::UnknownType:
     default:
       result = mozilla::gfx::VRControllerType::_empty;
+      assert(!"Unknown controller type.");
       VRB_LOG("Unknown controller type.");
       break;
   }

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -73,7 +73,9 @@ XrResult OpenXRInputSource::Initialize()
     for (auto& mapping: OpenXRInputMappings) {
       // Always populate default/fall-back profiles
       if (mapping.controllerType == device::UnknownType) {
-        mMappings.push_back(mapping);
+          mMappings.push_back(mapping);
+          // Use the system's deviceType instead to ensure we get a valid VRController on WebXR sessions
+          mMappings.back().controllerType = deviceType;
         continue;
       } else if (deviceType != mapping.controllerType) {
         continue;


### PR DESCRIPTION
The generic input profile is associated to the device::UnknownType which uses an empty VR controller in mozilla. The consequence is that there no controller is drawn during WebXR experiences for devices using the generic profile (eg Lynx). 

This issue had been fixed already in PR #834, but it got reverted because it broke the logic to detect generic profiles as fallbacks (see PR #907)

The solution proposed in this PR is to assign the DeviceType provided by the system to the ControllerDelegate instance, instead of the one provided by the generic profile.

Fixes #833

 