### PR TITLE
Track hand-tracking joint radii in controllers

### DIFF
--- a/app/src/main/cpp/Controller.cpp
+++ b/app/src/main/cpp/Controller.cpp
@@ -77,6 +77,7 @@ Controller::operator=(const Controller& aController) {
   batteryLevel = aController.batteryLevel;
   hasAim = aController.hasAim;
   handJointTransforms = aController.handJointTransforms;
+  handJointRadii = aController.handJointRadii;
   handActionEnabled = aController.handActionEnabled;
   handActionButtonToggle = aController.handActionButtonToggle;
   handActionButtonTransform = aController.handActionButtonTransform;
@@ -128,6 +129,7 @@ Controller::Reset() {
   batteryLevel = -1;
   hasAim = true;
   handJointTransforms.clear();
+  handJointRadii.clear();
   handActionEnabled = false;
   handActionButtonToggle = nullptr;
   handActionButtonTransform = nullptr;

--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -44,6 +44,7 @@ struct Controller {
   vrb::TogglePtr beamToggle;
   vrb::TogglePtr modelToggle;
   std::vector<vrb::Matrix>handJointTransforms;
+  std::vector<float>handJointRadii;
   bool hasAim;
   bool handActionEnabled;
   vrb::TogglePtr handActionButtonToggle;

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -199,7 +199,8 @@ ControllerContainer::InitializeBeam() {
   }
 }
 
-void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms)
+void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms,
+                                                std::vector<float> jointRadii)
 {
     if (!m.Contains(aControllerIndex))
         return;
@@ -209,6 +210,7 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
         return;
 
     controller.handJointTransforms = std::move(jointTransforms);
+    controller.handJointRadii = std::move(jointRadii);
 
     // Initialize left and right hands action button, which for now triggers back navigation
     // and exit app respectively.

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -67,7 +67,7 @@ public:
   bool IsVisible() const override;
   void SetVisible(const bool aVisible) override;
   void SetGazeModeIndex(const int32_t aControllerIndex) override;
-  void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms) override;
+  void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms, std::vector<float> jointRadii) override;
   void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) override;
   void SetHandActionEnabled(const int32_t aControllerIndex, bool aEnabled = false) override;
   void SetMode(const int32_t aControllerIndex, ControllerMode aMode = ControllerMode::None) override;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -80,7 +80,7 @@ public:
   virtual bool IsVisible() const = 0;
   virtual void SetVisible(const bool aVisible) = 0;
   virtual void SetGazeModeIndex(const int32_t aControllerIndex) = 0;
-  virtual void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms) = 0;
+  virtual void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms, std::vector<float> jointRadii) = 0;
   virtual void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) = 0;
   virtual void SetHandActionEnabled(const int32_t aControllerIndex, bool aEnabled = false) = 0;
   virtual void SetMode(const int32_t aControllerIndex, ControllerMode aMode = ControllerMode::None) = 0;

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -589,7 +589,9 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     // Prepare and submit hand joint locations data for rendering
     assert(mHasHandJoints);
     std::vector<vrb::Matrix> jointTransforms;
+    std::vector<float> jointRadii;
     jointTransforms.resize(mHandJoints.size());
+    jointRadii.resize(mHandJoints.size());
     for (int i = 0; i < mHandJoints.size(); i++) {
         vrb::Matrix transform = XrPoseToMatrix(mHandJoints[i].pose);
         bool positionIsValid = IsHandJointPositionValid((XrHandJointEXT) i, mHandJoints);
@@ -602,6 +604,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
         }
 
         jointTransforms[i] = transform;
+        jointRadii[i] = mHandJoints[i].radius;
     }
 
     // This is not really needed. It's just an optimization for devices taking over the control of
@@ -631,7 +634,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
 
     // We should handle the gesture whenever the system does not handle it.
     bool isHandActionEnabled = systemGestureDetected && (!systemTakesOverWhenHandsFacingHead || mHandeness == Left);
-    delegate.SetHandJointLocations(mIndex, std::move(jointTransforms));
+    delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
     delegate.SetAimEnabled(mIndex, hasAim);
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
     delegate.SetMode(mIndex, ControllerMode::Hand);


### PR DESCRIPTION
To support the WebXR Hand Input spec we need to keep track of the radius of all joints in the controller object.
See <https://www.w3.org/TR/webxr-hand-input-1/#xrjointpose-interface> Right now we only store the joint transforms.

Though we do store it in the OpenXR backend, the info is also needed in common code to be able to move it to the web engine when system state is pushed.

This change is part of an upcoming series that will add support for WebXR hand-tracking in Wolvic/Chromium.