### PR TITLE
Fix Youtube video pause when entering immersive mode

### DIFF
--- a/app/src/main/assets/extensions/fxr_youtube/main.js
+++ b/app/src/main/assets/extensions/fxr_youtube/main.js
@@ -191,7 +191,7 @@ class YoutubeExtension {
                 if (paused) {
                      player.playVideo();
                 }
-                return !paused;
+                return paused;
             }), 200);
         }
     }


### PR DESCRIPTION
The original code has a logical error that stops this from working correctly, we should retry until the video actually stops.

We allow users to enter the immersive mode by clicking on the video, while YouTube player will pause the video when we try to click on the video, which will happen at the same time even when users do not intend to pause the video.

The old code here is kind of nasty, however, although using event.stopPropagation can get rid of Youtube player's pause behavior, it will cause new issue if we change into that, where the player control will always remain shown when playing, thus the code here is still our best choice now.