### PR TITLE
Updated App Lab warning message

### DIFF
--- a/app/src/main/res/layout/deprecated_version_dialog.xml
+++ b/app/src/main/res/layout/deprecated_version_dialog.xml
@@ -3,11 +3,12 @@
 
     <RelativeLayout
         android:layout_width="@dimen/prompt_dialog_width"
-        android:layout_height="@dimen/prompt_dialog_height"
+        android:layout_height="wrap_content"
         android:background="@drawable/dialog_background"
         android:paddingStart="20dp"
         android:paddingTop="@dimen/prompt_dialog_padding_top"
         android:paddingEnd="20dp"
+        android:minHeight="@dimen/prompt_dialog_height"
         android:paddingBottom="@dimen/prompt_dialog_padding_bottom">
 
         <FrameLayout

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1913,6 +1913,10 @@ the Select` button. When clicked it closes all the previously selected tabs -->
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->
     <string name="whats_new_button_start_browsing">Lossurfen</string>
 
+    <string name="deprecated_version_dialog_title">Support endet bald</string>
+    <string name="deprecated_version_dialog_body">Diese \"App Lab\"-Version von Wolvic wird bis Ende Oktober 2023 entfernt.
+        \n\nBitte installieren Sie die neueste Version von Wolvic aus dem Meta Quest Store.
+        \n\nWICHTIG: Wenn Sie Sync nicht verwenden, wird die neue Wolvic-App Ihre Lesezeichen und Tabs nicht haben.</string>
 
     <!-- This string is displayed in the title of the slow script dialog. -->
     <string name="slow_script_dialog_title">Langsames Skript</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1742,12 +1742,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="web_apps_saved_notification">¡Aplicación web añadida!</string>
     <string name="download_addon_install">Instalar complemento</string>
     <string name="settings_language_portuguese">Portugués</string>
-    <string name="deprecated_version_dialog_title">Actualización necesaria</string>
-    <string name="deprecated_version_dialog_body">Esta versión de desarrollo de Wolvic dejará de estar disponible en breve.
-\n
-\nPor favor, instala la versión más reciente de Wolvic desde Oculus Store.
-\n
-\nIMPORTANTE: a menos que utilices Firefox Sync, la nueva aplicación Wolvic no tendrá tus marcadores y pestañas.</string>
     <string name="deprecated_version_dialog_info_button">Más información…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>
     <string name="security_options_permission_fine_location_warning">Wolvic sólo puede obtener tu ubicación aproximada. Esto se puede cambiar en la configuración del sistema.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1920,8 +1920,8 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_button_start_browsing">Comenzar a navegar</string>
 
     <string name="deprecated_version_dialog_title">Actualización necesaria</string>
-    <string name="deprecated_version_dialog_body">Esta versión de desarrollo de Wolvic dejará de estar disponible en breve.
-        \n\nPor favor, instala la versión más actual de Wolvic desde la tienda de Oculus.
+    <string name="deprecated_version_dialog_body">Esta versión de desarrollo de Wolvic dejará de estar disponible a finales de Octubre de 2023.
+        \n\nPor favor, instala la versión más actual de Wolvic desde la Meta Quest Store.
         \n\nIMPORTANTE: a menos que uses Firefox Sync, la nueva app de Wolvic no tendrá tus marcadores ni tus páginas abiertas.</string>
     <string name="deprecated_version_dialog_info_button">Aprender más…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1763,9 +1763,9 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="deprecated_version_dialog_info_button">En savoir plus…</string>
     <string name="deprecated_version_dialog_store_button">Installer…</string>
     <string name="hamburger_menu_toggle_passthrough">Passthrough</string>
-    <string name="deprecated_version_dialog_body">Cette version de développement de Wolvic sera bientôt discontinuée.
+    <string name="deprecated_version_dialog_body">Cette version de développement de Wolvic sera discontinuée à la fin d\'octobre 2023.
 \n
-\nVeuillez installer la nouvelle version de Wolvic à partir de l’Oculus Store.
+\nVeuillez installer la nouvelle version de Wolvic à partir de la Meta Quest Store.
 \n
 \nIMPORTANT : hormis si vous utilisez Firefox Sync, la nouvelle application Wolvic n’aura ni vos marque-pages ni vos onglets.</string>
     <string name="rCN_first_launch_body">Bienvenue dans « Wolvic » !

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -685,8 +685,8 @@
     <string name="hamburger_menu_addons">Complementos</string>
     <string name="whats_new_button_start_browsing">Comezar a navegar</string>
     <string name="deprecated_version_dialog_title">Actualización necesaria</string>
-    <string name="deprecated_version_dialog_body">Esta versión de desenrolo de Wolvic deixará de estar dispoñible en breve.
-        \n\nPor favor, instala a versión máis actual de Wolvic dende la tenda de Oculus.
+    <string name="deprecated_version_dialog_body">Esta versión de desenrolo de Wolvic deixará de estar dispoñible a finais de Outubro de 2023.
+        \n\nPor favor, instala a versión máis actual de Wolvic dende a Meta Quest Store.
         \n\nIMPORTANTE: a menos que uses Firefox Sync, a nova app de Wolvic non terá os teus marcadores nen as tuas páxinas abertas.</string>
     <string name="deprecated_version_dialog_info_button">Aprender máis…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1655,9 +1655,9 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="settings_language_portuguese">ポルトガル語</string>
     <string name="security_options_permission_fine_location_warning">Wolvicはおおよその位置情報のアクセスに限られています。この設定はシステム設定で変更できます。</string>
     <string name="deprecated_version_dialog_title">推奨アップデート</string>
-    <string name="deprecated_version_dialog_body">現在「App Lab」開発版のWolvicをご利用されています。
+    <string name="deprecated_version_dialog_body">現在「App Lab」開発版のWolvicをご利用されています。2023年10月の終わりまでに廃止される予定です。
 \n
-\nOculus Storeから最新版のWolvicをインストールしてください。
+\nMeta Quest Storeから最新版のWolvicをインストールしてください。
 \n
 \n重要：Firefox Syncを利用していない場合、最新版のWolvicにブックマークとタブは同期されません。</string>
     <string name="voice_service_huawei_asr">Huawei Automatic Speech Recognition</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1758,7 +1758,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="hamburger_menu_toggle_passthrough">패스스루</string>
     <string name="deprecated_version_dialog_title">권장 업데이트</string>
     <string name="security_options_permission_fine_location_warning">울빅은 당신의 대략적인 위치만 알 수 있습니다. 이는 시스템 설정에서 변경할 수 있습니다.</string>
-    <string name="deprecated_version_dialog_body">현재 울빅의 개발 버전인 \"App Lab\"을 실행하고 있습니다.
+    <string name="deprecated_version_dialog_body">현재 울빅의 개발 버전인 \"App Lab\"을 실행하고 있습니다.2023년 10월 말에 중단될 예정입니다.
 \n
 \n오큘러스 스토어에서 최신 버전의 울빅을 설치하세요.
 \n

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -630,8 +630,8 @@
     <string name="whats_new_body_1">Inicie sessão ou crie uma nova Conta Firefox para enviar guias do Firefox do computador ou dispositivo móvel para o seu fone de ouvido.</string>
     <string name="whats_new_button_start_browsing">Iniciar navegação</string>
     <string name="deprecated_version_dialog_title">Actualização necessária</string>
-    <string name="deprecated_version_dialog_body">Esta versão de desenvolvimento do Wolvic será descontinuada em breve.
-        \n\nPor favor, instale a última versão de Wolvic a partir da loja Oculus.
+    <string name="deprecated_version_dialog_body">Esta versão de desenvolvimento do Wolvic será descontinuada no final de outubro de 2023.
+        \n\nPor favor, instale a última versão de Wolvic a partir da Meta Quest Store.
         \n\nIMPORTANTE: a menos que utilize Firefox Sync, a nova aplicação Wolvic não terá os seus marcadores e páginas abertas.</string>
     <string name="deprecated_version_dialog_info_button">Saber mais…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2046,9 +2046,9 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="security_options_permission_fine_location_warning">Wolvic 只可以获取您的大致位置。 您可在系统设置菜单更改设置。</string>
     <string name="upload_list_empty">无可上载文档</string>
     <string name="hamburger_menu_toggle_passthrough">通过</string>
-    <string name="deprecated_version_dialog_body">您当前在运行一Wolvic \"试验应用\" 开发版本。
+    <string name="deprecated_version_dialog_body">您当前在运行一Wolvic \"试验应用\" 开发版本。它将在2023年10月底停止使用。
 \n
-\n请安装 Oculus 商店的Wolvic最新版本。
+\n请安装 Meta Quest 商店的Wolvic最新版本。
 \n
 \n重要提示：除非您用火狐同步，新版 Wolvic应用不会有你的书签和标签页。</string>
     <string name="deprecated_version_dialog_title">建议的更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2062,8 +2062,8 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_button_start_browsing">Start Browsing</string>
 
     <string name="deprecated_version_dialog_title">Support ending soon</string>
-    <string name="deprecated_version_dialog_body">This \"App Lab\" version of Wolvic will be removed soon.
-        \n\nPlease install the latest version of Wolvic from the Meta Store.
+    <string name="deprecated_version_dialog_body">This \"App Lab\" version of Wolvic will be removed by the end of October 2023.
+        \n\nPlease install the latest version of Wolvic from the Meta Quest Store.
         \n\nIMPORTANT: unless you use Sync, the new Wolvic app will not have your bookmarks and tabs.</string>
     <string name="deprecated_version_dialog_info_button">Learn more…</string>
     <string name="deprecated_version_dialog_info_url" translatable="false">https://wolvic.com/support/firefox-sync/</string>


### PR DESCRIPTION
Update the warning message that appears on startup on the AppLab version of Wolvic.

This is the updated message:

> **Support ending soon**
> 
> This "App Lab" version of Wolvic will be removed by the end of October 2023.
> 
> Please install the latest version of Wolvic from the Meta Quest Store.
> 
> IMPORTANT: unless you use Sync, the new Wolvic app will not have your bookmarks and tabs.