### PR TITLE
Rename Firefox account into Mozilla accounts in translations

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Indstillinger for udviklere</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Log in på konto</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Håndter konto</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Log ud</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Genopret forbindelse</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -309,11 +309,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Send din feedback</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Log ind</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Log ud</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Genopret forbindelse</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -556,11 +556,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">Autofyld</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Synkroniser logins med Firefox-konti</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Synkroniser logins med Mozilla-konti</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Konto…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -635,10 +635,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">Fra</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synkroniser</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Synkroniser ikke</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -784,7 +784,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">Vis alle bogmærker</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synkroniser</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">Historik</string>
@@ -933,12 +933,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">Læs mere om tilladelser</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synkroniser</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synkroniserer…</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Vil du logge ud fra din Firefox-konto?</string>
+    <string name="fxa_signout_confirmation_title">Vil du logge ud fra din Mozilla-konto?</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Når du logger ud, kan du ikke sende eller modtage faneblade fra andre enheder. Dine bogmærker og din historik vil heller ikke blive synkroniseret længere.</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1419,12 +1419,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">Log ind for at sende faneblade</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Log ind eller opret en ny Firefox-konto for at sende faneblade fra Firefox på din computer eller din mobile enhed til dit headset.</string>
+    <string name="whats_new_body_1">Log ind eller opret en ny Mozilla-konto for at sende faneblade fra Firefox på din computer eller din mobile enhed til dit headset.</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Med en Firefox-konto kan du nemt synkronisere bogmærker og historik mellem alle dine enheder.</string>
+    <string name="whats_new_body_sub_1">Med en Mozilla-konto kan du nemt synkronisere bogmærker og historik mellem alle dine enheder.</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Log ind</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -170,16 +170,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Entwickler-Optionen</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Mit Konto anmelden</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Konto verwalten</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Abmelden</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Verbindung wiederherstellen</string>
 
@@ -392,13 +392,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Senden Sie uns Ihr Feedback</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Anmelden</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Abmelden</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Verbindung wiederherstellen</string>
 
@@ -720,12 +720,12 @@
     <string name="security_options_login_autofill">Automatisch ausfüllen</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Zugangsdaten mit Firefox-Konten synchronisieren</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Zugangsdaten mit Mozilla-Konten synchronisieren</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Konto…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -824,11 +824,11 @@
     <string name="off">Aus</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synchronisieren</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Nicht synchronisieren</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1034,7 +1034,7 @@
     <string name="bookmarks_show_all">Lesezeichen verwalten</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synchronisieren</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1242,14 +1242,14 @@ um: <ul>%1$s</ul></p>]]></string>
     <string name="addons_permissions_learn_more">Erfahren Sie mehr über Berechtigungen</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synchronisieren</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Wird synchronisiert…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Vom Firefox-Konto abmelden?</string>
+    <string name="fxa_signout_confirmation_title">Vom Mozilla-Konto abmelden?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Wenn Sie sich abmelden, können Sie keine Tabs von anderen Geräten senden oder empfangen. Ihre Lesezeichen und die Chronik werden ebenfalls nicht mehr synchronisiert.</string>
@@ -1899,14 +1899,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Melden Sie sich an oder erstellen Sie ein neues Firefox-Konto, um Tabs von Firefox auf Ihrem Desktop oder Mobilgerät an Ihr Headset zu senden.</string>
+    <string name="whats_new_body_1">Melden Sie sich an oder erstellen Sie ein neues Mozilla-Konto, um Tabs von Firefox auf Ihrem Desktop oder Mobilgerät an Ihr Headset zu senden.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Mit dem Firefox-Konto können Sie außerdem Lesezeichen und Chronik auf allen Ihren Geräten synchronisieren.</string>
+    <string name="whats_new_body_sub_1">Mit dem Mozilla-Konto können Sie außerdem Lesezeichen und Chronik auf allen Ihren Geräten synchronisieren.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Anmelden</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -167,16 +167,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Developer Options</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Sign Into Account</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Manage Account</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Sign Out</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Reconnect</string>
 
@@ -390,13 +390,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Send us Your Feedback</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Sign in</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Sign out</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Reconnect</string>
 
@@ -735,12 +735,12 @@
     <string name="security_options_login_autofill">Autofill</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Synchronise logins with Firefox Accounts</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Synchronise logins with Mozilla Accounts</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Account…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -844,11 +844,11 @@
     <string name="off">Off</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synchronise</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Don’t Synchronise</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1062,7 +1062,7 @@
     <string name="bookmarks_show_all">Show All Bookmarks</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synchronise</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1269,14 +1269,14 @@
     <string name="addons_permissions_learn_more">Learn more about permissions</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synchronise</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synchronising…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Sign out of your Firefox Account?</string>
+    <string name="fxa_signout_confirmation_title">Sign out of your Mozilla Account?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">When you sign out, you won\'t be able to send or receive tabs from other devices. Your bookmarks and history will also stop synchronising.</string>
@@ -1926,14 +1926,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Sign in or create a new Firefox Account to send tabs from Firefox on your desktop or mobile device to your headset.</string>
+    <string name="whats_new_body_1">Sign in or create a new Mozilla Account to send tabs from Firefox on your desktop or mobile device to your headset.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Firefox Account also lets you synchronise bookmarks and history across all your devices.</string>
+    <string name="whats_new_body_sub_1">Mozilla Account also lets you synchronise bookmarks and history across all your devices.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Sign In</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Opciones de desarrollador</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Iniciar sesión en cuenta</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Administrar cuenta</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Cerrar sesión</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Volver a conectar</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -306,11 +306,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Envíanos tus comentarios</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Iniciar sesión</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Cerrar sesión</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Volver a conectar</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -553,11 +553,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">Autocompletado</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Sincronizar inicios de sesión con cuentas de Firefox</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Sincronizar inicios de sesión con cuentas de Mozilla</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Cuenta…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -633,10 +633,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">Desactivado</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Sincronizar</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">No sincronizar</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -782,7 +782,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">Mostrar todos los marcadores</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Sincronizar</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">Historial</string>
@@ -931,12 +931,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">Saber más sobre permisos</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Sincronizar</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Sincronizando…</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">¿Salir de tu cuenta Firefox?</string>
+    <string name="fxa_signout_confirmation_title">¿Salir de tu cuenta Mozilla?</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Cuando cierres la sesión, no podrás enviar ni recibir pestañas de otros dispositivos. Tus marcadores e historial también dejarán de sincronizarse.</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1417,12 +1417,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">Inicia sesión para enviar pestañas</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Inicia sesión o crea una nueva cuenta de Firefox para enviar pestañas desde Firefox en tu ordenador de escritorio o dispositivo móvil a tus auriculares.</string>
+    <string name="whats_new_body_1">Inicia sesión o crea una nueva cuenta de Mozilla para enviar pestañas desde Firefox en tu ordenador de escritorio o dispositivo móvil a tus auriculares.</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">La cuenta de Firefox también te permite sincronizar marcadores e historial en todos tus dispositivos.</string>
+    <string name="whats_new_body_sub_1">La cuenta de Mozilla también te permite sincronizar marcadores e historial en todos tus dispositivos.</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Iniciar sesión</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->
@@ -1672,7 +1672,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
         \n\t\u2022 Para capturar y traducir la voz a texto, los datos sonoros del usuario son enviados a los servidores titularidad de la empresa responsable de cada plataforma, a través de una API al efecto: como por ejemplo, en Oculus, de Facebook, un servicio que se envía a Oculus Voice SDK. En ningún momento dichos datos son tratados, accedidos ni incorporados a los servidores titularidad de IGALIA. Los datos que se recopilen serán responsabilidad exclusiva de las empresas titulares de cada plataforma (en adelante, los Terceros) las cuales pueden estar ubicadas fuera de la Unión Europea y sometidas a un régimen jurídico menos protector de la privacidad del usuario. Le recomendamos leer atentamente la política de privacidad y condiciones de uso de cada una de dichas plataformas externas antes de aceptar y utilizar sus servicios. IGALIA no será directa ni indirectamente responsable del tratamiento de datos personales por parte de dichos Terceros.
         \n\t\u2022 Se podrá obtener información de localización geográfica del navegador, en lugar del utilizado por el sistema. Sin embargo, para ello usted debe aceptar los permisos de localización de su dispositivo a través de un aviso específico al respecto e IGALIA en modo alguno vinculará dicha información con usted como persona identificada o identificable, aunque los Terceros citados en el punto anterior sí podrían hacerlo, en su caso. Preste atención a sus términos legales.
         \n\t\u2022 IGALIA no accederá ni almacenará, en modo alguno, las direcciones ni las URLs visitadas por usted.
-        \n\t\u2022 En caso de integración de los servicios Cloud para cuentas de Terceros, como Firefox Accounts o Google Accounts, para sincronizar datos como su historia de navegación o sus bookmarks de usuario, IGALIA no accederá ni tratará en modo alguno dicha información ni pasará por sus servidores.
+        \n\t\u2022 En caso de integración de los servicios Cloud para cuentas de Terceros, como Mozilla Accounts o Google Accounts, para sincronizar datos como su historia de navegación o sus bookmarks de usuario, IGALIA no accederá ni tratará en modo alguno dicha información ni pasará por sus servidores.
         \n\n Asimismo, usted observará que la aplicación le solicitará una serie de permisos especiales respecto a su dispositivo que, a continuación, aclaramos en cuanto a su función y finalidad:
         \n\n\t\u2022 Permiso para grabación de audio: Si usted autoriza esto, se utilizará para la citada función de traducción de voz a texto además de la funcionalidad de búsqueda por voz (“voice search”) para la que se utiliza el servicio que proporciona Meetkai cuya política de provacidad se puede consultar aquí: https://meetkai.com/privacy
         \n\n\t\u2022 Permiso para la captación de fotos y vídeos: Es posible que se solicite debido a que el dispositivo del usuario utilice cámaras para ver el entorno y situar al usuario en el espacio físico mediante sistemas de trazado o “tracking”. IGALIA no accede ni trata dicha información.

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -170,16 +170,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Opciones para desarrolladores</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Iniciar sesión en cuenta</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Administrar cuenta</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Cerrar sesión</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Reconectar</string>
 
@@ -392,13 +392,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Enviar comentarios</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Iniciar sesión</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Cerrar sesión</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Reconectar</string>
 
