### PR TITLE
Use context.getCacheDir() to store unzipped environment files

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/EnvironmentUtils.java
@@ -60,31 +60,17 @@ public class EnvironmentUtils {
     }
 
     /**
-     * Returns a path in the external for the remote environments unzipping.
+     * Returns a path in the cache for the remote environments unzipping.
      * @param context An activity context.
      * @param envId The environment id. This maps to the Remote properties JSON "value" environment property.
      * @return The location of the environment in the devices memory.
      */
     @Nullable
     public static String getExternalEnvPath(@NonNull Context context, @NonNull String envId) {
-        File outputFolder = context.getExternalFilesDir(ENVS_FOLDER);
-        if (outputFolder != null) {
-            outputFolder = new File(outputFolder, envId);
-            if (!outputFolder.exists()) {
-                if (outputFolder.mkdirs()) {
-                    return outputFolder.getAbsolutePath();
-
-                } else {
-                    return null;
-                }
-
-            } else {
-                return outputFolder.getAbsolutePath();
-            }
-
-        } else {
-            return null;
-        }
+        File outputFolder = new File(context.getCacheDir().getAbsolutePath(), ENVS_FOLDER + "/" + envId);
+        if (outputFolder.exists())
+            return outputFolder.getAbsolutePath();
+        return outputFolder.mkdirs() ? outputFolder.getAbsolutePath() : null;
     }
 
     /**


### PR DESCRIPTION
Resolves #963

I also tried to let the zip file download to the `context.getCacheDir()`/`context.getFilesDir()`, but this is not supported by the downloads manager. I don't think it's worth implementing our own downloading method here, so we should still keep using the `Context.getExternalFilesDir()`. 

After all the zip files are just stored temporarily, it doesn't matter too much if that dir is located in a removable media. `Context.getExternalFilesDir()` is also not available to any other app, without the need for READ/WRITE permissions as well.

```log
2023-09-29 21:44:46.351 31642-9971  DatabaseUtils           android.process.media                E  Writing exception to parcel
                                                                                                    java.lang.SecurityException: Unsupported path /data/data/com.igalia.wolvic/cache/spring_ktx_srgb.zip
                                                                                                    	at com.android.providers.downloads.Helpers.checkDestinationFilePathRestrictions(Helpers.java:617)
                                                                                                    	at com.android.providers.downloads.DownloadProvider.checkFileUriDestination(DownloadProvider.java:1073)
                                                                                                    	at com.android.providers.downloads.DownloadProvider.insert(DownloadProvider.java:732)
                                                                                                    	at android.content.ContentProvider.insert(ContentProvider.java:1701)
                                                                                                    	at android.content.ContentProvider$Transport.insert(ContentProvider.java:330)
                                                                                                    	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:168)
                                                                                                    	at android.os.Binder.execTransactInternal(Binder.java:1179)
                                                                                                    	at android.os.Binder.execTransact(Binder.java:1143)
2023-09-29 21:44:46.352 16321-16321 System.err              com.igalia.wolvic                    W  java.lang.SecurityException: Unsupported path /data/data/com.igalia.wolvic/cache/spring_ktx_srgb.zip
2023-09-29 21:44:46.352 16321-16321 System.err              com.igalia.wolvic                    W  	at android.os.Parcel.createExceptionOrNull(Parcel.java:2426)
2023-09-29 21:44:46.352 16321-16321 System.err              com.igalia.wolvic                    W  	at android.os.Parcel.createException(Parcel.java:2410)
2023-09-29 21:44:46.352 16321-16321 System.err              com.igalia.wolvic                    W  	at android.os.Parcel.readException(Parcel.java:2393)
2023-09-29 21:44:46.352 16321-16321 System.err              com.igalia.wolvic                    W  	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:190)
2023-09-29 21:44:46.352 16321-16321 System.err              com.igalia.wolvic                    W  	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142)
2023-09-29 21:44:46.352 16321-16321 System.err              com.igalia.wolvic                    W  	at android.content.ContentProviderProxy.insert(ContentProviderNative.java:557)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at android.content.ContentResolver.insert(ContentResolver.java:2193)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at android.content.ContentResolver.insert(ContentResolver.java:2155)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at android.app.DownloadManager.enqueue(DownloadManager.java:1119)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.downloads.DownloadsManager.startDownload(DownloadsManager.java:142)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.utils.EnvironmentsManager.downloadEnvironment(EnvironmentsManager.java:132)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.utils.EnvironmentsManager.setOrDownloadEnvironment(EnvironmentsManager.java:86)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.ui.widgets.settings.EnvironmentOptionsView.setEnv(EnvironmentOptionsView.java:133)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.ui.widgets.settings.EnvironmentOptionsView.$r8$lambda$fDHPK5SU1QBG350skfVVK--rAwI(Unknown Source:0)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.ui.widgets.settings.EnvironmentOptionsView$$ExternalSyntheticLambda4.onCheckedChanged(Unknown Source:2)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.ui.views.settings.ImageRadioGroupSetting.setChecked(ImageRadioGroupSetting.java:140)
2023-09-29 21:44:46.353 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.ui.views.settings.ImageRadioGroupSetting.lambda$addOption$1$com-igalia-wolvic-ui-views-settings-ImageRadioGroupSetting(ImageRadioGroupSetting.java:181)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at com.igalia.wolvic.ui.views.settings.ImageRadioGroupSetting$$ExternalSyntheticLambda1.onClick(Unknown Source:4)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.view.View.performClick(View.java:7455)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.widget.CompoundButton.performClick(CompoundButton.java:146)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.view.View.performClickInternal(View.java:7432)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.view.View.access$3700(View.java:835)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.view.View$PerformClick.run(View.java:28810)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.os.Handler.handleCallback(Handler.java:938)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.os.Handler.dispatchMessage(Handler.java:99)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.os.Looper.loopOnce(Looper.java:214)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.os.Looper.loop(Looper.java:304)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at android.app.ActivityThread.main(ActivityThread.java:7909)
2023-09-29 21:44:46.354 16321-16321 System.err              com.igalia.wolvic                    W  	at java.lang.reflect.Method.invoke(Native Method)
2023-09-29 21:44:46.355 16321-16321 System.err              com.igalia.wolvic                    W  	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
2023-09-29 21:44:46.355 16321-16321 System.err              com.igalia.wolvic                    W  	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1010)
```