### PR TITLE
[HVR] Fix flavor detection when deciding about requesting SSID

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -857,7 +857,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
                 // Getting the SSID, even if it's just to show it to the user, is considered
                 // "recollection of personal information" by Huawei store in Mainland China so avoid
                 // getting it.
-                if (BuildConfig.FLAVOR_store.toLowerCase().contains("mainlandChina") && DeviceType.isHVRBuild()) {
+                if (BuildConfig.FLAVOR_store.toLowerCase().contains("mainlandchina") && DeviceType.isHVRBuild()) {
                     mWifiSSID = getContext().getString(R.string.tray_wifi_unavailable_ssid);
                 } else {
                     WifiInfo currentWifi = wifiManager.getConnectionInfo();

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2054,5 +2054,5 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="keyboardview_keycode_mode_change">模式转变</string>
     <string name="keyboardview_keycode_enter">回车键</string>
 
-    <string name="tray_wifi_unavailable_ssid">未知的SSID</string>
+    <string name="tray_wifi_unavailable_ssid">SSID不可知</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2178,6 +2178,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="tray_status_headset">頭盔: %1$s</string>
 
     <!-- Shown in the tray wifi icon popup when SSID cannot be retrieved -->
-    <string name="tray_wifi_unavailable_ssid">未知的SSID</string>
+    <string name="tray_wifi_unavailable_ssid">SSID不可知</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2477,6 +2477,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="keyboardview_keycode_enter">Enter</string>
 
     <!-- Shown in the tray wifi icon popup when SSID cannot be retrieved -->
-    <string name="tray_wifi_unavailable_ssid">Unknown SSID</string>
+    <string name="tray_wifi_unavailable_ssid">SSID unavailable</string>
 
 </resources>


### PR DESCRIPTION
We've recently added some code for HVR in China that was meant to prevent Wolvic to call getSSID() because that's considered recollection of personal data even if we only use it to show the SSID in the UI.

The problem is that we were comparing the lowercase name of the flavor with "mainlandChina" with capital C, so this was obviously never matching. Correct that and also replace the default english translation from "unknown" to "unavailable" which is more precise.