@@ -720,12 +720,12 @@
     <string name="security_options_login_autofill">Autocompletado</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Sincronizar inicios de sesión con cuentas de Firefox</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Sincronizar inicios de sesión con cuentas de Mozilla</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Cuenta…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -829,11 +829,11 @@
     <string name="off">Desactivado</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Sincronizar</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">No sincronizar</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1039,7 +1039,7 @@
     <string name="bookmarks_show_all">Mostrar todos los marcadores</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Sincronizar</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1246,14 +1246,14 @@
     <string name="addons_permissions_learn_more">Saber más sobre permisos</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Sincronizar</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Sincronizando…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">¿Salir de tu cuenta Firefox?</string>
+    <string name="fxa_signout_confirmation_title">¿Salir de tu cuenta Mozilla?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Cuando cierres la sesión, no podrás enviar ni recibir pestañas de otros dispositivos. Tus marcadores e historial también dejarán de sincronizarse.</string>
@@ -1905,14 +1905,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Inicia sesión o crea una nueva cuenta de Firefox para enviar pestañas, desde Firefox en tu ordenador de escritorio o dispositivo móvil, a tus auriculares.</string>
+    <string name="whats_new_body_1">Inicia sesión o crea una nueva cuenta de Mozilla para enviar pestañas, desde Firefox en tu ordenador de escritorio o dispositivo móvil, a tus auriculares.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">La cuenta de Firefox también te permite sincronizar marcadores e historial en todos tus dispositivos.</string>
+    <string name="whats_new_body_sub_1">La cuenta de Mozilla también te permite sincronizar marcadores e historial en todos tus dispositivos.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Iniciar sesión</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
@@ -1922,7 +1922,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="deprecated_version_dialog_title">Actualización necesaria</string>
     <string name="deprecated_version_dialog_body">Esta versión de desarrollo de Wolvic dejará de estar disponible a finales de Octubre de 2023.
         \n\nPor favor, instala la versión más actual de Wolvic desde la Meta Quest Store.
-        \n\nIMPORTANTE: a menos que uses Firefox Sync, la nueva app de Wolvic no tendrá tus marcadores ni tus páginas abiertas.</string>
+        \n\nIMPORTANTE: a menos que uses Mozilla Sync, la nueva app de Wolvic no tendrá tus marcadores ni tus páginas abiertas.</string>
     <string name="deprecated_version_dialog_info_button">Aprender más…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>
 

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -133,16 +133,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Kehittäjävalinnat</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Kirjaudu tilille</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Hallitse tiliä</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Kirjaudu ulos</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Yhdistä uudelleen</string>
 
@@ -338,13 +338,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Lähetä palautetta</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Kirjaudu sisään</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Kirjaudu ulos</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Yhdistä uudelleen</string>
 
@@ -608,11 +608,11 @@
     <string name="off">Pois</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synkronoi</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Älä synkronoi</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -779,7 +779,7 @@
     <string name="bookmarks_show_all">Näytä kaikki kirjanmerkit</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synkronoi</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -849,14 +849,14 @@
     <string name="downloads_sort_download_size_desc">Suurimmat</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synkronoi</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synkronoidaan…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Haluatko kirjautua ulos Firefox-tililtäsi?</string>
+    <string name="fxa_signout_confirmation_title">Haluatko kirjautua ulos Mozilla-tililtäsi?</string>
 
     <!-- This string is displayed in the cancel button of the FxA sign out dialog displayed when the user clicks on the Sign out button.
          If clicked the user will be signed out from their FxA account and the dialog will be dismissed. -->
@@ -1385,10 +1385,10 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Firefox-tili mahdollistaa kirjanmerkkien ja historian synkronoinnin kaikkien laitteidesi välillä.</string>
+    <string name="whats_new_body_sub_1">Mozilla-tili mahdollistaa kirjanmerkkien ja historian synkronoinnin kaikkien laitteidesi välillä.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Kirjaudu sisään</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Options de développement</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Connectez-vous à votre compte</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Gérer le compte</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Déconnexion</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Se reconnecter</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -306,11 +306,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Donnez-nous votre avis</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Connexion</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Déconnexion</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Se reconnecter</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -553,11 +553,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">Remplissage automatique</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Synchroniser les identifiants avec les comptes Firefox</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Synchroniser les identifiants avec les comptes Mozilla</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Compte…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -635,10 +635,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">Désactivé</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synchronisation</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Ne pas synchroniser</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -784,7 +784,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">Afficher tous les marque-pages</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synchroniser</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">Historique</string>
@@ -933,12 +933,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">En savoir plus à propos des permissions</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synchroniser</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synchronisation…</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Vous déconnecter de votre compte Firefox ?</string>
+    <string name="fxa_signout_confirmation_title">Vous déconnecter de votre compte Mozilla ?</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">SI vous vous déconnectez, vous ne pourrez plus envoyer ni recevoir d’onglets d’autres appareils. Vos marque-pages et votre historique cesseront également de se synchroniser.</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1419,12 +1419,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">Connectez-vous pour envoyer des onglets</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Connectez-vous ou créez un nouveau compte Firefox pour envoyer des onglets depuis Firefox sur votre ordinateur ou votre appareil mobile vers votre casque.</string>
+    <string name="whats_new_body_1">Connectez-vous ou créez un nouveau compte Mozilla pour envoyer des onglets depuis Firefox sur votre ordinateur ou votre appareil mobile vers votre casque.</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Un compte Firefox vous permet également de synchroniser les marque-pages et l’historique entre tous vos appareils.</string>
+    <string name="whats_new_body_sub_1">Un compte Mozilla vous permet également de synchroniser les marque-pages et l’historique entre tous vos appareils.</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Se connecter</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->
@@ -1703,7 +1703,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n\t- afin de capturer et de traduire la voix en texte, les données sonores de l\'utilisateur sont envoyées aux serveurs appartenant à la société tierce responsable de chaque plateforme, à travers une API prévue à cet effet : par exemple, dans Oculus, depuis Facebook, un service qui l\'envoie à Oculus Voice SDK. À aucun moment les données susmentionnées ne sont traitées, accédées ou incorporées dans les serveurs appartenant à IGALIA. Les données transmises seront sous la responsabilité exclusive des sociétés tierces propriétaires de chaque plateforme (ci-après, les Tiers), qui peuvent être situées en dehors de l\'Union européenne et soumises à un régime juridique moins protecteur de la vie privée des utilisateurs. Nous vous recommandons de lire attentivement la politique de confidentialité et les conditions d\'utilisation de chacune de ces plateformes externes avant d\'accepter et d\'utiliser leurs services. IGALIA ne sera pas directement ou indirectement responsable du traitement des données personnelles par lesdits Tiers ;
 \n\t- les informations de localisation géographique peuvent être obtenues à partir du navigateur, au lieu de celui utilisé par le système. Toutefois, pour ce faire, vous devez paramétrer les autorisations de localisation de votre appareil par le biais d\'un avis spécifique à cet égard et IGALIA ne reliera en aucun cas les informations susmentionnées à vous en tant que personne identifiée ou identifiable, bien que les Tiers mentionnés au point précédent puissent le faire, le cas échéant. Nous vous recommandons de prêter attention à leurs conditions légales.
 \n\t- IGALIA n\'accède pas et ne stocke pas, de quelque manière que ce soit, les adresses ou URLs visitées par vous ;
-\n\t- l\'intégration avec des services Cloud (tels que Firefox Accounts ou Google Accounts) pour synchroniser des données telles que votre historique de navigation ou vos signets d\'utilisateur peut être possible. Dans ce cas, IGALIA n\'accèdera ni ne traitera aucune information de quelque manière que ce soit, et celle-ci ne passera pas par les serveurs d\'IGALIA.
+\n\t- l\'intégration avec des services Cloud (tels que Mozilla Accounts ou Google Accounts) pour synchroniser des données telles que votre historique de navigation ou vos signets d\'utilisateur peut être possible. Dans ce cas, IGALIA n\'accèdera ni ne traitera aucune information de quelque manière que ce soit, et celle-ci ne passera pas par les serveurs d\'IGALIA.
 \n
 \nNous vous rappelons à nouveau que les plateformes tierces auxquelles vous accédez ou que vous utilisez avec cette application pourraient collecter ces données ou d\'autres données d\'identification vous concernant, en les remplissant volontairement ou involontairement et/ou consciemment ou inconsciemment, éventuellement en dehors du champ d\'application de la législation européenne sur la protection des données. Par conséquent, nous vous recommandons de vous informer et de prêter une attention particulière aux conditions légales desdits Tiers, telles que, par exemple, les suivantes :
 \n
@@ -1767,7 +1767,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n
 \nVeuillez installer la nouvelle version de Wolvic à partir de la Meta Quest Store.
 \n
-\nIMPORTANT : hormis si vous utilisez Firefox Sync, la nouvelle application Wolvic n’aura ni vos marque-pages ni vos onglets.</string>
+\nIMPORTANT : hormis si vous utilisez Mozilla Sync, la nouvelle application Wolvic n’aura ni vos marque-pages ni vos onglets.</string>
     <string name="rCN_first_launch_body">Bienvenue dans « Wolvic » !
 \n
 \nAfin de vous enregistrer et d’utiliser « Wolvic », vous devez accepter les conditions d’utilisation et la politique de confidentialité, ou nous ne pourrons pas vous fournir de services. Veuillez lire attentivement les documents et cliquer sur « Accepter » pour continuer. Si vous cliquez « Refuser », vous ne pourrez pas continuer à utiliser « Wolvic ».

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -104,7 +104,7 @@
     <string name="voice_samples_collect_dialog_description2"><![CDATA[Para mellorar o recoñecemento de voz e outros servizos, precisamos recoller fragmentos de voz para investigación. Almacenamos os datos de xeito seguro e sen identificar información. Sempre será posible usar a busca por voz, mesmo se non se permite a recolección. <a href="">Saber máis</a>]]></string>
     <string name="hamburger_menu_tooltip">Menú</string>
     <string name="hamburger_menu_switch_to_desktop">Modo escritorio</string>
-    <string name="whats_new_body_1">Inicie sesión ou cree unha nova Firefox Account para enviar pestanas dende o escritorio ou móbil ao dispositivo XR.</string>
+    <string name="whats_new_body_1">Inicie sesión ou cree unha nova Mozilla Account para enviar pestanas dende o escritorio ou móbil ao dispositivo XR.</string>
     <string name="tracking_dialog_message"><![CDATA[A protección mellorada de seguimento está %1$s para esta páxina web. <a href="%2$s">Saber máis</a>]]></string>
     <string name="exit_confirm_dialog_body">Seguro que quere saír de %1$s\?</string>
     <string name="download_delete_all_confirm_body">Seguro que quere borrar todos os arquivos descargados\?</string>
@@ -217,7 +217,7 @@
     <string name="security_options_restore_tabs">Restaurar pestanas e xanelas ao reiniciar</string>
     <string name="security_options_autocomplete">Autocompletado na barra de enderezos</string>
     <string name="security_options_login_autofill">Autocompletado</string>
