### PR TITLE
Improve Device Name in Firefox/Mozilla Sync

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/Services.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/Services.kt
@@ -8,6 +8,7 @@ package com.igalia.wolvic.browser
 import android.content.Context
 import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.igalia.wolvic.BuildConfig
 import com.igalia.wolvic.R
@@ -92,8 +93,8 @@ class Services(val context: Context, places: Places): WSession.NavigationDelegat
         serverConfig = serverConfig,
         deviceConfig = DeviceConfig(
             // This is a default name, and can be changed once user is logged in.
-            // E.g. accountManager.authenticatedAccount()?.deviceConstellation()?.setDeviceNameAsync("new name")
-            name = "${context.getString(R.string.app_name)} on ${Build.MANUFACTURER} ${Build.MODEL}",
+            // E.g. accountManager.authenticatedAccount()?.deviceConstellation()?.setDeviceName("new name", context)
+            name = com.igalia.wolvic.utils.DeviceType.getDeviceName(context),
             type = DeviceType.VR,
             capabilities = setOf(DeviceCapability.SEND_TAB)
         ),

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -415,6 +415,17 @@ public class SettingsStore {
         return (float)getWindowWidth() / (float)getWindowHeight();
     }
 
+    public String getDeviceName() {
+        return mPrefs.getString(
+                mContext.getString(R.string.settings_key_device_name), DeviceType.getDeviceName(mContext));
+    }
+
+    public void setDeviceName(String aDeviceName) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putString(mContext.getString(R.string.settings_key_device_name), aDeviceName);
+        editor.commit();
+    }
+
     public int getDisplayDpi() {
         return mPrefs.getInt(
                 mContext.getString(R.string.settings_key_display_dpi), DISPLAY_DPI_DEFAULT);

--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -1,9 +1,13 @@
 package com.igalia.wolvic.utils;
 
+import android.content.Context;
+import android.os.Build;
+import android.provider.Settings;
 import android.util.Log;
 
 import androidx.annotation.IntDef;
 
+import com.igalia.wolvic.R;
 import com.igalia.wolvic.BuildConfig;
 
 public class DeviceType {
@@ -30,60 +34,60 @@ public class DeviceType {
     public static final int MetaQuest3 = 18;
 
     private static @Type int mType = Unknown;
+    private static String mDeviceName = "Unknown Device";
 
     public static void setType(@Type int aType) {
-        String name;
         switch (aType) {
             case OculusGo:
-                name = "Oculus Go";
+                mDeviceName = "Oculus Go";
                 break;
             case OculusQuest:
-                name = "Oculus Quest";
+                mDeviceName = "Oculus Quest";
                 break;
             case OculusQuest2:
-                name = "Oculus Quest 2";
+                mDeviceName = "Oculus Quest 2";
                 break;
             case MetaQuestPro:
-                name = "Meta Quest Pro";
+                mDeviceName = "Meta Quest Pro";
                 break;
             case ViveFocus:
-                name = "Vive Focus";
+                mDeviceName = "Vive Focus";
                 break;
             case ViveFocusPlus:
-                name = "Vive Focus Plus";
+                mDeviceName = "Vive Focus Plus";
                 break;
             case PicoNeo2:
-                name = "Pico Neo 2";
+                mDeviceName = "Pico Neo 2";
                 break;
             case PicoNeo3:
-                name = "Pico Neo 3";
+                mDeviceName = "Pico Neo 3";
                 break;
             case PicoG2:
-                name = "Pico G2";
+                mDeviceName = "Pico G2";
                 break;
             case PicoXR:
-                name = "Pico XR";
+                mDeviceName = "Pico XR";
                 break;
             case LynxR1:
-                name = "Lynx-R1";
+                mDeviceName = "Lynx-R1";
                 break;
             case LenovoA3:
-                name = "Lenovo A3";
+                mDeviceName = "Lenovo A3";
                 break;
             case LenovoVRX:
-                name = "Lenovo VRX";
+                mDeviceName = "Lenovo VRX";
                 break;
             case MagicLeap2:
-                name = "Magic Leap 2";
+                mDeviceName = "Magic Leap 2";
                 break;
             case MetaQuest3:
-                name = "Meta Quest 3";
+                mDeviceName = "Meta Quest 3";
                 break;
             default:
-                name = "Unknown Type";
+                mDeviceName = "Unknown Device";
                 break;
         }
-        Log.d("VRB", "Setting device type to: " + name);
+        Log.d("VRB", "Setting device type to: " + mDeviceName);
         mType = aType;
     }
     public static @Type int getType() {
@@ -145,5 +149,14 @@ public class DeviceType {
             return StoreType.META_APP_LAB;
         else
             return StoreType.NONE;
+    }
+
+    public static String getDeviceName(Context aContext) {
+        String appName = aContext.getString(R.string.app_name);
+        String deviceName = mDeviceName;
+        if (mType == DeviceType.Unknown) {
+            deviceName = Build.MANUFACTURER + " " + Build.MODEL;
+        }
+        return aContext.getString(R.string.device_name, appName, deviceName);
     }
 }

--- a/app/src/main/res/layout/options_fxa_account.xml
+++ b/app/src/main/res/layout/options_fxa_account.xml
@@ -72,6 +72,16 @@
                     android:text=""
                     tools:text="mozilla@mozilla.com" />
 
+                <com.igalia.wolvic.ui.views.settings.SingleEditSetting
+                    android:id="@+id/device_name_edit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:width="300dp"
+                    android:inputType="textWebEditText"
+                    app:description="@string/fxa_account_options_device_name"
+                    app:hintTextColor="@color/iron_blur"
+                    app:highlightedTextColor="@color/fog" />
+
                 <TextView
                     style="@style/settingsDescription"
                     android:gravity="center_vertical"

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -662,6 +662,9 @@
     <!-- This string is used to in the FxA account manage panel as a description of the Sign In/Out button. -->
     <string name="fxa_account_options_account">Account</string>
 
+    <!-- This string is used to in the FxA account manage panel as a description of the device name edit. -->
+    <string name="fxa_account_options_device_name">Device Name</string>
+
     <!-- This string is used to in the FxA account manage panel as a header for the sync options. -->
     <string name="fxa_account_options_sync_title">Sync Settings</string>
 

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1708,6 +1708,9 @@
          '%1$s' will be replaced at runtime with the app's name. -->
     <string name="homepage_hint">%1$s Home (Default)</string>
 
+    <!-- This string is displayed in mozilla account's device name.
+         '%1$s' will be replaced at runtime with the app's name while '%2$s' will be replaced with the actual device name. -->
+    <string name="device_name">%1$s on %2$s</string>
 
     <!-- This string is displayed in the title of an authentication prompt, which requests a username and a password. -->
     <string name="authentication_required">Authentication Required</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -511,6 +511,8 @@
     <string name="developer_options_homepage">主页</string>
     <!-- This string is used to in the FxA account manage panel as a description of the Sign In/Out button. -->
     <string name="fxa_account_options_account">账户</string>
+    <!-- This string is used to in the FxA account manage panel as a description of the device name edit. -->
+    <string name="fxa_account_options_device_name">设备名称</string>
     <!-- This string is used to in the FxA account manage panel as a header for the sync options. -->
     <string name="fxa_account_options_sync_title">同步设置</string>
     <!-- This string is used to in the FxA account manage panel as the description of the Sync button when is not syncing.

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1271,6 +1271,9 @@
     <!-- This string is displayed in any button used for removing all the items in the current context.
          '%1$s' will be replaced at runtime with the app's name. -->
     <string name="homepage_hint">%1$s 主页（默认）</string>
+    <!-- This string is displayed in mozilla account's device name.
+         '%1$s' will be replaced at runtime with the app's name while '%2$s' will be replaced with the actual device name. -->
+    <string name="device_name">%2$s 上的 %1$s</string>
     <!-- This string is displayed in the title of an authentication prompt, which requests a username and a password. -->
     <string name="authentication_required">需要验证身份</string>
     <!-- This string is displayed as the label of a username input in an authentication prompt. -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -663,6 +663,9 @@
     <!-- This string is used to in the FxA account manage panel as a description of the Sign In/Out button. -->
     <string name="fxa_account_options_account">帳號</string>
 
+    <!-- This string is used to in the FxA account manage panel as a description of the device name edit. -->
+    <string name="fxa_account_options_device_name">裝置名稱</string>
+
     <!-- This string is used to in the FxA account manage panel as a header for the sync options. -->
     <string name="fxa_account_options_sync_title">同步設定</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1706,7 +1706,9 @@
     <!-- This string is displayed in any button used for removing all the items in the current context.
          '%1$s' will be replaced at runtime with the app's name. -->
     <string name="homepage_hint">%1$s 首頁（預設值）</string>
-
+    <!-- This string is displayed in mozilla account's device name.
+         '%1$s' will be replaced at runtime with the app's name while '%2$s' will be replaced with the actual device name. -->
+    <string name="device_name">%2$s 上的 %1$s</string>
     <!-- This string is displayed in the title of an authentication prompt, which requests a username and a password. -->
     <string name="authentication_required">需要驗證</string>
     <!-- This string is displayed as the label of a username input in an authentication prompt. -->

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -137,7 +137,7 @@
 
     <!-- Options Panel -->
     <dimen name="options_width">585dp</dimen>
-    <dimen name="options_height">385dp</dimen>
+    <dimen name="options_height">420dp</dimen>
 
     <!-- Developer Panel -->
     <dimen name="options_button_width">140dp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -21,7 +21,8 @@
     <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version_v2</string>
     <string name="settings_key_input_mode" translatable="false">settings_touch_mode</string>
     <string name="settings_key_display_density" translatable="false">settings_display_density</string>
-    <string name="settings_key_display_dpi" translatable="false">settings_display_dpi</string>>
+    <string name="settings_key_display_dpi" translatable="false">settings_display_dpi</string>
+    <string name="settings_key_device_name" translatable="false">settings_device_name</string>
     <string name="settings_key_env" translatable="false">settings_env</string>
     <string name="settings_key_pointer_color" translatable="false">settings_pointer_color</string>
     <string name="settings_key_scroll_direction" translatable="false">settings_scroll_direction</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,6 +706,9 @@
     <!-- This string is used to in the FxA account manage panel as a description of the Sign In/Out button. -->
     <string name="fxa_account_options_account">Account</string>
 
+    <!-- This string is used to in the FxA account manage panel as a description of the device name edit. -->
+    <string name="fxa_account_options_device_name">Device Name</string>
+
     <!-- This string is used to in the FxA account manage panel as a header for the sync options. -->
     <string name="fxa_account_options_sync_title">Sync Settings</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1822,6 +1822,10 @@
          '%1$s' will be replaced at runtime with the app's name. -->
     <string name="homepage_hint">%1$s Home (Default)</string>
 
+    <!-- This string is displayed in mozilla account's device name.
+         '%1$s' will be replaced at runtime with the app's name while '%2$s' will be replaced with the actual device name. -->
+    <string name="device_name">%1$s on %2$s</string>
+
     <!-- This string is displayed in the title of an authentication prompt, which requests a username and a password. -->
     <string name="authentication_required">Authentication Required</string>
     <!-- This string is displayed as the label of a username input in an authentication prompt. -->


### PR DESCRIPTION
- Improve device name in mozilla account and make it translatable
Use the pre-defined device name according to device type. If the device type is unknown (i.e. no-api), use Build.MANUFACTURER + " " + Build.MODEL as fall back.
- Enable setting device name in firefox account options
- Extend the height of the options panel
So that we don't need to scroll for newly added haptic feedback in controllers settings in #1068 and device name in accounts settings.

Resolves #1069 
![image](https://github.com/Igalia/wolvic/assets/43995067/6e8ab0eb-ce5e-44c3-bce2-c42ae6e5be54)
![image](https://github.com/Igalia/wolvic/assets/43995067/47f75c19-80b6-483a-bd8c-935c68428f7d)
![image](https://github.com/Igalia/wolvic/assets/43995067/a3b23110-2808-4cf9-8687-85de3b369a47)
