### PR TITLE
Fix Chinese/Japanese keyboard typing

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1155,21 +1155,22 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         }
 
         if (mCurrentKeyboard.usesComposingText()) {
-            final KeyboardInterface.CandidatesResult candidates = mCurrentKeyboard.getCandidates(mComposingText);
-            setAutoCompletionVisible(candidates != null && candidates.words.size() > 0);
-            mAutoCompletionView.setItems(candidates != null ? candidates.words : null);
-            if (candidates != null && candidates.action == KeyboardInterface.CandidatesResult.Action.AUTO_COMPOSE) {
-                setAutoCompletionVisible(false);
-                onAutoCompletionItemClick(candidates.words.get(0));
-            } else if (candidates != null) {
-                postInputCommand(() -> displayComposingText(candidates.composing, ComposingAction.DO_NOT_FINISH));
-            } else {
-                mComposingText = "";
-
-                postInputCommand(() -> {
-                    displayComposingText("", ComposingAction.FINISH);
+            postInputCommand(() -> {
+                final KeyboardInterface.CandidatesResult candidates = mCurrentKeyboard.getCandidates(mComposingText);
+                postUICommand(() -> {
+                    setAutoCompletionVisible(candidates != null && candidates.words.size() > 0);
+                    mAutoCompletionView.setItems(candidates != null ? candidates.words : null);
                 });
-            }
+                if (candidates != null && candidates.action == KeyboardInterface.CandidatesResult.Action.AUTO_COMPOSE) {
+                    postUICommand(() -> setAutoCompletionVisible(false));
+                    onAutoCompletionItemClick(candidates.words.get(0));
+                } else if (candidates != null) {
+                     displayComposingText(candidates.composing, ComposingAction.DO_NOT_FINISH);
+                } else {
+                    mComposingText = "";
+                    displayComposingText("", ComposingAction.FINISH);
+                }
+            });
         } else {
             final InputConnection connection = mInputConnection;
             postInputCommand(() -> {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1247,7 +1247,6 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         mComposingDisplayText = aText;
         if (aAction == ComposingAction.FINISH) {
             mInputConnection.finishComposingText();
-            mComposingText = "";
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1060,7 +1060,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
         final String text = aText;
         final InputConnection connection = mInputConnection;
-        if (mCurrentKeyboard.usesComposingText()) {
+        if (mCurrentKeyboard.usesComposingText() && !mIsInVoiceInput) {
             postInputCommand(() -> {
                 CharSequence seq = connection.getSelectedText(0);
                 String selected = seq != null ? seq.toString() : "";
@@ -1070,7 +1070,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
                 }
                 mComposingText += text;
             });
-        } else if (mCurrentKeyboard.usesTextOverride()) {
+        } else if (mCurrentKeyboard.usesTextOverride() || mIsInVoiceInput) {
             postInputCommand(() -> {
                 String beforeText = getTextBeforeCursor(connection);
                 String newBeforeText = mCurrentKeyboard.overrideAddText(beforeText, text);


### PR DESCRIPTION
- Fix Chinese/Japanese keyboard typing in web page

Now Chinese/Japanese keyboard typing is broken when you try to type in web pages.

We should use postInputCommand to wait for the mComposingText to be updated before we updateCandidates, otherwise we won't have anything in mComposingText when we type our first letter, causing input candidates to not display at all.

- Make Chinese keyboard able to type character by character

We shouldn't empty mComposingText each time when we finished displayComposingText

e.g. 测试一下
测 -> ce
试 -> shi
一 -> yi
下 -> xia

When we input `ceshiyixia`, after we choose `测试`(ceshi), `yixia` shouldn't get dismissed and we should still be able to choose `一下(yixia)`

Before: (quite annoying)

https://github.com/Igalia/wolvic/assets/43995067/1c11a89c-99ec-4b81-b5a2-3dccdc9e2ae4

After: (the same behavior as most Chinese input methods)

https://github.com/Igalia/wolvic/assets/43995067/6fc35f99-5653-43b9-877a-55f8df64e732

- Fix voice input when keyboard uses composing text

We don't want to compose text again when we use voice input, e.g. Voice input English while keyboard layout is Chinese.