-    <string name="security_options_login_sync">Sincronizar inicios de sesión con Firefox Accounts</string>
+    <string name="security_options_login_sync">Sincronizar inicios de sesión con Mozilla Accounts</string>
     <string name="security_options_login_fxa">Conta…</string>
     <string name="security_options_login_exceptions">Excepcións…</string>
     <string name="security_options_tracking_protection">Protección de tracking</string>
@@ -314,7 +314,7 @@
     <string name="addons_remove_error_dialog_title">Ocorreu un erro ao eliminar %1$s</string>
     <string name="addons_permissions_learn_more">Saber máis sobre permisos</string>
     <string name="addons_remove_error_dialog_ok">Ok</string>
-    <string name="fxa_signout_confirmation_title">Pechar a sesión de Firefox Accounts\?</string>
+    <string name="fxa_signout_confirmation_title">Pechar a sesión de Mozilla Accounts\?</string>
     <string name="fxa_signout_confirmation_body">Cando peche a sesión, non vai poder enviar ou recibir pestanas doutros dispositivos. O seu historial e os marcadores tamén deixarán de sincronizarse.</string>
     <string name="fxa_signout_confirmation_checkbox_v1">Limpar historial, marcadores e inicios de sesión neste dispositivo</string>
     <string name="fxa_signout_confirmation_signout">Pechar sesión</string>
@@ -442,7 +442,7 @@
     <string name="send_tab_dialog_button">Enviar</string>
     <string name="whats_new_title_1">Iniciar sesión para enviar pestanas</string>
     <string name="whats_new_button_sign_in">Iniciar sesión</string>
-    <string name="whats_new_body_sub_1">Firefox Account tamén permite sincronizar os marcadores e o historial en todos os dispositivos.</string>
+    <string name="whats_new_body_sub_1">Mozilla Account tamén permite sincronizar os marcadores e o historial en todos os dispositivos.</string>
     <string name="slow_script_dialog_title">Script lento</string>
     <string name="slow_script_dialog_action_stop">Deter o script</string>
     <string name="slow_script_dialog_description">Unha páxina web está ralentizando o navegador (%1$s). Que desexa facer\?</string>
@@ -561,7 +561,7 @@
 \n\t• Para capturar e traducir a voz en texto, os datos de son do usuario son transferidos a servidores propiedade da compañía responsable de cada plataforma, a través da API para este propósito: por exemplo, en Oculus, de Facebook, un servizo que o envía ao SDK de voz de Oculus. En ningún momento, os datos mencionados son procesados, accedidos ou incorporados a servidores propiedade de IGALIA. Os datos transmitidos serán responsabilidade exclusiva das compañías que posúen cada plataforma (de aquí en diante, Terceiras Partes), que poden estar localizadas fora da Unión Europea e suxeitas a un réxime legar menos protector da privacidade do usuario. Recomendámoslle que lea con coidade a política de privacidade e os termos de uso de cada unha destas plataformas externas antes de aceptar e usar os seus servizos. IGALIA non será directa nin indirectamente responsable do procesamento dos datos persoais por estas Terceiras Partes.
 \n\t• A información de localización xeográfica podería obterse dende o navegador, en lugar da usada polo sistema. No entanto, para facer isto, debe configurar os permisos de localización do seu dispositivo cun aviso específico neste sentido e IGALIA non enlazará en ningún momento esta información a vostede como persoa identificada ou identificable, aínda que as Terceiras Partes mencionadas no punto anterior poderían facelo, se é aplicable. Recomendámoslle que preste atención aos seus termos legais.
 \n\t• IGALIA non accederá nin almacenará, de ningún modo, os enderezos ou URLs que visite.
-\n\t• A integración con servizos cloud (como Firefox Accounts ou Google Accounts) para sincronizar datos como o historial de busca ou os seus marcadores podería ser posible. Neste caso, IGALIA non accederá ou procesará ningunha información de ningún modo, e tampouco a transmitirá a través dos servidores de IGALIA.
+\n\t• A integración con servizos cloud (como Mozilla Accounts ou Google Accounts) para sincronizar datos como o historial de busca ou os seus marcadores podería ser posible. Neste caso, IGALIA non accederá ou procesará ningunha información de ningún modo, e tampouco a transmitirá a través dos servidores de IGALIA.
 \n
 \nRecordámoslle de novo que as plataformas de Terceiras Partes ás que vostede acceda ou use con esta aplicación poderían recoller estes ou outros datos identificativos de seu, ben proporcionándoos de maneira voluntaria ou involuntaria, consciente ou inconscientemente, posiblemente fora do alcance da lexislación de protección de datos Europea. Polo tanto, recomendámoslle que se informe e preste especial atención aos termos legais de ditas Terceiras Partes, como por exemplo, as seguintes:
 \n
@@ -687,7 +687,7 @@
     <string name="deprecated_version_dialog_title">Actualización necesaria</string>
     <string name="deprecated_version_dialog_body">Esta versión de desenrolo de Wolvic deixará de estar dispoñible a finais de Outubro de 2023.
         \n\nPor favor, instala a versión máis actual de Wolvic dende a Meta Quest Store.
-        \n\nIMPORTANTE: a menos que uses Firefox Sync, a nova app de Wolvic non terá os teus marcadores nen as tuas páxinas abertas.</string>
+        \n\nIMPORTANTE: a menos que uses Mozilla Sync, a nova app de Wolvic non terá os teus marcadores nen as tuas páxinas abertas.</string>
     <string name="deprecated_version_dialog_info_button">Aprender máis…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>
     <string name="webxr_dialog_button_on">Activado</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -170,16 +170,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Opzioni per gli sviluppatori</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Accedi all’account</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Gestisci account</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Disconnetti</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Riconnetti</string>
 
@@ -392,13 +392,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Invia feedback</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Accedi</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Disconnetti</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Riconnetti</string>
 
@@ -720,12 +720,12 @@
     <string name="security_options_login_autofill">Compilazione automatica</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Sincronizza le credenziali con l’account Firefox</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Sincronizza le credenziali con l’account Mozilla</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Account…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -823,11 +823,11 @@
     <string name="off">Disattivato</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Sincronizza</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Non sincronizzare</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1033,7 +1033,7 @@
     <string name="bookmarks_show_all">Visualizza tutti i segnalibri</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Sincronizza</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1240,14 +1240,14 @@
     <string name="addons_permissions_learn_more">Ulteriori informazioni sui permessi</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Sincronizza</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Sincronizzazione in corso…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Desideri disconnetterti dal tuo account Firefox?</string>
+    <string name="fxa_signout_confirmation_title">Desideri disconnetterti dal tuo account Mozilla?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Quando ti disconnetti, non potrai più inviare o ricevere scheda dagli altri dispositivi. Anche la sincronizzazione dei segnalibri e della cronologia verrà interrotta.</string>
@@ -1902,14 +1902,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Accedi o crea un account Firefox per inviare schede dai tuoi dispositivi al visore VR attraverso Firefox.</string>
+    <string name="whats_new_body_1">Accedi o crea un account Mozilla per inviare schede dai tuoi dispositivi al visore VR attraverso Firefox.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">L’account Firefox ti consente anche di sincronizzare i segnalibri e la cronologia tra tutti i tuoi dispositivi.</string>
+    <string name="whats_new_body_sub_1">L’account Mozilla ti consente anche di sincronizzare i segnalibri e la cronologia tra tutti i tuoi dispositivi.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Accedi</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">開発者オプション</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">アカウントにログイン</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">アカウントを管理</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">ログアウト</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">再接続</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -306,11 +306,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">フィードバックを送る</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">ログイン</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">ログアウト</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">再接続</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -553,11 +553,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">自動補完</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Firefox アカウントでログイン情報を同期する</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Mozilla アカウントでログイン情報を同期する</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">アカウント…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -633,10 +633,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">オフ</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">同期する</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">同期しない</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -782,7 +782,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">すべてのブックマークを表示</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">同期</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">履歴</string>
@@ -931,12 +931,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">許可設定の詳細</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">同期</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">同期中...</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Firefox アカウントからログアウトしますか？</string>
+    <string name="fxa_signout_confirmation_title">Mozilla アカウントからログアウトしますか？</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">ログアウトすると、他の端末とタブを送受信できなくなります。ブックマークと履歴の同期も停止します。</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1417,12 +1417,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">ログインしてタブを送信</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Firefox アカウントにログインまたはアカウント登録をして、タブをデスクトップまたはモバイル端末の Firefox からヘッドセットへ送信できます。</string>
+    <string name="whats_new_body_1">Mozilla アカウントにログインまたはアカウント登録をして、タブをデスクトップまたはモバイル端末の Firefox からヘッドセットへ送信できます。</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Firefox アカウントを利用して、ブックマークや履歴をご使用のすべての端末と同期することもできます。</string>
+    <string name="whats_new_body_sub_1">Mozilla アカウントを利用して、ブックマークや履歴をご使用のすべての端末と同期することもできます。</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">ログイン</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->
@@ -1659,7 +1659,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n
 \nMeta Quest Storeから最新版のWolvicをインストールしてください。
 \n
-\n重要：Firefox Syncを利用していない場合、最新版のWolvicにブックマークとタブは同期されません。</string>
+\n重要：Mozilla Syncを利用していない場合、最新版のWolvicにブックマークとタブは同期されません。</string>
     <string name="voice_service_huawei_asr">Huawei Automatic Speech Recognition</string>
     <string name="deprecated_version_dialog_info_button">詳細情報…</string>
     <string name="deprecated_version_dialog_store_button">インストール…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">개발자 옵션</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">계정 로그인</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">계정 관리</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">로그아웃</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">다시 연결하기</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -307,11 +307,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">의견 보내기</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">로그인</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">로그아웃</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">다시 연결하기</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -554,11 +554,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">자동 채우기</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Firefox 계정과 로그인 동기화</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Mozilla 계정과 로그인 동기화</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">계정…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -635,10 +635,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">꺼짐</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">동기화</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">동기화 안 함</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -784,7 +784,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">모든 북마크 보기</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">동기화</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">기록</string>
