### PR TITLE
[HVR] Allow Wolvic to run in different phones with Huawei Glasses

### DIFF
--- a/app/src/main/cpp/DeviceUtils.cpp
+++ b/app/src/main/cpp/DeviceUtils.cpp
@@ -117,13 +117,18 @@ device::DeviceType DeviceUtils::GetDeviceTypeFromSystem(bool is6DoF) {
     char model[128];
     int length = PopulateDeviceModelString(model);
 
+#ifdef HVR
+    // Huawei glasses can be attached to multiple different phones, so we basically cannot filter
+    // by device type in this case.
+    return is6DoF ? device::HVR6DoF : device::HVR3DoF;
+#endif
+
     if (deviceNamesMap.empty()) {
         deviceNamesMap.emplace("Quest", device::OculusQuest);
         deviceNamesMap.emplace("Quest 2", device::OculusQuest2);
         // So far no need to differentiate between Pico4 and Pico4E
         deviceNamesMap.emplace("A8110", device::PicoXR);
         deviceNamesMap.emplace("Lynx-R1", device::LynxR1);
-        deviceNamesMap.emplace("kirin9000", is6DoF ? device::HVR6DoF : device::HVR3DoF);
         deviceNamesMap.emplace("motorola edge 30 pro", device::LenovoA3);
         deviceNamesMap.emplace("Quest Pro", device::MetaQuestPro);
         deviceNamesMap.emplace("VRX", device::LenovoVRX);


### PR DESCRIPTION
Huawei Glasses can be attached to different Huawei phones. With our new filtering based on the product model returned by Android, we were limitting it to only run on the Mate 40 Pro (the one we have been used for testing).

It's better not to be attached to any particular model in the case of the HVR build to allow it to be run in multiple compatible devices.

Fixes #1053