### PR TITLE
Fix several issues related to VR videos playing

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -743,9 +743,6 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         }
         closeFloatingMenus();
         mWidgetManager.pushWorldBrightness(mBrightnessWidget, mBrightnessWidget.getSelectedBrightness());
-        // Disable curved window for 3D side by side video
-        mSavedCylinderDensity = mWidgetManager.getCylinderDensity();
-        mWidgetManager.setCylinderDensityForce(0.0f);
     }
 
     private void exitFullScreenMode() {
@@ -776,7 +773,6 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isKioskMode());
         closeFloatingMenus();
         mWidgetManager.popWorldBrightness(mBrightnessWidget);
-        mWidgetManager.setCylinderDensityForce(mSavedCylinderDensity);
     }
 
     private void enterResizeMode() {
@@ -872,6 +868,14 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         if (mViewModel.getIsInVRVideo().getValue().get()) {
             return;
         }
+
+        // Remember the cylinder density before we enter VR video
+        mSavedCylinderDensity = mWidgetManager.getCylinderDensity();
+        // We have to disable curved display temporary if we are playing front facing VR videos
+        if (isFrontFacingVRProjection(aProjection)) {
+            mWidgetManager.setCylinderDensityForce(0.0f);
+        }
+
         mViewModel.setIsInVRVideo(true);
         mWidgetManager.pushBackHandler(mVRVideoBackHandler);
         mProjectionMenu.setSelectedProjection(aProjection);
@@ -958,6 +962,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mViewModel.setAutoEnteredVRVideo(false);
         AnimationHelper.fadeIn(mBinding.navigationBarFullscreen.fullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
 
+        mWidgetManager.setCylinderDensityForce(mSavedCylinderDensity);
         // Reposition UI in front of the user when exiting a VR video.
         mWidgetManager.recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL);
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -865,7 +865,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
     }
 
     private void enterVRVideo(@VideoProjectionMenuWidget.VideoProjectionFlags int aProjection) {
-        if (mViewModel.getIsInVRVideo().getValue().get()) {
+        if (mViewModel.getIsInVRVideo().getValue().get() || aProjection == VIDEO_PROJECTION_NONE) {
             return;
         }
 


### PR DESCRIPTION
- Preserve curved screen when playing 2D video

Only disable the curved screen when it's playing front facing 3d VR videos
Resolve #1055

- Return when we enterVRVideo with non-projection

So that we won't have a crash when the user reselects 2D projection and we are already playing in 2D full-screen mode.