### PR TITLE
[Chromium] Fix emulated controller position

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -694,9 +694,19 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     if (renderMode == device::RenderMode::StandAlone)
         pointerTransform.TranslateInPlace(kAverageHeight);
 
+#if CHROMIUM
+    // Blink WebXR uses the grip space instead of the local space to position the
+    // controller. Since controller's position is the same as the origin of the
+    // grip space, we just set the transform matrix to the identity.
+    // Then we need to correct the beam transform matrix to maintain origin and
+    // direction when we are not in immersive mode.
+    delegate.SetTransform(mIndex, vrb::Matrix::Identity());
+    delegate.SetBeamTransform(mIndex, pointerTransform);
+#else
     delegate.SetTransform(mIndex, pointerTransform);
-    delegate.SetImmersiveBeamTransform(mIndex, pointerTransform);
     delegate.SetBeamTransform(mIndex, vrb::Matrix::Identity());
+#endif
+    delegate.SetImmersiveBeamTransform(mIndex, pointerTransform);
 
     device::CapabilityFlags flags = device::Orientation | device::Position | device::GripSpacePosition;
     delegate.SetCapabilityFlags(mIndex, flags);


### PR DESCRIPTION
Right now Wolvic/Chromium shows a wrong position when controllers are emulated during hand-tracking. This is due to the fact that blink uses the grip space for the controller position, instead of the local space.

For actual controllers, we already fixed this in 95c24cb48, and this is the fix for emulated controllers. It sets the controller's `transformMatrix` to the identity matrix, because this grip position's origin coincides with the controller position. But then we need to correct the start position and direction of the beam by setting the controller's `beamTransformMatrix`; which is used together with the `transformMatrix` to calculate origin and direction (see Controller::StartPoint and Controller::Orientation).