### PR TITLE
Tooltip size independent of device density

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/UIButton.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/UIButton.java
@@ -324,7 +324,7 @@ public class UIButton extends AppCompatImageButton implements CustomUIButton {
             float ratio = WidgetPlacement.viewToWidgetRatio(getContext(), parent);
 
             mTooltipView.getPlacement().parentHandle = parent.getHandle();
-            mTooltipView.getPlacement().density = mTooltipDensity;
+            mTooltipView.setDensityScale(mTooltipDensity);
             // At the moment we only support showing tooltips on top or bottom of the target view
             if (mTooltipPosition == ViewUtils.TooltipPosition.BOTTOM) {
                 mTooltipView.getPlacement().anchorY = 1.0f;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NotificationManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NotificationManager.java
@@ -215,7 +215,7 @@ public class NotificationManager {
 
     private static void setPlacement(@NonNull TooltipWidget notificationView, @NonNull Notification notification) {
         notificationView.getPlacement().parentHandle = notification.mParent.getHandle();
-        notificationView.getPlacement().density = WidgetPlacement.floatDimension(notification.mParent.getContext(), notification.mDensity);
+        notificationView.setDensityScale(WidgetPlacement.floatDimension(notification.mParent.getContext(), notification.mDensity));
         notificationView.getPlacement().translationZ = notification.mZTranslation;
         notificationView.getPlacement().cylinder = notification.mCurved;
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TooltipWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TooltipWidget.java
@@ -11,13 +11,14 @@ import androidx.annotation.StringRes;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.utils.AnimationHelper;
-import com.igalia.wolvic.utils.DeviceType;
 
 public class TooltipWidget extends UIWidget {
 
     protected TextView mText;
     protected ViewGroup mLayout;
     protected int mLayoutRes;
+    protected float mDefaultDensity;
+    protected float mDensityScale = 1.0f;
 
     public TooltipWidget(@NonNull Context aContext, @NonNull  @LayoutRes int layoutRes) {
         super(aContext);
@@ -46,6 +47,8 @@ public class TooltipWidget extends UIWidget {
         aPlacement.anchorX = 0.5f;
         aPlacement.anchorY = 0.5f;
         aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tooltip_z_distance);
+        mDefaultDensity = getResources().getDisplayMetrics().density;
+        aPlacement.density = mDefaultDensity * mDensityScale;
     }
 
     public void updateUI() {
@@ -72,10 +75,6 @@ public class TooltipWidget extends UIWidget {
         int paddingV = getPaddingTop() + getPaddingBottom();
         mWidgetPlacement.width = (int)((getMeasuredWidth() + paddingH)/mWidgetPlacement.density);
         mWidgetPlacement.height = (int)((getMeasuredHeight() + paddingV)/mWidgetPlacement.density);
-        if (DeviceType.isHVRBuild()) {
-            // Widgets are very small in HVR
-            mWidgetPlacement.worldWidth = 1.5f * WidgetPlacement.worldToDpRatio(getContext()) * mWidgetPlacement.width;
-        }
 
         super.show(aShowFlags);
         AnimationHelper.scaleIn(mLayout, 100, 0, null);
@@ -98,4 +97,9 @@ public class TooltipWidget extends UIWidget {
         mText.setText(text);
     }
 
+    // Modify the widget scale to change the size of the widget.
+    public void setDensityScale(float densityScale) {
+        mDensityScale = densityScale;
+        getPlacement().density = mDefaultDensity * mDensityScale;
+    }
 }

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -129,7 +129,8 @@
     <item name="tray_world_width" format="float" type="dimen">1.2</item>
     <dimen name="tray_width">204dp</dimen>
     <dimen name="tray_height">66dp</dimen>
-    <item name="tray_tooltip_density" format="float" type="dimen">3.0</item>
+    <!-- The density of the tray tooltips is the default one. -->
+    <item name="tray_tooltip_density" format="float" type="dimen">1.0</item>
     <dimen name="tray_tooltip_padding_h">20dp</dimen>
     <dimen name="tray_tooltip_padding_v">10dp</dimen>
     <dimen name="tray_tooltip_text_size">22sp</dimen>
@@ -232,7 +233,8 @@
     <dimen name="tooltip_default_padding_h">25dp</dimen>
     <dimen name="tooltip_default_padding_v">15dp</dimen>
     <dimen name="tooltip_default_text_size">24sp</dimen>
-    <item name="tooltip_default_density" format="float" type="dimen">2.0</item>
+    <!-- We modify the density slightly so the tooltip will be 50% larger. -->
+    <item name="tooltip_default_density" format="float" type="dimen">.75</item>
 
     <!-- General 2nd level settings dimensions -->
     <dimen name="settings_dialog_width">600dp</dimen>


### PR DESCRIPTION
To scale the size of tooltip widgets, we modify the "density" field in the tooltip's placement.

Our implementation replaced the default density with a fixed value. However, that default density is different between devices; when we replace the device-dependent density value with a fixed number, we introduce differences between devices.

In practice, this meant that tooltips could be too large on some systems and too small on others.

This PR makes the tooltip's density dependent of the device's density, so tooltips have the same relative size everywhere.