### PR TITLE
[NoAPI] Reorganize the functionalities of the buttons

### DIFF
--- a/app/src/main/res/layout/noapi_layout.xml
+++ b/app/src/main/res/layout/noapi_layout.xml
@@ -23,7 +23,7 @@
         app:layout_constraintStart_toStartOf="parent">
 
         <ImageButton
-            android:id="@+id/forward_button"
+            android:id="@+id/up_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="0"
@@ -56,7 +56,7 @@
             android:src="@drawable/ic_baseline_arrow_right_24px" />
 
         <ImageButton
-            android:id="@+id/backward_button"
+            android:id="@+id/down_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="2"
@@ -80,7 +80,7 @@
             android:src="@drawable/ic_rotate_right_black_24px" />
 
         <ImageButton
-            android:id="@+id/pitch_up_button"
+            android:id="@+id/forward_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="0"
@@ -88,7 +88,7 @@
             android:src="@drawable/ic_baseline_add_24px" />
 
         <ImageButton
-            android:id="@+id/pitch_down_button"
+            android:id="@+id/backward_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="0"
@@ -107,7 +107,7 @@
         app:layout_constraintEnd_toEndOf="parent">
 
         <ImageButton
-            android:id="@+id/up_button"
+            android:id="@+id/pitch_up_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="0"
@@ -115,7 +115,7 @@
             android:src="@drawable/ic_keyboard_arrow_up_black_24px" />
 
         <ImageButton
-            android:id="@+id/down_button"
+            android:id="@+id/pitch_down_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="1"


### PR DESCRIPTION
So that it feels more natural:
- '+' '-' buttons for forward and backward (zoom in/out)
- D-pad up and down should not do anything related to pitch changes