### PR TITLE
Fix voice search default language selection

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
+++ b/app/src/common/shared/com/igalia/wolvic/speech/MKSpeechRecognizer.java
@@ -19,6 +19,7 @@ import com.meetkai.speechlibrary.STTResult;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionListener {
 
@@ -74,12 +75,13 @@ public class MKSpeechRecognizer implements SpeechRecognizer, ISpeechRecognitionL
         }
 
         Locale locale;
-        if (mSupportedLanguages.contains(settings.locale)) {
+        if (!Objects.equals(settings.locale, LocaleUtils.DEFAULT_LANGUAGE_ID) &&
+            mSupportedLanguages.contains(settings.locale)) {
             // the user has selected a specific language in the Settings UI
             // TODO use the device's location to find the country code
             locale = new Locale(settings.locale, defaultLocale.getCountry());
         } else {
-            locale = defaultLocale;
+            locale = new Locale(defaultLocale.getLanguage(), defaultLocale.getCountry());
         }
         settings.locale = LocaleUtils.getClosestLanguageForLocale(
                 locale, mSupportedLocales, LocaleUtils.FALLBACK_LANGUAGE_TAG);


### PR DESCRIPTION
We should not consider `default` as a language, as something like `default_CN` will not be valid anyway, then it will fallback to `en_US`. We should get the language from the default local in this case.

We should also not directly use `Locale.getDefault()`, as e.g. for Simplified Chinese, it will return `zh_CN_#Hans`, which will fallback to `zh_HK`. We should reconstruct the defaultLocale and extract only the language and country code so that it matches the language list in mSupportedLocales