@@ -933,12 +933,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">권한에 대해 더 알아보기</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">동기화</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">동기화 중…</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Firefox 계정에서 로그아웃하시겠습니까?</string>
+    <string name="fxa_signout_confirmation_title">Mozilla 계정에서 로그아웃하시겠습니까?</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">로그 아웃하면 다른 기기에서 탭을 보내거나 받을 수 없습니다. 북마크와 기록도 동기화가 중지됩니다.</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1417,12 +1417,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">탭을 보내기 위해 로그인</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">데스크톱 또는 모바일 기기의 Firefox에서 헤드셋으로 탭을 보내려면 로그인하거나 새 Firefox 계정을 만드세요.</string>
+    <string name="whats_new_body_1">데스크톱 또는 모바일 기기의 Firefox에서 헤드셋으로 탭을 보내려면 로그인하거나 새 Mozilla 계정을 만드세요.</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Firefox 계정을 사용하면 모든 기기에서 북마크와 기록을 동기화 할 수 있습니다.</string>
+    <string name="whats_new_body_sub_1">Mozilla 계정을 사용하면 모든 기기에서 북마크와 기록을 동기화 할 수 있습니다.</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">로그인</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->
@@ -1701,7 +1701,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n\t• 음성을 캡쳐하여 텍스트로 변환하기 위해 사용자의 사운드 데이터는 이러한 목적을 위해 만들어진 API를 통해서 각 플랫폼을 담당하는 제 3자 회사가 소유한 서버로 전송됩니다: 예를 들어, Facebook의 Oculus 서비스는 Oculus Voice SDK로 전송합니다. 앞서 언급한 데이터는 그 어떤 시점에서도 IGALIA 소유의 서버에서 처리, 접근, 통합되지 않습니다. 전송된 데이터는 각 플랫폼을 소유한 제 3자 회사들(이하 제 3자들)이 전적으로 책임질 것이며, 이는 유럽 연합 외부에 위치할 수 있고 사용자 프라이버시를 덜 보호하는 법적 제도를 적용할 수도 있습니다. 서비스를 수락하고 사용하기 전에 이러한 외부 플랫폼들의 개인 정보 정책 및 사용 약관을 주의 깊게 읽어볼 것을 권장합니다. IGALIA는 상기 제 3자들의 개인 데이터 처리에 관해 직간접적으로 책임을 지지 않습니다.
 \n\t• 지리적 위치 정보는 시스템에서 사용되는 것이 아니라 브라우저에서 얻을 수 있습니다. 그러나 그렇게 하기 위해선, 이와 관련한 특정 통지를 통해서 장치의 위치 권한을 설정해야 하며, IGALIA는 앞서 언급한 정보를 식별 되었거나 식별 가능한 사람으로 연결 지을 수 없습니다. 만약 그것이 적용 가능하다면, 이전 항목에서 언급한 제 3자들은 그렇게 할 수도 있습니다. 제 3자들의 법적 조항에 주의를 기울이는 것을 권장합니다.
 \n\t• IGALIA는 귀하가 방문한 주소 또는 URL에 어떠한 방식으로도 접근하거나 저장하지 않습니다.
-\n\t• 브라우저 탐색 기록 또는 사용자 북마크와 같은 데이터를 동기화 하기 위해서 (Firefox 계정 또는 Google 계정과 같은) 클라우드 서비스와 통합될 수 있습니다. 이러한 경우, IGALIA는 어떤 방식으로든 어떠한 정보에도 접근하거나 처리하지 않으며 IGALIA의 서버로도 전달하지 않습니다.
+\n\t• 브라우저 탐색 기록 또는 사용자 북마크와 같은 데이터를 동기화 하기 위해서 (Mozilla 계정 또는 Google 계정과 같은) 클라우드 서비스와 통합될 수 있습니다. 이러한 경우, IGALIA는 어떤 방식으로든 어떠한 정보에도 접근하거나 처리하지 않으며 IGALIA의 서버로도 전달하지 않습니다.
 \n
 \n귀하가 이 애플리케이션과 함께 접근하거나 사용하는 제 3자 플랫폼들이 자발적 또는 비자발적 및/또는 의식적 또는 무의식적으로 유럽 데이터 보호법의 범위를 벗어나 귀하에 관한 식별 데이터를 수집할 수 있음을 다시 한번 알려드립니다. 따라서 다음과 같은 제3자의 법적 조항들을 숙지하고 특별한 주의를 기울이는 것을 권장합니다.
 \n
@@ -1762,7 +1762,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n
 \n오큘러스 스토어에서 최신 버전의 울빅을 설치하세요.
 \n
-\n중요: Firefox 동기화를 사용하지 않는한, 새로운 울빅 앱은 당신의 북마크와 탭을 갖고 있지 않습니다.</string>
+\n중요: Mozilla 동기화를 사용하지 않는한, 새로운 울빅 앱은 당신의 북마크와 탭을 갖고 있지 않습니다.</string>
     <string name="upload_list_empty">업로드 할 수 있는 파일이 없습니다</string>
     <string name="deprecated_version_dialog_info_button">자세히 알아보기…</string>
     <string name="deprecated_version_dialog_store_button">설치…</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -171,16 +171,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Utviklerinnstillinger</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Logg inn på konto</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Behandle konto</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Logg ut</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Koble til på nytt</string>
 
@@ -393,13 +393,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Send oss din tilbakemelding</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Logg inn</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Logg ut</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Koble til på nytt</string>
 
@@ -721,12 +721,12 @@
     <string name="security_options_login_autofill">Autofyll</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Synkroniser innlogginger med Firefox-kontoer</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Synkroniser innlogginger med Mozilla-kontoer</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Konto …</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -825,11 +825,11 @@
     <string name="off">Av</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synkroniser</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Ikke synkroniser</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1036,7 +1036,7 @@
     <string name="bookmarks_show_all">Vis alle bokmerker</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synkroniser</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1243,14 +1243,14 @@
     <string name="addons_permissions_learn_more">Les mer om tillatelser</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synkroniser</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synkroniserer…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Logge ut av Firefox-kontoen din?</string>
+    <string name="fxa_signout_confirmation_title">Logge ut av Mozilla-kontoen din?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Når du logger deg ut, vil du ikke kunne sende eller motta faner fra andre enheter. Bokmerkene og historikken din slutter også å synkronisere.</string>
@@ -1901,14 +1901,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Logg inn eller opprett en ny Firefox-konto for å sende faner fra Firefox på din datamaskin eller mobilenhet til hodesettet.</string>
+    <string name="whats_new_body_1">Logg inn eller opprett en ny Mozilla-konto for å sende faner fra Firefox på din datamaskin eller mobilenhet til hodesettet.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Med en Firefox-konto kan du også synkronisere bokmerker og historikk på alle dine enheter.</string>
+    <string name="whats_new_body_sub_1">Med en Mozilla-konto kan du også synkronisere bokmerker og historikk på alle dine enheter.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Logg inn</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -171,16 +171,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Ontwikkelaarsopties</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Aanmelden bij account</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Account beheren</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Afmelden</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Opnieuw verbinden</string>
 
@@ -393,13 +393,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Stuur ons uw feedback</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Aanmelden</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Afmelden</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Opnieuw verbinden</string>
 
@@ -723,12 +723,12 @@
     <string name="security_options_login_autofill">Automatisch invullen</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Aanmeldingen synchroniseren met Firefox Accounts</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Aanmeldingen synchroniseren met Mozilla Accounts</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Account…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -828,11 +828,11 @@
     <string name="off">Uit</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synchroniseren</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Niet synchroniseren</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1039,7 +1039,7 @@
     <string name="bookmarks_show_all">Alle bladwijzers tonen</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Sync</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1246,14 +1246,14 @@
     <string name="addons_permissions_learn_more">Meer info over toestemmingen</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Sync</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synchroniseren…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Afmelden bij uw Firefox-account?</string>
+    <string name="fxa_signout_confirmation_title">Afmelden bij uw Mozilla-account?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Wanneer u zicht afmeldt, kunt u geen tabbladen van andere apparaten ontvangen of verzenden. Uw bladwijzers en geschiedenis worden ook niet meer gesynchroniseerd.</string>
@@ -1908,14 +1908,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Meld u aan of maak een nieuwe Firefox-account aan om tabbladen van Firefox op uw desktop of mobiele apparaat naar uw headset te verzenden.</string>
+    <string name="whats_new_body_1">Meld u aan of maak een nieuwe Mozilla-account aan om tabbladen van Firefox op uw desktop of mobiele apparaat naar uw headset te verzenden.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Met Firefox Account kunt u ook bladwijzers en uw geschiedenis met al uw apparaten synchroniseren.</string>
+    <string name="whats_new_body_sub_1">Met Mozilla Account kunt u ook bladwijzers en uw geschiedenis met al uw apparaten synchroniseren.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Aanmelden</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-nn-rNO/strings.xml
+++ b/app/src/main/res/values-nn-rNO/strings.xml
@@ -170,16 +170,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Utviklarinnstillingar</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Logg inn på konto</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Handter konto</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Logg ut</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Kople til på nytt</string>
 
@@ -393,13 +393,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Send oss ei tilbakemelding</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Logg inn</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Logg ut</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Kople til på nytt</string>
 
@@ -721,12 +721,12 @@
     <string name="security_options_login_autofill">Autofyll</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Synkroniser innloggingar med Firefox-kontoar</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Synkroniser innloggingar med Mozilla-kontoar</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Konto…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -825,11 +825,11 @@
     <string name="off">Av</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synkroniser</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Ikkje synkroniser</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1035,7 +1035,7 @@
     <string name="bookmarks_show_all">Vis alle bokmerke</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synkroniser</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1242,14 +1242,14 @@
     <string name="addons_permissions_learn_more">Les meir om løyve</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synkroniser</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synkroniserer…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Logge ut av Firefox-kontoen din?</string>
+    <string name="fxa_signout_confirmation_title">Logge ut av Mozilla-kontoen din?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">Når du loggar deg ut, vil du ikkje kunne sende eller motta faner frå andre einingar. Bokmerka og historikken din sluttar også å synkronisere.</string>
@@ -1902,14 +1902,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Logg inn eller opprett ein ny Firefox-konto for å sende faner frå Firefox på datamaskina di eller mobileining til headsettet.</string>
+    <string name="whats_new_body_1">Logg inn eller opprett ein ny Mozilla-konto for å sende faner frå Firefox på datamaskina di eller mobileining til headsettet.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Med ein Firefox-konto kan du òg synkronisere bokmerke og historikk på alle einingane dine.</string>
+    <string name="whats_new_body_sub_1">Med ein Mozilla-konto kan du òg synkronisere bokmerke og historikk på alle einingane dine.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Logg inn</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -171,16 +171,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Opcje dla programistów</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Zaloguj się na konto</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Zarządzaj kontem</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Wyloguj się</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Połącz ponownie</string>
 
@@ -393,13 +393,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Wyślij swoją opinię</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Zaloguj się</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Wyloguj się</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Połącz ponownie</string>
 
