### PR TITLE
Default homepage for mainland China

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -370,7 +370,7 @@ android {
             buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "true"
             buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
             buildConfigField "Boolean", "CN_FIRST_RUN_IN_PHONE_UI", "true"
-            resValue 'string', 'HOMEPAGE_URL', 'about:blank'
+            resValue 'string', 'HOMEPAGE_URL', 'https://wolvic.com/welcome/'
         }
     }
 


### PR DESCRIPTION
Use https://wolvic.com/welcome/ as our default homepage for mainland China packages.