### PR TITLE
Enable haptic feedback for controllers

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -246,6 +246,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         @Override
         public void onGlobalFocusChanged(View oldFocus, View newFocus) {
             Log.d(LOGTAG, "======> OnGlobalFocusChangeListener: old(" + oldFocus + ") new(" + newFocus + ")");
+            triggerHapticFeedback();
             for (FocusChangeListener listener: mFocusChangeListeners) {
                 listener.onGlobalFocusChanged(oldFocus, newFocus);
             }
@@ -1822,6 +1823,14 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    public void triggerHapticFeedback() {
+        SettingsStore settings = SettingsStore.getInstance(this);
+        if (settings.isHapticFeedbackEnabled()) {
+            queueRunnable(() -> triggerHapticFeedbackNative(settings.getHapticPulseDuration(), settings.getHapticPulseIntensity()));
+        }
+    }
+
+    @Override
     public void setControllersVisible(final boolean aVisible) {
         queueRunnable(() -> setControllersVisibleNative(aVisible));
     }
@@ -2024,6 +2033,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void startWidgetMoveNative(int aHandle, int aMoveBehaviour);
     private native void finishWidgetMoveNative();
     private native void setWorldBrightnessNative(float aBrightness);
+    private native void triggerHapticFeedbackNative(float aPulseDuration, float aPulseIntensity);
     private native void setTemporaryFilePath(String aPath);
     private native void exitImmersiveNative();
     private native void workaroundGeckoSigAction();

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1096,14 +1096,14 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             final float y = aY / scale;
 
             if (widget == null) {
-                MotionEventGenerator.dispatch(mRootWidget, aDevice, aFocused, aPressed, x, y);
+                MotionEventGenerator.dispatch(this, mRootWidget, aDevice, aFocused, aPressed, x, y);
 
             } else if (widget.getBorderWidth() > 0) {
                 final int border = widget.getBorderWidth();
-                MotionEventGenerator.dispatch(widget, aDevice, aFocused, aPressed, x - border, y - border);
+                MotionEventGenerator.dispatch(this, widget, aDevice, aFocused, aPressed, x - border, y - border);
 
             } else {
-                MotionEventGenerator.dispatch(widget, aDevice, aFocused, aPressed, x, y);
+                MotionEventGenerator.dispatch(this, widget, aDevice, aFocused, aPressed, x, y);
             }
         });
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -97,6 +97,9 @@ public class SettingsStore {
     public final static int MSAA_DEFAULT_LEVEL = 1;
     public final static boolean AUDIO_ENABLED = false;
     public final static float CYLINDER_DENSITY_ENABLED_DEFAULT = 4680.0f;
+    public final static float HAPTIC_PULSE_DURATION_DEFAULT = 10.0f;
+    public final static float HAPTIC_PULSE_INTENSITY_DEFAULT = 1.0f;
+    public final static boolean HAPTIC_FEEDBACK_ENABLED = false;
     private final static long CRASH_RESTART_DELTA = 2000;
     public final static boolean AUTOPLAY_ENABLED = false;
     public final static boolean DEBUG_LOGGING_DEFAULT = BuildConfig.DEBUG;
@@ -581,6 +584,36 @@ public class SettingsStore {
 
     public boolean isCurvedModeEnabled() {
         return getCylinderDensity() > 0;
+    }
+
+    public float getHapticPulseDuration() {
+        return mPrefs.getFloat(mContext.getString(R.string.settings_key_haptic_pulse_duration), HAPTIC_PULSE_DURATION_DEFAULT);
+    }
+
+    public void setHapticPulseDuration(float aPulseDuration) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putFloat(mContext.getString(R.string.settings_key_haptic_pulse_duration), aPulseDuration);
+        editor.commit();
+    }
+
+    public float getHapticPulseIntensity() {
+        return mPrefs.getFloat(mContext.getString(R.string.settings_key_haptic_pulse_intensity), HAPTIC_PULSE_INTENSITY_DEFAULT);
+    }
+
+    public void setHapticPulseIntensity(float aPulseIntensity) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putFloat(mContext.getString(R.string.settings_key_haptic_pulse_intensity), aPulseIntensity);
+        editor.commit();
+    }
+
+    public void setHapticFeedbackEnabled(boolean isEnabled) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(mContext.getString(R.string.settings_key_haptic_feedback_enabled), isEnabled);
+        editor.commit();
+    }
+
+    public boolean isHapticFeedbackEnabled() {
+        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_haptic_feedback_enabled), HAPTIC_FEEDBACK_ENABLED);
     }
 
     public void setSelectedKeyboard(Locale aLocale) {

--- a/app/src/common/shared/com/igalia/wolvic/input/MotionEventGenerator.java
+++ b/app/src/common/shared/com/igalia/wolvic/input/MotionEventGenerator.java
@@ -12,6 +12,7 @@ import android.view.InputDevice;
 import android.view.MotionEvent;
 
 import com.igalia.wolvic.ui.widgets.Widget;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import java.util.Arrays;
@@ -86,7 +87,7 @@ public class MotionEventGenerator {
         event.recycle();
     }
 
-    public static void dispatch(Widget aWidget, int aDevice, boolean aFocused, boolean aPressed, float aX, float aY) {
+    public static void dispatch(WidgetManagerDelegate widgetManager, Widget aWidget, int aDevice, boolean aFocused, boolean aPressed, float aX, float aY) {
         Device device = devices.get(aDevice);
         if (device == null) {
             device = new Device(aDevice);
@@ -119,6 +120,7 @@ public class MotionEventGenerator {
         }
         if (aWidget != device.mPreviousWidget && !aPressed) {
             generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_ENTER, true);
+            widgetManager.triggerHapticFeedback();
             device.mHoverStartWidget = aWidget;
         }
         if (aPressed && !device.mWasPressed) {
@@ -140,6 +142,7 @@ public class MotionEventGenerator {
             if (!isOtherDeviceDown(device.mDevice)) {
                 generateEvent(device.mTouchStartWidget, device, aFocused, MotionEvent.ACTION_UP, false);
                 generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_ENTER, true);
+                widgetManager.triggerHapticFeedback();
                 device.mHoverStartWidget = aWidget;
             }
             device.mTouchStartWidget = null;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -558,6 +558,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     @Override
     public void onPress(int primaryCode) {
         Log.d(LOGTAG, "Keyboard onPress " + primaryCode);
+        mWidgetManager.triggerHapticFeedback();
     }
 
     @Override
@@ -606,6 +607,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             handleDomainLongPress();
             mIsLongPress = true;
         }
+        mWidgetManager.triggerHapticFeedback();
     }
 
     public void onMultiTap(Keyboard.Key key) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -77,6 +77,7 @@ public interface WidgetManagerDelegate {
     void pushWorldBrightness(Object aKey, float aBrightness);
     void setWorldBrightness(Object aKey, float aBrightness);
     void popWorldBrightness(Object aKey);
+    void triggerHapticFeedback();
     void setControllersVisible(boolean visible);
     void setWindowSize(float targetWidth, float targetHeight);
     void keyboardDismissed();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -14,6 +14,7 @@ import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsControllerBinding;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
+import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 
 class ControllerOptionsView extends SettingsView {
@@ -53,6 +54,9 @@ class ControllerOptionsView extends SettingsView {
         int scrollDirection = SettingsStore.getInstance(getContext()).getScrollDirection();
         mBinding.scrollDirectionRadio.setOnCheckedChangeListener(mScrollDirectionListener);
         setScrollDirection(mBinding.scrollDirectionRadio.getIdForValue(scrollDirection), false);
+
+        mBinding.hapticFeedbackSwitch.setOnCheckedChangeListener(mHapticFeedbackListener);
+        setHapticFeedbackEnabled(SettingsStore.getInstance(getContext()).isHapticFeedbackEnabled(), false);
     }
 
     private void resetOptions() {
@@ -62,6 +66,7 @@ class ControllerOptionsView extends SettingsView {
         if (!mBinding.scrollDirectionRadio.getValueForId(mBinding.scrollDirectionRadio.getCheckedRadioButtonId()).equals(SettingsStore.SCROLL_DIRECTION_DEFAULT)) {
             setScrollDirection(mBinding.scrollDirectionRadio.getIdForValue(SettingsStore.SCROLL_DIRECTION_DEFAULT), true);
         }
+        setHapticFeedbackEnabled(SettingsStore.HAPTIC_FEEDBACK_ENABLED, true);
     }
 
     private void setPointerColor(int checkedId, boolean doApply) {
@@ -85,6 +90,16 @@ class ControllerOptionsView extends SettingsView {
         }
     }
 
+    private void setHapticFeedbackEnabled(boolean value, boolean doApply) {
+        mBinding.hapticFeedbackSwitch.setOnCheckedChangeListener(null);
+        mBinding.hapticFeedbackSwitch.setValue(value, false);
+        mBinding.hapticFeedbackSwitch.setOnCheckedChangeListener(mHapticFeedbackListener);
+
+        if (doApply) {
+            SettingsStore.getInstance(getContext()).setHapticFeedbackEnabled(value);
+        }
+    }
+
     private RadioGroupSetting.OnCheckedChangeListener mPointerColorListener = (radioGroup, checkedId, doApply) -> {
         setPointerColor(checkedId, doApply);
     };
@@ -92,6 +107,9 @@ class ControllerOptionsView extends SettingsView {
     private RadioGroupSetting.OnCheckedChangeListener mScrollDirectionListener = (radioGroup, checkedId, doApply) -> {
         setScrollDirection(checkedId, doApply);
     };
+
+    private SwitchSetting.OnCheckedChangeListener mHapticFeedbackListener = (compoundButton, enabled, apply) ->
+    setHapticFeedbackEnabled(enabled, true);
 
     @Override
     protected SettingViewType getType() {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1179,6 +1179,21 @@ BrowserWorld::EndFrame() {
 }
 
 void
+BrowserWorld::TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity) {
+  if (!m.controllers) {
+    return;
+  }
+
+  for (Controller& controller: m.controllers->GetControllers()) {
+    if (!controller.focused || !m.controllers->GetHapticCount(controller.index)) {
+      continue;
+    }
+    m.controllers->SetHapticFeedback(controller.index, controller.inputFrameID + 1, aPulseDuration, aPulseIntensity);
+    return;
+  }
+}
+
+void
 BrowserWorld::Draw(device::Eye aEye) {
   ASSERT_ON_RENDER_THREAD();
   if (m.drawHandler) {
@@ -2006,6 +2021,11 @@ JNI_METHOD(void, finishWidgetMoveNative)
 JNI_METHOD(void, setWorldBrightnessNative)
 (JNIEnv*, jobject, jfloat aBrightness) {
   crow::BrowserWorld::Instance().SetBrightness(aBrightness);
+}
+
+JNI_METHOD(void, triggerHapticFeedbackNative)
+(JNIEnv*, jobject, jfloat aPulseDuration, jfloat aPulseIntensity) {
+  crow::BrowserWorld::Instance().TriggerHapticFeedback(aPulseDuration, aPulseIntensity);
 }
 
 JNI_METHOD(void, setTemporaryFilePath)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -47,6 +47,7 @@ public:
   void StartFrame();
   void Draw(device::Eye aEye);
   void EndFrame();
+  void TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity);
   void TogglePassthrough();
   void SetTemporaryFilePath(const std::string& aPath);
   void UpdateEnvironment();

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -649,10 +649,6 @@ ExternalVR::SetHapticState(ControllerContainerPtr aControllerContainer) const {
         break;
       }
     }
-    // All hapticState has already been reset to zero, so it can't be match.
-    if (j == mozilla::gfx::kVRHapticsMaxCount) {
-      aControllerContainer->SetHapticFeedback(i, 0, 0.0f, 0.0f);
-    }
   }
 }
 

--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -40,6 +40,12 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/haptic_feedback_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/controller_options_haptic_feedback" />
+
                 <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
                     android:id="@+id/pointer_color_radio"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -602,6 +602,10 @@
          motion of user input. -->
     <string name="developer_options_scroll_direction_reversed">Reversed</string>
 
+    <!-- This string is used to label the switch that allow the user to enable/disable
+         haptic feedback of the remote controller. -->
+    <string name="controller_options_haptic_feedback">Haptic Feedback</string>
+
     <!-- This string describes what the 'Reset' button in the developer options does which is
          restore all the developer settings to their default value. -->
     <string name="developer_options_reset">Reset Developer Settings</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -468,6 +468,9 @@
          "Reversed" refers to the motion of scrolled material being reversed with respect to direction of
          motion of user input. -->
     <string name="developer_options_scroll_direction_reversed">反向</string>
+    <!-- This string is used to label the switch that allow the user to enable/disable
+         haptic feedback of the remote controller. -->
+    <string name="controller_options_haptic_feedback">触觉反馈</string>
     <!-- This string describes what the 'Reset' button in the developer options does which is
          restore all the developer settings to their default value. -->
     <string name="developer_options_reset">重置开发者设置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -604,6 +604,10 @@
          motion of user input. -->
     <string name="developer_options_scroll_direction_reversed">反向</string>
 
+    <!-- This string is used to label the switch that allow the user to enable/disable
+         haptic feedback of the remote controller. -->
+    <string name="controller_options_haptic_feedback">振動反饋</string>
+
     <!-- This string describes what the 'Reset' button in the developer options does which is
          restore all the developer settings to their default value. -->
     <string name="developer_options_reset">重設開發者設定</string>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -32,6 +32,9 @@
     <string name="settings_key_display_language" translatable="false">settings_display_language</string>
     <string name="settings_key_content_languages" translatable="false">settings_content_languages</string>
     <string name="settings_key_cylinder_density" translatable="false">settings_cylinder_density</string>
+    <string name="settings_key_haptic_pulse_duration" translatable="false">settings_haptic_pulse_duration</string>
+    <string name="settings_key_haptic_pulse_intensity" translatable="false">settings_haptic_pulse_intensity</string>
+    <string name="settings_key_haptic_feedback_enabled" translatable="false">settings_haptic_feedback_enabled</string>
     <string name="settings_key_keyboard_locale" translatable="false">settings_key_keyboard_locale</string>
     <string name="settings_key_crash_restart_count" translatable="false">settings_key_crash_restart_count</string>
     <string name="settings_key_crash_restart_count_timestamp" translatable="false">settings_key_crash_restart_count_timestamp</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -647,6 +647,10 @@
          motion of user input. -->
     <string name="developer_options_scroll_direction_reversed">Reversed</string>
 
+    <!-- This string is used to label the switch that allow the user to enable/disable
+         haptic feedback of the remote controller. -->
+    <string name="controller_options_haptic_feedback">Haptic Feedback</string>
+
     <!-- This string describes what the 'Reset' button in the developer options does which is
          restore all the developer settings to their default value. -->
     <string name="developer_options_reset">Reset Developer Settings</string>


### PR DESCRIPTION
Haptic feedback will be triggered when:
- Android view global focus changes
- press on the keyboard
- `MotionEvent.ACTION_HOVER_ENTER`

Users can disable the haptic feedback in controller settings.

Resolves #1067 
![image](https://github.com/Igalia/wolvic/assets/43995067/ac5723d9-fc73-4c2f-97c5-0c804b02d827)