@@ -721,12 +721,12 @@
     <string name="security_options_login_autofill">Automatyczne wypełnianie</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
     <string name="security_options_login_sync">Synchronizuj dane logowania za pomocą konta Firefoksa</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Konto…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -826,11 +826,11 @@
     <string name="off">Wyłączone</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synchronizuj</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Nie synchronizuj</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1036,7 +1036,7 @@
     <string name="bookmarks_show_all">Wyświetl wszystkie zakładki</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synchronizuj</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1243,7 +1243,7 @@
     <string name="addons_permissions_learn_more">Więcej informacji o uprawnieniach</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synchronizuj</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
@@ -1908,7 +1908,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_body_sub_1">Konto Firefoksa umożliwia także synchronizowanie zakładek i historii między wszystkimi używanymi urządzeniami.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Zaloguj się</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -63,7 +63,7 @@
     <string name="addons_last_updated_title">Última atualização</string>
     <string name="addons_remove_error_dialog_ok">Ok</string>
     <string name="fxa_syncing">Sincronizando…</string>
-    <string name="fxa_signout_confirmation_title">Sair de sua Conta Firefox\?</string>
+    <string name="fxa_signout_confirmation_title">Sair de sua Conta Mozilla\?</string>
     <string name="history_section_today">Hoje</string>
     <string name="download_context_delete">Remover</string>
     <string name="downloads_sort">Organizar Por</string>
@@ -228,7 +228,7 @@
     <string name="fxa_account_syncing_off">A sincronização está desativada</string>
     <string name="security_options_login_save">Salvar logins e senhas</string>
     <string name="security_options_login_autofill">Preenchimento automático</string>
-    <string name="security_options_login_sync">Sincronize logins com contas Firefox</string>
+    <string name="security_options_login_sync">Sincronize logins com contas Mozilla</string>
     <string name="security_options_permission_notifications">Notificações</string>
     <string name="cancel_button">Cancelar</string>
     <string name="security_options_tracking_protection">Proteção contra rastreamento</string>
@@ -572,7 +572,7 @@
 \n• Para capturar e traduzir a voz em texto, os dados sonoros do usuário são enviados aos servidores de propriedade da empresa terceirizada responsável por cada plataforma, por meio de uma API para esse fim: por exemplo, no Oculus, do Facebook, um serviço que o envia para o Oculus Voice SDK. Em nenhum momento os dados acima mencionados são processados, acessados ou incorporados aos servidores de propriedade da IGALIA. Os dados transmitidos serão da exclusiva responsabilidade das empresas terceiras proprietárias de cada plataforma (doravante, os Terceiros), que poderão estar localizadas fora da União Europeia e sujeitas a um regime jurídico menos protetor da privacidade do utilizador. Recomendamos que você leia atentamente a política de privacidade e os termos de uso de cada uma dessas plataformas externas antes de aceitar e usar seus serviços. A IGALIA não será direta ou indiretamente responsável pelo tratamento de dados pessoais por tais Terceiros.
 \n• As informações de localização geográfica podem ser obtidas do navegador, ao invés do utilizado pelo sistema. No entanto, para isso, deve definir as permissões de localização do seu dispositivo através de um aviso específico a este respeito e a IGALIA não vinculará de forma alguma as referidas informações a você como pessoa identificada ou identificável, embora os Terceiros mencionados no ponto anterior poderia fazê-lo, se aplicável. Recomendamos que você preste atenção aos seus termos legais.
 \n• A IGALIA não acessará nem armazenará, de forma alguma, os endereços ou URLs visitados por você.
-\n• Pode ser possível a integração com serviços em nuvem (como Contas Firefox ou Contas do Google) para sincronizar dados como seu histórico de navegação ou seus favoritos de usuário. Neste caso, a IGALIA não acessará ou processará qualquer informação de forma alguma, nem passará pelos servidores da IGALIA.
+\n• Pode ser possível a integração com serviços em nuvem (como Contas Mozilla ou Contas do Google) para sincronizar dados como seu histórico de navegação ou seus favoritos de usuário. Neste caso, a IGALIA não acessará ou processará qualquer informação de forma alguma, nem passará pelos servidores da IGALIA.
 \n
 \nLembramos novamente que as plataformas de Terceiros que você acessa ou usa com este aplicativo podem coletar esses ou outros dados de identificação sobre você, preenchendo-os de forma voluntária ou involuntária e/ou consciente ou inconscientemente, possivelmente fora do escopo da legislação europeia de proteção de dados . Portanto, recomendamos que você se informe e preste atenção especial aos termos legais dos referidos Terceiros, como, por exemplo, o seguinte:
 \n
@@ -626,13 +626,13 @@
     <string name="login_edit_dialog_site_button">Abrir</string>
     <string name="slow_script_dialog_action_wait">Esperar</string>
     <string name="tracking_dialog_button_disable">Desativar</string>
-    <string name="whats_new_body_sub_1">A Conta Firefox também permite sincronizar favoritos e histórico em todos os seus dispositivos.</string>
-    <string name="whats_new_body_1">Inicie sessão ou crie uma nova Conta Firefox para enviar guias do Firefox do computador ou dispositivo móvel para o seu fone de ouvido.</string>
+    <string name="whats_new_body_sub_1">A Conta Mozilla também permite sincronizar favoritos e histórico em todos os seus dispositivos.</string>
+    <string name="whats_new_body_1">Inicie sessão ou crie uma nova Conta Mozilla para enviar guias do Firefox do computador ou dispositivo móvel para o seu fone de ouvido.</string>
     <string name="whats_new_button_start_browsing">Iniciar navegação</string>
     <string name="deprecated_version_dialog_title">Actualização necessária</string>
     <string name="deprecated_version_dialog_body">Esta versão de desenvolvimento do Wolvic será descontinuada no final de outubro de 2023.
         \n\nPor favor, instale a última versão de Wolvic a partir da Meta Quest Store.
-        \n\nIMPORTANTE: a menos que utilize Firefox Sync, a nova aplicação Wolvic não terá os seus marcadores e páginas abertas.</string>
+        \n\nIMPORTANTE: a menos que utilize Mozilla Sync, a nova aplicação Wolvic não terá os seus marcadores e páginas abertas.</string>
     <string name="deprecated_version_dialog_info_button">Saber mais…</string>
     <string name="deprecated_version_dialog_store_button">Instalar…</string>
     <string name="popup_dialog_button_on">Ligado</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -138,7 +138,7 @@
     <string name="tab_sent_notification">Guia enviada!</string>
     <string name="hamburger_menu_send_tab">Enviar guia para aparelho</string>
     <string name="whats_new_title_1">Faça login para enviar guias</string>
-    <string name="whats_new_body_1">Inicie sessão ou crie uma nova Conta Firefox para enviar guias do Firefox do computador ou aparelho móvel para os seus auscultadores.</string>
+    <string name="whats_new_body_1">Inicie sessão ou crie uma nova Conta Mozilla para enviar guias do Firefox do computador ou aparelho móvel para os seus auscultadores.</string>
     <string name="whats_new_button_sign_in">Entrar</string>
     <string name="slow_script_dialog_title">Script lento</string>
     <string name="slow_script_dialog_action_wait">Esperar</string>
@@ -218,7 +218,7 @@
 \n• Para capturar e traduzir a voz em texto, os dados sonoros do utilizador são enviados aos servidores de propriedade da empresa terceirizada responsável por cada plataforma, por meio de uma API para esse fim: por exemplo, no Oculus, do Facebook, um serviço que o envia para o Oculus Voice SDK. Em nenhum momento os dados acima mencionados são processados, acessados ou incorporados aos servidores de propriedade da IGALIA. Os dados transmitidos serão da exclusiva responsabilidade das empresas terceiras proprietárias de cada plataforma (doravante, os Terceiros), que poderão estar localizadas fora da União Europeia e sujeitas a um regime jurídico menos protetor da privacidade do utilizador. Recomendamos que leia atentamente a política de privacidade e os termos de uso de cada uma dessas plataformas externas antes de aceitar e usar os serviços dela. A IGALIA não será direta ou indiretamente responsável pelo tratamento de dados pessoais por tais Terceiros.
 \n• As informações de localização geográfica podem ser obtidas do navegador, ao invés do utilizado pelo sistema. No entanto, para isso, deve definir as permissões de localização do seu aparelho através de um aviso específico a este respeito e a IGALIA não vinculará de forma alguma as referidas informações a como pessoa identificada ou identificável, embora os Terceiros mencionados no ponto anterior poderia fazê-lo, se aplicável. Recomendamos que preste atenção aos seus termos legais.
 \n• A IGALIA não acessará nem armazenará, de forma alguma, os endereços ou URLs visitados por si.
-\n• Pode ser possível a integração com serviços em nuvem (como Contas Firefox ou Contas do Google) para sincronizar dados como seu histórico de navegação ou os seus favoritos de utilizador. Neste caso, a IGALIA não acessará ou processará qualquer informação de forma alguma, nem passará pelos servidores da IGALIA.
+\n• Pode ser possível a integração com serviços em nuvem (como Contas Mozilla ou Contas do Google) para sincronizar dados como seu histórico de navegação ou os seus favoritos de utilizador. Neste caso, a IGALIA não acessará ou processará qualquer informação de forma alguma, nem passará pelos servidores da IGALIA.
 \n
 \nLembramos novamente que as plataformas de Terceiros que acessa ou usa com esta aplicação podem coletar esses ou outros dados de identificação sobre si, preenchendo-os de forma voluntária ou involuntária e/ou consciente ou inconscientemente, possivelmente fora do escopo da legislação europeia de proteção de dados . Portanto, recomendamos que se informe e preste atenção especial aos termos legais dos referidos Terceiros, como, por exemplo, o seguinte:
 \n
@@ -486,7 +486,7 @@
     <string name="security_options_login_fxa">Conta…</string>
     <string name="settings_fxa_account_manage">Configurar Conta</string>
     <string name="settings_developer_options">Opções de Programador</string>
-    <string name="security_options_login_sync">Sincronize logins com contas Firefox</string>
+    <string name="security_options_login_sync">Sincronize logins com contas Mozilla</string>
     <string name="restart_now_dialog_button">Reiniciar Agora</string>
     <string name="keyboard_enter_label">ENTER</string>
     <string name="permission_notification">Permite %1$s enviar notificações\?</string>
@@ -578,7 +578,7 @@
     <string name="addons_download_success_dialog_ok">Certo, entendi</string>
     <string name="addons_remove_success_dialog_ok">Ok</string>
     <string name="addons_remove_success_dialog_title">%1$s desinstalado com sucesso</string>
