### PR TITLE
Add back the mute/unmute control in VR video control

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabMediaSessionObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabMediaSessionObserver.java
@@ -209,6 +209,12 @@ public class TabMediaSessionObserver extends MediaSessionObserver implements Med
                 return;
             getMediaSession().setMute(mute);
         }
+
+        @Override
+        public boolean canCtrlVolume() {
+            // TODO: Check if the media session in Chromium supports volume control.
+            return false;
+        }
     }
 
     private void updatePosition() {

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/MediaSessionDelegateImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/MediaSessionDelegateImpl.java
@@ -137,5 +137,11 @@ import org.mozilla.geckoview.GeckoSession;
         public void muteAudio(boolean mute) {
             mGeckoMediaSession.muteAudio(mute);
         }
+
+        @Override
+        public boolean canCtrlVolume() {
+            // Gecko MediaSession doesn't have a way to control volume.
+            return false;
+        }
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/browser/Media.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/Media.java
@@ -116,9 +116,14 @@ public class Media implements WMediaSession.Delegate {
         // TODO: mMediaSession doesn't seem to have a way to set volume. Should we change system volume instead?
     }
 
+    public boolean canCtrlVolume() {
+        return mMediaSession != null && mMediaSession.canCtrlVolume();
+    }
+
     public void setMuted(boolean aIsMuted) {
         if (mMediaSession != null) {
             mMediaSession.muteAudio(aIsMuted);
+            mIsMuted = aIsMuted;
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WMediaSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WMediaSession.java
@@ -76,6 +76,13 @@ public interface WMediaSession {
      */
     void muteAudio(final boolean mute);
 
+    /**
+     * Check whether the media session supports volume control.
+     *
+     * @return True if this media session supports volume control, false otherwise.
+     */
+    boolean canCtrlVolume();
+
     /** Implement this delegate to receive media session events. */
     @UiThread
     interface Delegate {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
@@ -126,6 +126,7 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
                 mMedia.setMuted(true);
                 mBinding.volumeControl.setVolume(0);
             }
+            mBinding.setMuted(mMedia.isMuted());
             mBinding.mediaVolumeButton.requestFocusFromTouch();
         });
 
@@ -223,6 +224,11 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
             return false;
         });
         mBinding.mediaVolumeButton.setOnHoverListener((v, event) -> {
+            // Only show the volume control when it's supported
+            if (!mMedia.canCtrlVolume()) {
+                return false;
+            }
+
             float startY = v.getY();
             float maxY = startY + v.getHeight();
             //for this we only hide on the left side of volume button or outside y area of button
@@ -315,7 +321,6 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
         mBinding.mediaControlSeekBar.setCurrentTime(mMedia.getCurrentTime());
         mBinding.setPlaying(mMedia.isPlaying());
         mBinding.mediaControlSeekBar.setSeekable(mMedia.canSeek());
-        mBinding.mediaVolumeButton.setEnabled(false);
 
         mMedia.addMediaListener(this);
     }


### PR DESCRIPTION
The original code has the volume control, but since volume control now is not supported in Gecko media session, we add the canCtrlVolume() in WMediaSession and return false in Gecko Session. We call it and check the availability when the volume button is on hover.

https://github.com/Igalia/wolvic/assets/43995067/ad2d36fe-7677-4bbe-aee1-341b2d4b3491

