### PR TITLE
Move homepage URL to a resValue in build config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,6 +123,7 @@ android {
         buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        resValue 'string', 'HOMEPAGE_URL', "https://wolvic.com/start"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14 -fexceptions -frtti -Werror" +
@@ -369,6 +370,7 @@ android {
             buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "true"
             buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
             buildConfigField "Boolean", "CN_FIRST_RUN_IN_PHONE_UI", "true"
+            resValue 'string', 'HOMEPAGE_URL', 'about:blank'
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -383,7 +383,7 @@ public class SettingsStore {
     public String getHomepage() {
         return mPrefs.getString(
                 mContext.getString(R.string.settings_key_homepage),
-                mContext.getString(R.string.homepage_url));
+                mContext.getString(R.string.HOMEPAGE_URL));
     }
 
     public void setHomepage(String aHomepage) {

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -726,7 +726,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
     public String getHomeUri() {
         String homepage = SettingsStore.getInstance(mContext).getHomepage();
-        if (homepage.equals(mContext.getString(R.string.homepage_url)) && mState.mRegion != null) {
+        if (homepage.equals(mContext.getString(R.string.HOMEPAGE_URL)) && mState.mRegion != null) {
             homepage = homepage + "?region=" + mState.mRegion;
         }
         return homepage;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -75,7 +75,7 @@ class DisplayOptionsView extends SettingsView {
             mBinding.startWithPassthroughSwitch.setVisibility(View.GONE);
         }
 
-        mDefaultHomepageUrl = getContext().getString(R.string.homepage_url);
+        mDefaultHomepageUrl = getContext().getString(R.string.HOMEPAGE_URL);
 
         mBinding.homepageEdit.setHint1(getContext().getString(R.string.homepage_hint, getContext().getString(R.string.app_name)));
         mBinding.homepageEdit.setDefaultFirstValue(mDefaultHomepageUrl);

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -224,7 +224,7 @@ public class UrlUtils {
     }
 
     public static boolean isContentFeed(Context aContext, @Nullable String url) {
-        String feed = aContext.getString(R.string.homepage_url);
+        String feed = aContext.getString(R.string.HOMEPAGE_URL);
         return UrlUtils.getHost(feed).equalsIgnoreCase(UrlUtils.getHost(url));
     }
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -2,7 +2,6 @@
     <string name="app_name" translatable="false">Wolvic</string>
     <string name="bug_report_url" translatable="false">github.com/Igalia/wolvic/issues</string>
     <!-- You can test a local file using: "resource://android/assets/webvr/index.html" -->
-    <string name="homepage_url" translatable="false">https://wolvic.com/start</string>
     <string name="settings_key_homepage" translatable="false">settings_homepage</string>
     <string name="settings_key_crash" translatable="false">settings_crash</string>
     <string name="settings_key_locale" translatable="false">settings_locale</string>


### PR DESCRIPTION
We're removing it from the list of non translatable strings. Having it in the build config allows us to specify different start pages per flavour. In this case we're interested in providing a different one for the Chinese market as some of the experiences in the start page cannot be either viewed from mainland China or simply take a lot to load.

So far we're using about:blank but we can change that in the future.