-    <string name="fxa_signout_confirmation_title">Sair da sua Conta Firefox\?</string>
+    <string name="fxa_signout_confirmation_title">Sair da sua Conta Mozilla\?</string>
     <string name="addons_remove_error_dialog_title">Um erro aconteceu ao remover %1$s</string>
     <string name="fxa_signout_confirmation_checkbox_v1">Apagar histórico, favoritos e logins deste aparelho</string>
     <string name="history_clear_now">Limpe Agora</string>
@@ -670,7 +670,7 @@
     <string name="tab_added_notification">Nova guia adicionada!</string>
     <string name="hamburger_menu_switch_to_desktop">Modo desktop</string>
     <string name="send_tab_dialog_description">Escolha um aparelho para enviar a guia.</string>
-    <string name="whats_new_body_sub_1">A Conta Firefox também permite sincronizar favoritos e histórico em todos os seus aparelhos.</string>
+    <string name="whats_new_body_sub_1">A Conta Mozilla também permite sincronizar favoritos e histórico em todos os seus aparelhos.</string>
     <string name="slow_script_dialog_description">Uma página da web está deixando seu navegador mais lento (%1$s). O que gostaria de fazer\?</string>
     <string name="download_error_body">Ocorreu um erro ao descarregar %1$s. Por favor, tente novamente.</string>
     <string name="download_error_ok">Ok</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Настройки разработчика</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Войти в аккаунт</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Управление аккаунтом</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Выйти</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Переподключиться</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -306,11 +306,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Отправьте свой отзыв</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Войти</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Выйти</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Переподключиться</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -553,11 +553,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">Автозаполнение</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Синхронизировать логины с Аккаунтом Firefox</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Синхронизировать логины с Аккаунтом Mozilla</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Аккаунт…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -633,10 +633,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">Отключено</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Синхронизировать</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Не синхронизировать</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -782,7 +782,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">Все закладки</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Синхронизировать</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">История</string>
@@ -931,12 +931,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">Узнать больше о разрешениях</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Синхронизировать</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Синхронизация…</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Выйти из вашего Аккаунта Firefox?</string>
+    <string name="fxa_signout_confirmation_title">Выйти из вашего Аккаунта Mozilla?</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">После выхода из аккаунта, вы больше не сможете отправлять или получать вкладки с устройств. Ваши закладки и история также прекратят синхронизироваться.</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1416,12 +1416,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">Войдите, чтобы отправлять вкладки</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Войдите или создайте новый Аккаунт Firefox, чтобы отправлять вкладки с Firefox на ПК или мобильного устройства на вашу гарнитуру.</string>
+    <string name="whats_new_body_1">Войдите или создайте новый Аккаунт Mozilla, чтобы отправлять вкладки с Firefox на ПК или мобильного устройства на вашу гарнитуру.</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Аккаунт Firefox также позволит вам синхронизировать закладки и историю на всех ваших устройствах.</string>
+    <string name="whats_new_body_sub_1">Аккаунт Mozilla также позволит вам синхронизировать закладки и историю на всех ваших устройствах.</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Войти</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Utvecklaralternativ</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Logga in på konto</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Hantera konto</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Logga ut</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Återanslut</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -306,11 +306,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Skicka oss din feedback</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Logga in</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Logga ut</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Återanslut</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -553,11 +553,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">Autofyll</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Synkronisera inloggningar med Firefox-konton</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Synkronisera inloggningar med Mozilla-konton</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Konto…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -633,10 +633,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">Av</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Synkronisera</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Synkronisera inte</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -782,7 +782,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">Visa alla bokmärken</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Synkronisera</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">Historik</string>
@@ -931,12 +931,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">Läs mer om behörigheter</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Synkronisera</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Synkroniserar…</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Logga ut från ditt Firefox-konto?</string>
+    <string name="fxa_signout_confirmation_title">Logga ut från ditt Mozilla-konto?</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">När du loggar ut kommer du inte att kunna skicka eller ta emot flikar från andra enheter. Dina bokmärken och historik slutar också synkronisera.</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1417,12 +1417,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">Logga in för att skicka flikar</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Logga in eller skapa ett nytt Firefox-konto för att skicka flikar från Firefox på din stationära eller mobila enhet till ditt headset.</string>
+    <string name="whats_new_body_1">Logga in eller skapa ett nytt Mozilla-konto för att skicka flikar från Firefox på din stationära eller mobila enhet till ditt headset.</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Med ett Firefox-konto kan du också synkronisera bokmärken och historik mellan alla dina enheter.</string>
+    <string name="whats_new_body_sub_1">Med ett Mozilla-konto kan du också synkronisera bokmärken och historik mellan alla dina enheter.</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Logga in</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->
@@ -1666,7 +1666,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n
 \nInstallera den senaste versionen av Wolvic från Oculus Store.
 \n
-\nVIKTIGT: om du inte använder Firefox Sync kommer den nya Wolvic-appen inte att ha dina bokmärken och flikar.</string>
+\nVIKTIGT: om du inte använder Mozilla Sync kommer den nya Wolvic-appen inte att ha dina bokmärken och flikar.</string>
     <string name="external_open_uri_error_security_exception_body">SecurityException vid start av intent för %1$s</string>
     <string name="user_feedback_tooltip">Dela idéer och feedback</string>
     <string name="hamburger_menu_toggle_passthrough">Passera genom</string>
@@ -1727,7 +1727,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n• För att fånga och översätta rösten till text skickas användarens ljuddata till servrarna som ägs av det tredje part som ansvarar för varje plattform, genom ett API för detta ändamål: till exempel i Oculus, från Facebook, en tjänst som skickar den till Oculus Voice SDK. Vid inget tillfälle behandlas, nås eller införlivas ovan nämnda data i servrarna som ägs av IGALIA. De data som överförs kommer att vara det exklusiva ansvaret för de tredjepartsföretag som äger varje plattform (hädanefter tredje parten), som kan vara belägen utanför Europeiska unionen och omfattas av en rättslig ordning som är mindre skyddande för användarnas integritet. Vi rekommenderar att du noggrant läser sekretesspolicyn och användarvillkoren för var och en av dessa externa plattformar innan du accepterar och använder deras tjänster. IGALIA kommer inte att vara direkt eller indirekt ansvarig för behandlingen av personuppgifter av nämnda tredje parter.
 \n• Geografisk platsinformation kan erhållas från webbläsaren, istället för den som används av systemet. För att göra det måste du dock ställa in platsbehörigheterna för din enhet genom ett specifikt meddelande i detta avseende och IGALIA kommer inte på något sätt att länka ovannämnda information till dig som en identifierad eller identifierbar person, även om de tredje parter som nämns i föregående punkt skulle kunna göra det, om tillämpligt. Vi rekommenderar att du uppmärksammar deras juridiska villkor.
 \n• IGALIA kommer inte att komma åt eller lagra på något sätt de adresser eller webbadresser som du besökt.
-\n• Integration med molntjänster (som Firefox-konton eller Google-konton) för att synkronisera data som din webbhistorik eller dina användarbokmärken kan vara möjlig. I det här fallet kommer IGALIA inte att komma åt eller bearbeta någon information på något sätt, och den kommer inte heller att passera genom IGALIAs servrar.
+\n• Integration med molntjänster (som Mozilla-konton eller Google-konton) för att synkronisera data som din webbhistorik eller dina användarbokmärken kan vara möjlig. I det här fallet kommer IGALIA inte att komma åt eller bearbeta någon information på något sätt, och den kommer inte heller att passera genom IGALIAs servrar.
 \n
 \nVi påminner dig igen om att de tredjepartsplattformar som du kommer åt eller använder med denna applikation kan samla in denna eller andra identifierande data om dig, antingen fylla i dem frivilligt eller ofrivilligt och/eller medvetet eller omedvetet, möjligen utanför räckvidden av europeisk dataskyddslagstiftning . Därför rekommenderar vi att du informerar dig själv och ägnar särskild uppmärksamhet åt de juridiska villkoren för nämnda tredje parter, såsom till exempel följande:
 \n

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -128,13 +128,13 @@
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">开发者选项</string>
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">登录账户</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">管理账户</string>
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">退出</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">重新连接</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -306,11 +306,11 @@
     <!-- This string is displayed in the settings header under the Wolvic logo. When clicked the settings panel is closed
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">提交您的反馈意见</string>
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">登录</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">退出</string>
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">重新连接</string>
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
@@ -565,11 +565,11 @@
      and is used to enable or disable login auto-fill. If disabled the logins forms won't be auto-filled. -->
     <string name="security_options_login_autofill">自动填写</string>
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">使用 Firefox 账户同步登录信息</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">使用 Mozilla 账户同步登录信息</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">账户…</string>
     <!-- This string labels a button in the Logins And Passwords settings dialog
      that when clicked opens the saved logins panel which lists all the stored logins/password entries. -->
@@ -647,10 +647,10 @@
     <!-- This string is displayed below the On/Off switch to indicate a switch's current state as 'Off'. -->
     <string name="off">关</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">同步</string>
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">停用同步</string>
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
          button used to initiate Voice Search. -->
@@ -801,7 +801,7 @@
          all the bookmarks. -->
     <string name="bookmarks_show_all">显示所有书签</string>
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">同步</string>
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
     <string name="history_title">历史记录</string>
@@ -950,12 +950,12 @@
     <!-- This string is displayed at the bottom of the addon permissions list view. When clicked it will open a new tab with the addons permissions SUMO page -->
     <string name="addons_permissions_learn_more">详细了解“权限”</string>
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">同步</string>
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">正在同步…</string>
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">要退出 Firefox 账户吗？</string>
+    <string name="fxa_signout_confirmation_title">要退出 Mozilla 账户吗？</string>
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">退出后，就无法发送标签页或收到来自其他设备的标签页，也会停止同步书签与历史记录。</string>
     <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
@@ -1435,12 +1435,12 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="whats_new_title_1">登录以发送标签页</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">创建或登录一个 Firefox 账户，以便您在台式机、笔记本电脑、移动设备向头戴式设备上的 Firefox 发送标签页。</string>
+    <string name="whats_new_body_1">创建或登录一个 Mozilla 账户，以便您在台式机、笔记本电脑、移动设备向头戴式设备上的 Firefox 发送标签页。</string>
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Firefox 账户还可让您在所有设备上同步书签和历史记录。</string>
+    <string name="whats_new_body_sub_1">Mozilla 账户还可让您在所有设备上同步书签和历史记录。</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">登录</string>
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. If clicked the dialog is dismissed. -->
@@ -1999,7 +1999,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n您也可以通过热线400-650-7728联系我们，我们的工作时间为中国工作日早上10点至晚上6点。
     </string>
     <string name="privacy_policy_subtitle_2">数据保护</string>
