### PR TITLE
Fix several issues related to seek bar for VR video playing

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/MediaSeekBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/MediaSeekBar.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 
 public class MediaSeekBar extends LinearLayout implements SeekBar.OnSeekBarChangeListener {
     private SeekBar mSeekBar;
@@ -83,8 +84,9 @@ public class MediaSeekBar extends LinearLayout implements SeekBar.OnSeekBarChang
                 notify = true;
             }
 
+            final int padding = WidgetPlacement.dpDimension(getContext(), R.dimen.media_controls_seek_bar_padding);
             if (notify) {
-                final float ratio = event.getX() / view.getWidth();
+                final float ratio = (event.getX() - padding) / (view.getWidth() - 2 * padding);
                 notifySeekPreview(mDuration * ratio);
             }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
@@ -165,14 +165,23 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
 
             @Override
             public void onSeekPreview(String aText, double aRatio) {
+                final int padding = WidgetPlacement.dpDimension(getContext(), R.dimen.media_controls_seek_bar_padding);
                 mBinding.mediaControlSeekLabel.setText(aText);
                 View childView = mBinding.mediaControlSeekBar.getSeekBarView();
                 childView.getDrawingRect(mOffsetViewBounds);
                 MediaControlsWidget.this.offsetDescendantRectToMyCoords(childView, mOffsetViewBounds);
 
                 FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) mBinding.mediaControlSeekLabel.getLayoutParams();
-                params.setMarginStart(mOffsetViewBounds.left + (int) (aRatio * mOffsetViewBounds.width()) - mBinding.mediaControlSeekLabel.getMeasuredWidth() / 2);
+                params.setMarginStart(mOffsetViewBounds.left + padding +
+                        (int) (aRatio * (mOffsetViewBounds.width() - 2 * padding)) -
+                        mBinding.mediaControlSeekLabel.getMeasuredWidth() / 2);
                 mBinding.mediaControlSeekLabel.setLayoutParams(params);
+
+                if (aRatio < 0 || aRatio > 1) {
+                    mBinding.mediaControlSeekLabel.setVisibility(View.GONE);
+                } else {
+                    mBinding.mediaControlSeekLabel.setVisibility(View.VISIBLE);
+                }
             }
         });
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
@@ -33,7 +33,6 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
     private MediaControlsBinding mBinding;
     private Media mMedia;
     private Runnable mBackHandler;
-    private boolean mPlayOnSeekEnd;
     private Rect mOffsetViewBounds;
     private VideoProjectionMenuWidget mProjectionMenu;
     static long VOLUME_SLIDER_CHECK_DELAY = 1000;
@@ -140,9 +139,7 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
         mBinding.mediaControlSeekBar.setDelegate(new MediaSeekBar.Delegate() {
             @Override
             public void onSeekDragStart() {
-                mPlayOnSeekEnd = mMedia.isPlaying();
                 mBinding.mediaControlSeekLabel.setVisibility(View.VISIBLE);
-                mMedia.pause();
                 mBinding.mediaControlSeekBar.requestFocusFromTouch();
             }
 
@@ -153,9 +150,6 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
 
             @Override
             public void onSeekDragEnd() {
-                if (mPlayOnSeekEnd) {
-                    mMedia.play();
-                }
                 mBinding.mediaControlSeekLabel.setVisibility(View.GONE);
             }
 

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -94,6 +94,7 @@
     <dimen name="media_controls_panel_width">284dp</dimen>
     <dimen name="media_controls_panel_height">85dp</dimen>
     <dimen name="media_controls_rounded_corners">15dp</dimen>
+    <dimen name="media_controls_seek_bar_padding">30dp</dimen>
     <dimen name="media_controls_world_z" format="float" type="dimen">2.5</dimen>
 
     <!-- Top Bar -->


### PR DESCRIPTION
- Don't pause video playing intentionally when seeking
This is creating some race conditions and cause the seek to fail sometimes.

And there's no reason to pause in this case as well.

- Fix to make video seeking bar show the correct time
We should also considering the padding after we got the seekBar view bound

Before:

https://github.com/Igalia/wolvic/assets/43995067/303ad8fa-7bdd-482d-be23-fc391bc8c660

After:

https://github.com/Igalia/wolvic/assets/43995067/1973e04e-9b97-4551-8469-7c19bae0ecd7
