### PR TITLE
Properly set the Quest3 device name

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -77,6 +77,7 @@ public class DeviceType {
                 break;
             case MetaQuest3:
                 name = "Meta Quest 3";
+                break;
             default:
                 name = "Unknown Type";
         }


### PR DESCRIPTION
The device name is set in a switch. In the case of the Quest3 the case didn't have a break statement so it was falling through the default case. This was the reason why the Quest3 was recognized as "Unknown Type" even though the DeviceType was correctly detected.