-    <string name="privacy_policy_section_2">IGALIA承诺遵守相关个人数据保护的法律规定：2016年4月27日欧洲议会和理事会关于保护自然人处理个人数据和此类数据自由流动的第2016/679号欧盟条例，废除95/46/EC欧盟指令（《通用数据保护条例》）；12 月 5 日第 3/2018 号《个人数据保护和保障数字权利组织法》（LOPDGDD）。 “个人数据”指任何与个人身份识别，提供直接或间接地追踪个人身份的相关信息，特别是身份信息，例如姓名、识别号码、位置数据等，或者结合其它与特定个人相关的可识别信息，例如上述人的身体、生理、遗传、精神、经济、文化或社会身份标识。 IGALIA不会以可识别用户的方式收集个人数据。因此，您可以在不透露身份的情况下，或直接或间接向IGALIA提供个人数据的情况下使用该应用程序，咨询和浏览虚拟现实环境；因此，IGALIA将不对任何输入WOLVIC的数据负责。 IGALIA从本应用程序的使用中获得的唯一数据和信息，在任何时候都不会与用户关联，这些数据和信息如下： • 分析性的、纯统计性的、非身份识别性的数据。 • 为了获取声音并将其译成文本，用户的声音数据将通过相关应用程序接口（API）发送到负责每个平台的第三方公司的服务器上：例如，Facebook旗下的Oculus，声音数据将被发送到Oculus Voice SDK。上述数据在任何时候都不会被处理、访问或纳入IGALIA服务器中。传送的数据将由拥有各平台的第三方公司（以下简称“第三方”）全权负责，这些公司可能位于欧盟以外，并受用户隐私保护程度较弱的法律制度约束。我们建议您在接受和使用这些外部平台的服务之前，仔细阅读其隐私政策和使用条款。IGALIA不会直接或间接对上述第三方的个人数据处理负责。 • 地理位置信息可能从浏览器中获得，而非系统所在的地理位置信息。然而，要获取地理位置信息，必须通过相关具体通知设置设备位置权限，IGALIA不会以任何方式将上述信息用以确定和识别您的身份，但上一点中所提及的第三方可能会进行相关操作。我们建议您关注第三方的法律条款。 • IGALIA不会以任何方式访问或储存您访问过的地址或网络地址（URL）。 • 如果使用云服务（如火狐账户或谷歌账户）集成同步您的浏览历史或用户书签等数据。在这种情况下，IGALIA不会以任何方式访问或处理任何信息，且该信息不会经过IGALIA服务器。 同样，您会注意到本应用程序将针对您的设备请求一系列特殊权限，下面我们就其功能和用途进行说明： • 录音权限：如果您授权，除了Meetkai提供的语音搜索功能（“语音搜索”）之外，它还将用于翻译功能（上述语音到文本），可以在这里阅读其隐私政策： https://meetkai.com/privacy • 拍摄照片和视频的权限：通过跟踪系统，如果用户的设备使用相机记录用户所处物理空间的环境和地点，则可能会请求此权限。 IGLIA 不访问或处理任何信息。 • 读取、修改或删除存储卡上的照片、多媒体内容和文件的权限：这是必要的，以便浏览器可以在设备上保存本地信息，例如缓存文件、设置、访问的页面和收藏夹等。IGALIA 不访问或处理所述信息。 • 根据 GPS、电话站或 WIFI 等来源获取位置信息的权限：如果您授权，您的应用程序将始终显示一个图标，以示连接类型，以及在适当情况下，上面提到的地理位置。 IGLIA 绝不会将上述信息与您作为已识别或可识别的人联系起来，但是上述第三方可能会这样做（如果适用的话）。请注意他们的法律条款。具体来说，在华为设备中，GPS 信息会被访问并提供给公司名为“LocationService”的服务。 我们再次提醒您，您访问或使用本应用程序的第三方平台可能会收集上述数据或其他身份识别数据(自愿或非自愿地、有意或无意填写的数据)，相关数据收集可能超出欧洲数据保护立法的范围。因此，我们建议您了解并特别关注相关第三方法律条款，例如： • 谷歌: https://policies.google.com/privacy • Facebook: https://www.facebook.com/about/privacy/update • 华为: https://www.huawei.com/es/privacy-policy 同样, 望您知悉, 在使用浏览器的语音识别选项时, Meetkai将以完全匿名的方式保存您的语音转录, 用于改善其服务。Meetkai不会直接保存您的语音, 也不会以任何方式关联您的语音转录与您的身份。更多关于MeetKai的隐私策略请看: https://meetkai.com/es/privacy Igalia也无意于关联任何语音转录和身份或影响其隐私, 因此, Igalia 要求其声音地址中不得包含任何个人或机密信息。 在任何情况下，IGALIA保证当事人对其个人数据行使访问、纠正、删除、反对、限制处理和转移的权利。 为此，IGALIA已建立内部协议/程序来行使以上权利。 当事人可通过以下方式行使该权利：致信IGALIA的公司所在地：拉科鲁尼亚Bugallal Marchesi街22号1层，邮编15008，（Calle Bugallal Marchesi, 22, 1º, 15008, A Coruña），注明“数据保护”（“Data Protection”）；或者，发送电子邮件至info@igalia.com。 使用以上两种方式联系时，当事人必须附上国民身份证、护照或身份证明文件的副本，以证明其身份。 • 数据保护官员或相关权利管理部门将在专用表格中记录权利行使事宜，其中包含以下数据： • 申请号：将为每份收到的申请分配一个编号。 • 管理部门：如果负责人管理多个部门，将写明收到申请的部门。 • 投诉提交渠道：将写明收到请求的渠道，包括邮寄地址、邮件等。 • 申请日期：将注明申请被提交的日期。 • 行使的权利：当事人行使的权利类型。 • 反馈日期：向当事人发送答复的日期。 支持性文件（请求/回复受理凭证、通信等）将被存档，以便妥善保管。 同样，提醒您，您有权向西班牙数据保护局投诉。</string>
+    <string name="privacy_policy_section_2">IGALIA承诺遵守相关个人数据保护的法律规定：2016年4月27日欧洲议会和理事会关于保护自然人处理个人数据和此类数据自由流动的第2016/679号欧盟条例，废除95/46/EC欧盟指令（《通用数据保护条例》）；12 月 5 日第 3/2018 号《个人数据保护和保障数字权利组织法》（LOPDGDD）。 “个人数据”指任何与个人身份识别，提供直接或间接地追踪个人身份的相关信息，特别是身份信息，例如姓名、识别号码、位置数据等，或者结合其它与特定个人相关的可识别信息，例如上述人的身体、生理、遗传、精神、经济、文化或社会身份标识。 IGALIA不会以可识别用户的方式收集个人数据。因此，您可以在不透露身份的情况下，或直接或间接向IGALIA提供个人数据的情况下使用该应用程序，咨询和浏览虚拟现实环境；因此，IGALIA将不对任何输入WOLVIC的数据负责。 IGALIA从本应用程序的使用中获得的唯一数据和信息，在任何时候都不会与用户关联，这些数据和信息如下： • 分析性的、纯统计性的、非身份识别性的数据。 • 为了获取声音并将其译成文本，用户的声音数据将通过相关应用程序接口（API）发送到负责每个平台的第三方公司的服务器上：例如，Facebook旗下的Oculus，声音数据将被发送到Oculus Voice SDK。上述数据在任何时候都不会被处理、访问或纳入IGALIA服务器中。传送的数据将由拥有各平台的第三方公司（以下简称“第三方”）全权负责，这些公司可能位于欧盟以外，并受用户隐私保护程度较弱的法律制度约束。我们建议您在接受和使用这些外部平台的服务之前，仔细阅读其隐私政策和使用条款。IGALIA不会直接或间接对上述第三方的个人数据处理负责。 • 地理位置信息可能从浏览器中获得，而非系统所在的地理位置信息。然而，要获取地理位置信息，必须通过相关具体通知设置设备位置权限，IGALIA不会以任何方式将上述信息用以确定和识别您的身份，但上一点中所提及的第三方可能会进行相关操作。我们建议您关注第三方的法律条款。 • IGALIA不会以任何方式访问或储存您访问过的地址或网络地址（URL）。 • 如果使用云服务（如Mozilla账户或谷歌账户）集成同步您的浏览历史或用户书签等数据。在这种情况下，IGALIA不会以任何方式访问或处理任何信息，且该信息不会经过IGALIA服务器。 同样，您会注意到本应用程序将针对您的设备请求一系列特殊权限，下面我们就其功能和用途进行说明： • 录音权限：如果您授权，除了Meetkai提供的语音搜索功能（“语音搜索”）之外，它还将用于翻译功能（上述语音到文本），可以在这里阅读其隐私政策： https://meetkai.com/privacy • 拍摄照片和视频的权限：通过跟踪系统，如果用户的设备使用相机记录用户所处物理空间的环境和地点，则可能会请求此权限。 IGLIA 不访问或处理任何信息。 • 读取、修改或删除存储卡上的照片、多媒体内容和文件的权限：这是必要的，以便浏览器可以在设备上保存本地信息，例如缓存文件、设置、访问的页面和收藏夹等。IGALIA 不访问或处理所述信息。 • 根据 GPS、电话站或 WIFI 等来源获取位置信息的权限：如果您授权，您的应用程序将始终显示一个图标，以示连接类型，以及在适当情况下，上面提到的地理位置。 IGLIA 绝不会将上述信息与您作为已识别或可识别的人联系起来，但是上述第三方可能会这样做（如果适用的话）。请注意他们的法律条款。具体来说，在华为设备中，GPS 信息会被访问并提供给公司名为“LocationService”的服务。 我们再次提醒您，您访问或使用本应用程序的第三方平台可能会收集上述数据或其他身份识别数据(自愿或非自愿地、有意或无意填写的数据)，相关数据收集可能超出欧洲数据保护立法的范围。因此，我们建议您了解并特别关注相关第三方法律条款，例如： • 谷歌: https://policies.google.com/privacy • Facebook: https://www.facebook.com/about/privacy/update • 华为: https://www.huawei.com/es/privacy-policy 同样, 望您知悉, 在使用浏览器的语音识别选项时, Meetkai将以完全匿名的方式保存您的语音转录, 用于改善其服务。Meetkai不会直接保存您的语音, 也不会以任何方式关联您的语音转录与您的身份。更多关于MeetKai的隐私策略请看: https://meetkai.com/es/privacy Igalia也无意于关联任何语音转录和身份或影响其隐私, 因此, Igalia 要求其声音地址中不得包含任何个人或机密信息。 在任何情况下，IGALIA保证当事人对其个人数据行使访问、纠正、删除、反对、限制处理和转移的权利。 为此，IGALIA已建立内部协议/程序来行使以上权利。 当事人可通过以下方式行使该权利：致信IGALIA的公司所在地：拉科鲁尼亚Bugallal Marchesi街22号1层，邮编15008，（Calle Bugallal Marchesi, 22, 1º, 15008, A Coruña），注明“数据保护”（“Data Protection”）；或者，发送电子邮件至info@igalia.com。 使用以上两种方式联系时，当事人必须附上国民身份证、护照或身份证明文件的副本，以证明其身份。 • 数据保护官员或相关权利管理部门将在专用表格中记录权利行使事宜，其中包含以下数据： • 申请号：将为每份收到的申请分配一个编号。 • 管理部门：如果负责人管理多个部门，将写明收到申请的部门。 • 投诉提交渠道：将写明收到请求的渠道，包括邮寄地址、邮件等。 • 申请日期：将注明申请被提交的日期。 • 行使的权利：当事人行使的权利类型。 • 反馈日期：向当事人发送答复的日期。 支持性文件（请求/回复受理凭证、通信等）将被存档，以便妥善保管。 同样，提醒您，您有权向西班牙数据保护局投诉。</string>
     <string name="privacy_policy_subtitle_3">适用法律和原文语言</string>
     <string name="privacy_policy_section_3">本隐私政策受西班牙法律管辖。本应用程序的隐私政策语言为西班牙语。因此，西班牙语原文版本和其他语言的译文之间可能出现的任何分歧，均以西班牙语版本为准。</string>
     <string name="settings_privacy_choose_search_engine_description">选择你偏爱的搜索引擎。</string>
