### PR TITLE
Set tray date displaying format without hardcoding

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -911,7 +911,8 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
     @NonNull
     private String getFormattedDate() {
-        SimpleDateFormat format = new SimpleDateFormat("EEEE, dd MMMM yyyy", LocaleUtils.getDisplayLanguage(getContext()).getLocale());
+        java.text.DateFormat format = SimpleDateFormat.getDateInstance(
+                SimpleDateFormat.FULL, LocaleUtils.getDisplayLanguage(getContext()).getLocale());
         return format.format(new Date());
     }
 }


### PR DESCRIPTION
We shouldn't hardcode the date displaying format as date and time notations can vary according to the language

e.g. In Chinese
Before: (not the correct way of notating https://en.wikipedia.org/wiki/Date_and_time_notation_in_Asia#Greater_China)
![Screenshot from 2023-10-02 23-46-14](https://github.com/Igalia/wolvic/assets/43995067/2be9b3eb-9162-49fb-82f7-dcd1e360b66d)

After:
![Screenshot from 2023-10-02 23-43-05](https://github.com/Igalia/wolvic/assets/43995067/196b5009-1128-4bf0-b141-c52239d0c046)
