### PR TITLE
[OpenXR] Prefer BLEND_MODE_ALPHA over BLEND_MODE_ADDITIVE

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -360,7 +360,7 @@ struct DeviceDelegateOpenXR::State {
       const auto supportsAlphaBlendMode = std::find(blendModes.begin(), blendModes.end(), blendMode) != blendModes.end();
       CHECK(supportsOpaqueBlendMode || supportsAdditiveBlendMode || supportsAlphaBlendMode);
 
-      passthroughBlendMode = supportsAdditiveBlendMode ? XR_ENVIRONMENT_BLEND_MODE_ADDITIVE : (supportsAlphaBlendMode ? XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND : XR_ENVIRONMENT_BLEND_MODE_OPAQUE);
+      passthroughBlendMode = supportsAlphaBlendMode ? XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND : (supportsAdditiveBlendMode ? XR_ENVIRONMENT_BLEND_MODE_ADDITIVE : XR_ENVIRONMENT_BLEND_MODE_OPAQUE);
       defaultBlendMode = supportsOpaqueBlendMode ? XR_ENVIRONMENT_BLEND_MODE_OPAQUE : passthroughBlendMode;
       VRB_LOG("OpenXR: selected default blend mode %s", to_string(defaultBlendMode));
       VRB_LOG("OpenXR: selected passthrough blend mode %s", to_string(passthroughBlendMode));


### PR DESCRIPTION
Wolvic automatically selects the blend mode by inspecting the list of available blend modes. In particular the order in which we select the default blend mode is OPAQUE->ADDITIVE->ALPHA.

In the particular case of the MagicLeap2 that does not work well because ADDITIVE was selected (as it does not support OPAQUE) and that was causing issues with video playing. In particular audio can be heard but no video was rendered. I guess the problem is how video formats interact with an additive blend mode (in which black pixels are considered transparent).

Everything works fine if we select ALPHA, so let's switch the preferred order as it plays nicely with all of our supported configurations.