@@ -2050,7 +2050,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n
 \n请安装 Meta Quest 商店的Wolvic最新版本。
 \n
-\n重要提示：除非您用火狐同步，新版 Wolvic应用不会有你的书签和标签页。</string>
+\n重要提示：除非您用Mozilla同步，新版 Wolvic应用不会有你的书签和标签页。</string>
     <string name="deprecated_version_dialog_title">建议的更新</string>
     <string name="deprecated_version_dialog_info_button">了解更多…</string>
     <string name="deprecated_version_dialog_store_button">安装…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -170,16 +170,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">開發者選項</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">登入帳號</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">管理帳號</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">登出</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">重新連結</string>
 
@@ -392,13 +392,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">傳送意見回饋給我們</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">登入</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">登出</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">重新連結</string>
 
@@ -736,12 +736,12 @@
     <string name="security_options_login_autofill">自動填寫</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">使用 Firefox 帳號同步登入資訊</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">使用 Mozilla 帳號同步登入資訊</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">帳號…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -843,11 +843,11 @@
     <string name="off">關閉</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">同步</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">不同步</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1060,7 +1060,7 @@
     <string name="bookmarks_show_all">顯示所有書籤</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Sync</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1267,14 +1267,14 @@
     <string name="addons_permissions_learn_more">了解權限的更多資訊</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Sync</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">同步中…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">要登出 Firefox 帳號嗎？</string>
+    <string name="fxa_signout_confirmation_title">要登出 Mozilla 帳號嗎？</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">登出後，就無法傳送分頁或收到來自其他裝置的分頁，也會停止同步書籤與上網紀錄。</string>
@@ -1924,14 +1924,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">註冊或登入 Firefox Account，即可從桌面版或行動版 Firefox 將分頁傳送到 VR 眼鏡。</string>
+    <string name="whats_new_body_1">註冊或登入 Mozilla Account，即可從桌面版或行動版 Firefox 將分頁傳送到 VR 眼鏡。</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Firefox Account 還可以用來在裝置間同步書籤與上網紀錄。</string>
+    <string name="whats_new_body_sub_1">Mozilla Account 還可以用來在裝置間同步書籤與上網紀錄。</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">登入</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,16 +179,16 @@
          opens a dialog box that contains settings that an application or Web developer might want to change. -->
     <string name="settings_developer_options">Developer Options</string>
 
-    <!-- This string is used in the 'Settings' window when user is not signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is not signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_in">Sign Into Account</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_manage">Manage Account</string>
 
-    <!-- This string is used in the 'Account' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Account' window when user is signed into a Mozilla Account -->
     <string name="settings_fxa_account_sign_out">Sign Out</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_fxa_account_reconnect">Reconnect</string>
 
@@ -431,13 +431,13 @@
          a the survey web site in opened in the currently focused window -->
     <string name="settings_send_your_feedback">Send us Your Feedback</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <!-- This string is used in the 'Settings' window when user is signed-out of Mozilla Accounts -->
     <string name="settings_accounts_sign_in">Sign in</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account -->
     <string name="settings_accounts_sign_out">Sign out</string>
 
-    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+    <!-- This string is used in the 'Settings' window when user is signed into a Mozilla Account, but needs to re-enter their password.
          Most common reason for this state is that the account password was changed on another device. -->
     <string name="settings_accounts_reconnect">Reconnect</string>
 
@@ -779,12 +779,12 @@
     <string name="security_options_login_autofill">Autofill</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Logins And Passwords settings dialog
-     and is used to enable or disable login sync with Firefox Account. If disabled the logins
-     won't be synced with the Firefox Account. -->
-    <string name="security_options_login_sync">Sync logins with Firefox Accounts</string>
+     and is used to enable or disable login sync with Mozilla Account. If disabled the logins
+     won't be synced with the Mozilla Account. -->
+    <string name="security_options_login_sync">Sync logins with Mozilla Accounts</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
-     that when clicked opens the Firefox Accounts settings panel. -->
+     that when clicked opens the Mozilla Accounts settings panel. -->
     <string name="security_options_login_fxa">Account…</string>
 
     <!-- This string labels a button in the Logins And Passwords settings dialog
@@ -892,11 +892,11 @@
     <string name="off">Off</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="sync">Sync</string>
 
     <!-- This string is displayed on the left of switched that are used to enable/disable sync when the switch is enabled.
-         i.e. The history switch for Firefox account syncing-->
+         i.e. The history switch for Mozilla account syncing-->
     <string name="do_not_sync">Don’t Sync</string>
 
     <!-- This string is displayed in the voice-search dialog box that is shown to the user when they press the
@@ -1122,7 +1122,7 @@
     <string name="bookmarks_show_all">Show All Bookmarks</string>
 
     <!-- This string is displayed is the "Sync" button in the bookmarks panel. When pressed the
-         bookmarks are synced with the Firefox account. -->
+         bookmarks are synced with the Mozilla account. -->
     <string name="bookmarks_sync">Sync</string>
 
     <!-- This string is displayed as the title of the history list, which contains the user's visited websites. -->
@@ -1332,14 +1332,14 @@
     <string name="addons_permissions_learn_more">Learn more about permissions</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel. When pressed the
-         history is synced with the Firefox account. -->
+         history is synced with the Mozilla account. -->
     <string name="fxa_sync">Sync</string>
 
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Syncing…</string>
 
     <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
-    <string name="fxa_signout_confirmation_title">Sign out of your Firefox Account?</string>
+    <string name="fxa_signout_confirmation_title">Sign out of your Mozilla Account?</string>
 
     <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
     <string name="fxa_signout_confirmation_body">When you sign out, you won’t be able to send or receive tabs from other devices. Your bookmarks and history will also stop syncing.</string>
@@ -2047,14 +2047,14 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_1">Sign in or create a new Firefox Account to send tabs from Firefox on your desktop or mobile device to your headset.</string>
+    <string name="whats_new_body_1">Sign in or create a new Mozilla Account to send tabs from Firefox on your desktop or mobile device to your headset.</string>
 
     <!-- This string is displayed in the body of the what's new dialog that is displayed if the user has updated
          or updated the app and hasn't signed it yet. -->
-    <string name="whats_new_body_sub_1">Firefox Account also lets you sync bookmarks and history across all your devices.</string>
+    <string name="whats_new_body_sub_1">Mozilla Account also lets you sync bookmarks and history across all your devices.</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
-         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Firefox Account sign-in page. -->
+         or updated the app and hasn't signed it yet. If clicked the user is redirected to the Mozilla Account sign-in page. -->
     <string name="whats_new_button_sign_in">Sign In</string>
 
     <!-- This string is displayed a button of the what's new dialog that is displayed if the user has updated
@@ -2439,7 +2439,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
         \n\t\u2022 In order to capture and translate the voice into text, the user’s sound data is sent to the servers owned by the third party company responsible for each platform, through an API for this purpose: for example, in Oculus, from Facebook, a service that sends it to Oculus Voice SDK. At no time is the aforementioned data processed, accessed, or incorporated into the servers owned by IGALIA. The data transmitted will be the exclusive responsibility of the third party companies that own each platform (hereinafter, the Third Parties), which may be located outside the European Union and subject to a legal regime that is less protective of user privacy. We recommend that you carefully read the privacy policy and terms of use of each of these external platforms before accepting and using their services. IGALIA will not be directly or indirectly responsible for the processing of personal data by said Third Parties.
         \n\t\u2022 Geographic location information maybe be obtained from the browser, instead of the one used by the system. However, in order to do so, you must set the location permissions of your device through a specific notice in this regard and IGALIA will in no way link the aforementioned information to you as an identified or identifiable person, although the Third Parties mentioned in the previous point could do so, if applicable. We recommend you to pay attention to their legal terms.
         \n\t\u2022 IGALIA will not access or store, in any way, the addresses or URLs visited by you.
-        \n\t\u2022 Integration with Cloud services (such as Firefox Accounts or Google Accounts) to synchronize data such as your browsing history or your user bookmarks may be possible. In this case, IGALIA will not access or process any information in any way, nor will it pass through IGALIA’s servers.
+        \n\t\u2022 Integration with Cloud services (such as Mozilla Accounts or Google Accounts) to synchronize data such as your browsing history or your user bookmarks may be possible. In this case, IGALIA will not access or process any information in any way, nor will it pass through IGALIA’s servers.
         \n\nWe remind you again that the Third Party platforms that you access or use with this application could collect this or other identifying data about you, either filling them in voluntarily or involuntarily and/or consciously or unconsciously, possibly outside the scope of European data protection legislation. Therefore, we recommend that you inform yourself and pay special attention to the legal terms of said Third Parties, such as, for example, the following:
         \n\n\t\u2022 Google: https://policies.google.com/privacy
         \n\t\u2022 Facebook: https://www.facebook.com/about/privacy/update


### PR DESCRIPTION
As of https://support.mozilla.org/en-US/kb/firefox-accounts-renamed-mozilla-accounts