### PR TITLE
Allow jumping to the video start/end by clicking on time labels

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/MediaSeekBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/MediaSeekBar.java
@@ -170,6 +170,14 @@ public class MediaSeekBar extends LinearLayout implements SeekBar.OnSeekBarChang
         return mSeekBar;
     }
 
+    public View getLeftTextView() {
+        return mLeftText;
+    }
+
+    public View getRightTextView() {
+        return mRightText;
+    }
+
     private void updateProgress() {
         if (mTouching || mDuration <= 0) {
             return;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
@@ -137,6 +137,14 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
             mBinding.mediaBackButton.requestFocusFromTouch();
         });
 
+        mBinding.mediaControlSeekBar.getLeftTextView().setOnClickListener(v -> {
+            mMedia.seek(0);
+        });
+
+        mBinding.mediaControlSeekBar.getRightTextView().setOnClickListener(v -> {
+            mMedia.seek(mMedia.getDuration());
+        });
+
         mBinding.mediaControlSeekBar.setDelegate(new MediaSeekBar.Delegate() {
             @Override
             public void onSeekDragStart() {


### PR DESCRIPTION
Get the inspiration from YouTube VR App. It's particularly useful for allow clicking the left time label, as now it's much easier to restart the video without the need to drag the seek bar.

https://github.com/Igalia/wolvic/assets/43995067/823c1de1-b540-4eea-8725-15fc2438bd9c

