### PR TITLE
Add break for all cases in setting device type name

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -45,6 +45,7 @@ public class DeviceType {
                 break;
             case MetaQuestPro:
                 name = "Meta Quest Pro";
+                break;
             case ViveFocus:
                 name = "Vive Focus";
                 break;
@@ -80,6 +81,7 @@ public class DeviceType {
                 break;
             default:
                 name = "Unknown Type";
+                break;
         }
         Log.d("VRB", "Setting device type to: " + name);
         mType = aType;


### PR DESCRIPTION
Same as #1091

This will at least make it recognize "Meta Quest Pro" correctly