### PR TITLE
Disable Overley extension for Lynx

### DIFF
--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -35,8 +35,9 @@ void OpenXRExtensions::Initialize() {
         sSupportedExtensions.insert(extension.extensionName);
     }
 #ifdef LYNX
-    // Lynx incorrectly advertises this extension as supported but in reality it does not work.
+    // Lynx incorrectly advertises these extensions as supported but in reality they don't work.
     sSupportedExtensions.erase(XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME);
+    sSupportedExtensions.erase(XR_EXTX_OVERLAY_EXTENSION_NAME);
 #elif PICOXR
     // Pico incorrectly advertises this extension as supported but it makes Wolvic not work.
     sSupportedExtensions.erase(XR_EXTX_OVERLAY_EXTENSION_NAME);


### PR DESCRIPTION
Lynx advertises the XR_EXTX_overlay as supported, but it doesn't work. This PR removes it from the list of supported extensions.