### PR TITLE
[Chromium] Add support for WebXR Hand Input Module - Level 1

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -181,6 +181,10 @@ public class RuntimeImpl implements WRuntime {
             CommandLine.getInstance().appendSwitchWithValue("enable-logging", "stderr");
         if (BuildConfig.FLAVOR_abi == "x64")
             CommandLine.getInstance().appendSwitchWithValue("disable-features", "Vulkan");
+
+        // Enable WebXR Hand Input, which is disabled by default in blink (experimental)
+        CommandLine.getInstance().appendSwitchWithValue("enable-features", "WebXRHandInput");
+
         setupWebGLMSAA();
         DeviceUtils.addDeviceSpecificUserAgentSwitch();
         LibraryLoader.getInstance().ensureInitialized();

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -508,8 +508,6 @@ ExternalVR::PushFramePoses(const vrb::Matrix& aHeadTransform, const std::vector<
       continue;
     }
     mozilla::gfx::VRControllerState& immersiveController = m.system.controllerState[i];
-    memset(&immersiveController, 0, sizeof(immersiveController));
-
     memcpy(immersiveController.controllerName, controller.immersiveName.c_str(), controller.immersiveName.size() + 1);
     immersiveController.numButtons = controller.numButtons;
     immersiveController.buttonPressed = controller.immersivePressedState;
@@ -541,11 +539,11 @@ ExternalVR::PushFramePoses(const vrb::Matrix& aHeadTransform, const std::vector<
     }
 
     if (flags & static_cast<uint16_t>(mozilla::gfx::ControllerCapabilityFlags::Cap_GripSpacePosition)) {
-      vrb::Matrix immersiveBeamTransform;
-      if (controller.mode == ControllerMode::Device)
-        immersiveBeamTransform = controller.immersiveBeamTransform;
-      else
-        immersiveBeamTransform = controller.transformMatrix.PostMultiply(controller.immersiveBeamTransform);
+#ifdef OPENXR
+      auto immersiveBeamTransform = controller.immersiveBeamTransform;
+#else
+      auto immersiveBeamTransform = controller.transformMatrix.PostMultiply(controller.immersiveBeamTransform);
+#endif
       vrb::Vector position(immersiveBeamTransform.GetTranslation());
       vrb::Quaternion rotate(immersiveBeamTransform.AfineInverse());
       memcpy(&(immersiveController.pose.position), position.Data(), sizeof(immersiveController.pose.position));

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -367,6 +367,21 @@ struct VRDisplayState {
 #endif
 };
 
+#if CHROMIUM
+// WebXR hand-tracking support
+struct VRHandJointData {
+  float transform[16];
+  float radius;
+};
+
+// https://www.w3.org/TR/webxr-hand-input-1/#skeleton-joints-section
+static const uint32_t kHandTrackingNumJoints = 25;
+
+struct VRHandTrackingData {
+  VRHandJointData handJointData[kHandTrackingNumJoints];
+};
+#endif
+
 struct VRControllerState {
   char controllerName[kVRControllerNameMaxLen];
 #ifdef MOZILLA_INTERNAL_API
@@ -431,6 +446,11 @@ struct VRControllerState {
 
   bool isPositionValid;
   bool isOrientationValid;
+
+#if CHROMIUM
+  bool hasHandTrackingData;
+  VRHandTrackingData handTrackingData;
+#endif
 
 #ifdef MOZILLA_INTERNAL_API
   void Clear() { memset(this, 0, sizeof(VRControllerState)); }

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -691,11 +691,8 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     }
 #endif
 
-    vrb::Matrix pointerTransformStandalone;
     if (renderMode == device::RenderMode::StandAlone)
-        pointerTransformStandalone = pointerTransform.Translate(kAverageHeight);
-    else
-        pointerTransformStandalone = pointerTransform;
+        pointerTransform.TranslateInPlace(kAverageHeight);
 
 #if CHROMIUM
     // Blink WebXR uses the grip space instead of the local space to position the

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -691,8 +691,11 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     }
 #endif
 
+    vrb::Matrix pointerTransformStandalone;
     if (renderMode == device::RenderMode::StandAlone)
-        pointerTransform.TranslateInPlace(kAverageHeight);
+        pointerTransformStandalone = pointerTransform.Translate(kAverageHeight);
+    else
+        pointerTransformStandalone = pointerTransform;
 
 #if CHROMIUM
     // Blink WebXR uses the grip space instead of the local space to position the


### PR DESCRIPTION
https://www.w3.org/TR/webxr-hand-input-1/

This patch adds pushing the current hand-tracking info we already have for each controller, to the web engine, as part of the regular system state synchronization.

The chromium backend, in turn, will pass this state (namely the hand-joint poses and radius) to its already existing WebXR hand-tracking infrastructure.

@FIXME: For now we are not using any hand-specific interaction profile (see https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_EXT_hand_interaction) because we don't support the XR_EXT_hand_interaction extension yet; and also because we currently emulate controllers when in hand-tracking mode to allow web apps that don't support WebXR hand-tracking to be usable with the hands.

It can be tested with e.g:
* https://immersive-web.github.io/webxr-samples/immersive-hands.html
* https://developer.playcanvas.com/en/tutorials/webxr-hands/