### PR TITLE
Disable 1€ filtering for Magic Leap 2

### DIFF
--- a/app/src/openxr/cpp/OpenXRGestureManager.h
+++ b/app/src/openxr/cpp/OpenXRGestureManager.h
@@ -45,7 +45,12 @@ XrHandTrackingAimStateFB mFBAimState;
 
 class OpenXRGestureManagerHandJoints : public OpenXRGestureManager {
 public:
-OpenXRGestureManagerHandJoints(HandJointsArray& handJoints);
+typedef struct OneEuroFilterParams {
+float mincutoff;
+float beta;
+float dcutoff;
+} OneEuroFilterParams;
+OpenXRGestureManagerHandJoints(HandJointsArray&, OneEuroFilterParams* = nullptr);
 private:
 bool hasAim() const override;
 XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -140,8 +140,18 @@ XrResult OpenXRInputSource::Initialize()
 
         if (mSupportsFBHandTrackingAim)
             mGestureManager = std::make_unique<OpenXRGestureManagerFBHandTrackingAim>();
-        else
-            mGestureManager = std::make_unique<OpenXRGestureManagerHandJoints>(mHandJoints);
+        else {
+            switch (deviceType) {
+                case device::MagicLeap2:
+                    // Disable filtering for ML2, data is already quite good.
+                    mGestureManager = std::make_unique<OpenXRGestureManagerHandJoints>(mHandJoints);
+                    break;
+                default:
+                    // TODO: fine tune params for different devices.
+                    OpenXRGestureManagerHandJoints::OneEuroFilterParams params = { 0.25, 0.1, 1 };
+                    mGestureManager = std::make_unique<OpenXRGestureManagerHandJoints>(mHandJoints, &params);
+            };
+        }
     }
 
     // Initialize double buffers for storing XR_MSFT_hand_tracking_mesh geometry


### PR DESCRIPTION
We initially developed it for the Lenovo A3 which was not providing stable and reliable joint data. As the results were quite good we decided to use it for every single device.

However devices like the MagicLeap2 provide a quite good and clean signal with almost zero noise, so let's better disable it for those devices (their SDKs already do a similar filtering).

The GestureManager constructor has now a new parametter which is a pointer to a struct with 3 floats. If that pointer is null then we do no filtering. This is more complex than just using a boolean but it'd allow us to provide per-device settings for the filtering.