### PR TITLE
[Chromium] Disable Vulkan for x64 builds

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -179,6 +179,8 @@ public class RuntimeImpl implements WRuntime {
         CommandLine.init(new String[] {});
         if (BuildConfig.DEBUG)
             CommandLine.getInstance().appendSwitchWithValue("enable-logging", "stderr");
+        if (BuildConfig.FLAVOR_abi == "x64")
+            CommandLine.getInstance().appendSwitchWithValue("disable-features", "Vulkan");
         setupWebGLMSAA();
         DeviceUtils.addDeviceSpecificUserAgentSwitch();
         LibraryLoader.getInstance().ensureInitialized();


### PR DESCRIPTION
We've been seeing an important number of crashes on the Chromium side with vulkan related backtraces when running it on a x64 device as the Magic Leap 2. Looks like Chromium automatically enables Vulkan for x64. When using Chromium with ARM devices the selected graphics context is OpenGLES instead (see gpu/command_buffer/service/shared_context_state.cc in Chromium).

Furthermore it looks like it's interferring in some nasty ways, for example videos do not render anything if vulkan is enabled.