### PR TITLE
Use Khronos OpenXR headers in OCULUSVR builds

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -95,7 +95,6 @@ if(OPENXR)
     if (OCULUSVR)
         include_directories(
             ${CMAKE_SOURCE_DIR}/../third_party/OVRPlatformSDK/Include
-            ${CMAKE_SOURCE_DIR}/../third_party/ovr_openxr_mobile_sdk/OpenXR/Include
         )
         add_custom_command(TARGET native-lib POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -35,9 +35,6 @@
 
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
-#ifdef OCULUSVR
-#include <openxr/openxr_oculus.h>
-#endif
 #include "OpenXRHelpers.h"
 #include "OpenXRSwapChain.h"
 #include "OpenXRInput.h"


### PR DESCRIPTION
We have been traditionally using Oculus' OpenXR headers in the OCULUSVR builds. However we don't use and we don't plan to use any vendor specific API that is not part of the official spec.

So instead of using that header we just better stick to the ones provided by the official repository.