### PR TITLE
Use move semantics to save hand transforms deep copies

### DIFF
--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -199,7 +199,7 @@ ControllerContainer::InitializeBeam() {
   }
 }
 
-void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, const std::vector<vrb::Matrix>& jointTransforms)
+void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms)
 {
     if (!m.Contains(aControllerIndex))
         return;
@@ -208,7 +208,7 @@ void ControllerContainer::SetHandJointLocations(const int32_t aControllerIndex, 
     if (!m.root)
         return;
 
-    controller.handJointTransforms = jointTransforms;
+    controller.handJointTransforms = std::move(jointTransforms);
 
     // Initialize left and right hands action button, which for now triggers back navigation
     // and exit app respectively.

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -67,7 +67,7 @@ public:
   bool IsVisible() const override;
   void SetVisible(const bool aVisible) override;
   void SetGazeModeIndex(const int32_t aControllerIndex) override;
-  void SetHandJointLocations(const int32_t aControllerIndex, const std::vector<vrb::Matrix>& jointTransforms) override;
+  void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms) override;
   void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) override;
   void SetHandActionEnabled(const int32_t aControllerIndex, bool aEnabled = false) override;
   void SetMode(const int32_t aControllerIndex, ControllerMode aMode = ControllerMode::None) override;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -80,7 +80,7 @@ public:
   virtual bool IsVisible() const = 0;
   virtual void SetVisible(const bool aVisible) = 0;
   virtual void SetGazeModeIndex(const int32_t aControllerIndex) = 0;
-  virtual void SetHandJointLocations(const int32_t aControllerIndex, const std::vector<vrb::Matrix>& jointTransforms) = 0;
+  virtual void SetHandJointLocations(const int32_t aControllerIndex, std::vector<vrb::Matrix> jointTransforms) = 0;
   virtual void SetAimEnabled(const int32_t aControllerIndex, bool aEnabled = true) = 0;
   virtual void SetHandActionEnabled(const int32_t aControllerIndex, bool aEnabled = false) = 0;
   virtual void SetMode(const int32_t aControllerIndex, ControllerMode aMode = ControllerMode::None) = 0;

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -629,7 +629,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
 
     // We should handle the gesture whenever the system does not handle it.
     bool isHandActionEnabled = systemGestureDetected && (!systemTakesOverWhenHandsFacingHead || mHandeness == Left);
-    delegate.SetHandJointLocations(mIndex, jointTransforms);
+    delegate.SetHandJointLocations(mIndex, std::move(jointTransforms));
     delegate.SetAimEnabled(mIndex, hasAim);
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
     delegate.SetMode(mIndex, ControllerMode::Hand);


### PR DESCRIPTION
When hand tracking is used we need to store the hand joint transforms (matrices basically) in the controller containers. We do it for every frame. Right now the set method receives a const reference to a vector that is assigned to a vector member inside Controller. This means that we are effectively doing deep copies of all those vectors.

Instead we can just simply replace the const reference by a pass by value attribute. Inside Controller we use move semantics to move the function attribute to the class member. That way if the caller passes a lvalue then the code does 1 copy, but if the caller passes and rvalue (as this patch does using std::move) then no copy will be made and vector internals are just being moved around.