### PR TITLE
OpenXR: Add support for XR_FB_keyboard_tracking

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -16,6 +16,10 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
+    <!-- Tell the system this app can handle tracked keyboards -->
+    <uses-feature android:name="oculus.software.trackedkeyboard" android:required="false" />
+    <uses-permission android:name="com.oculus.permission.TRACKED_KEYBOARD" />
+
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1530,6 +1530,7 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
     m.controllersReadyCallback();
     m.controllersReadyCallback = nullptr;
   }
+  m.input->SetKeyboardTrackingEnabled(m.keyboardTrackingSupported);
 
   vrb::RenderContextPtr context = m.context.lock();
 

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -21,6 +21,8 @@ PFN_xrCreatePassthroughLayerFB OpenXRExtensions::sXrCreatePassthroughLayerFB = n
 PFN_xrDestroyPassthroughLayerFB OpenXRExtensions::sXrDestroyPassthroughLayerFB = nullptr;
 PFN_xrCreateHandMeshSpaceMSFT OpenXRExtensions::sXrCreateHandMeshSpaceMSFT = nullptr;
 PFN_xrUpdateHandMeshMSFT OpenXRExtensions::sXrUpdateHandMeshMSFT = nullptr;
+PFN_xrCreateKeyboardSpaceFB OpenXRExtensions::xrCreateKeyboardSpaceFB = nullptr;
+PFN_xrQuerySystemTrackedKeyboardFB OpenXRExtensions::xrQuerySystemTrackedKeyboardFB = nullptr;
 
 void OpenXRExtensions::Initialize() {
     // Extensions.
@@ -107,6 +109,13 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
                                           reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreatePassthroughLayerFB)));
         CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrDestroyPassthroughLayerFB",
                                           reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyPassthroughLayerFB)));
+    }
+
+    if (IsExtensionSupported(XR_FB_KEYBOARD_TRACKING_EXTENSION_NAME)) {
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreateKeyboardSpaceFB",
+                                        reinterpret_cast<PFN_xrVoidFunction *>(&xrCreateKeyboardSpaceFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance,"xrQuerySystemTrackedKeyboardFB",
+                                        reinterpret_cast<PFN_xrVoidFunction *>(&xrQuerySystemTrackedKeyboardFB)));
     }
 }
 

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -36,6 +36,10 @@ namespace crow {
 
     static PFN_xrCreateHandMeshSpaceMSFT sXrCreateHandMeshSpaceMSFT;
     static PFN_xrUpdateHandMeshMSFT sXrUpdateHandMeshMSFT;
+
+    static PFN_xrCreateKeyboardSpaceFB xrCreateKeyboardSpaceFB;
+    static PFN_xrQuerySystemTrackedKeyboardFB xrQuerySystemTrackedKeyboardFB;
+
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
      static std::unordered_set<std::string> sSupportedApiLayers;

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -2,6 +2,7 @@
 #include "OpenXRHelpers.h"
 #include "OpenXRInputSource.h"
 #include "OpenXRActionSet.h"
+#include "OpenXRExtensions.h"
 #include <vector>
 
 namespace crow {
@@ -80,6 +81,10 @@ XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, 
     input->Update(frameState, baseSpace, head, offsets, renderMode, delegate);
   }
 
+  // Update tracked keyboard
+  if (keyboardTrackingFB != nullptr)
+    UpdateTrackedKeyboard(frameState, baseSpace);
+
   return XR_SUCCESS;
 }
 
@@ -142,7 +147,70 @@ HandMeshBufferPtr OpenXRInput::GetNextHandMeshBuffer(const int32_t aControllerIn
   return mInputSources.at(aControllerIndex)->GetNextHandMeshBuffer();
 }
 
+void OpenXRInput::UpdateTrackedKeyboard(const XrFrameState& frameState, XrSpace baseSpace) {
+  CHECK(keyboardTrackingFB != nullptr);
+  CHECK(OpenXRExtensions::xrQuerySystemTrackedKeyboardFB != nullptr);
+  CHECK(OpenXRExtensions::xrCreateKeyboardSpaceFB != nullptr);
+
+  XrKeyboardTrackingQueryFB queryInfo = {
+    .type = XR_TYPE_KEYBOARD_TRACKING_QUERY_FB,
+    .flags = XR_KEYBOARD_TRACKING_QUERY_LOCAL_BIT_FB,
+  };
+  XrKeyboardTrackingDescriptionFB kbdDesc;
+  CHECK_XRCMD(OpenXRExtensions::xrQuerySystemTrackedKeyboardFB(mSession, &queryInfo, &kbdDesc));
+
+  // Check if keyboard disappeared or changed, and clear up state if so
+  if ((kbdDesc.flags & XR_KEYBOARD_TRACKING_EXISTS_BIT_FB) == 0 ||
+       kbdDesc.trackedKeyboardId != keyboardTrackingFB->trackedKeyboardId) {
+    if (keyboardTrackingFB->space != XR_NULL_HANDLE) {
+      xrDestroySpace(keyboardTrackingFB->space);
+      keyboardTrackingFB->space = XR_NULL_HANDLE;
+    }
+    keyboardTrackingFB->trackedKeyboardId = 0;
+  }
+
+  // Bail-out if no keyboard exists
+  if ((kbdDesc.flags & XR_KEYBOARD_TRACKING_EXISTS_BIT_FB) == 0)
+    return;
+
+  keyboardTrackingFB->trackedKeyboardId = kbdDesc.trackedKeyboardId;
+
+  // Create the XrSpace to track the keyboard, if not done already
+  if (keyboardTrackingFB->space == XR_NULL_HANDLE) {
+    VRB_LOG("Tracked keyboard detected: %s", kbdDesc.name);
+
+    XrKeyboardSpaceCreateInfoFB createInfo{
+      .type = XR_TYPE_KEYBOARD_SPACE_CREATE_INFO_FB,
+      .trackedKeyboardId = kbdDesc.trackedKeyboardId,
+    };
+    CHECK_XRCMD(OpenXRExtensions::xrCreateKeyboardSpaceFB(mSession, &createInfo,
+                                                          &keyboardTrackingFB->space));
+  }
+
+  // If keyboard is active, query and store the keyboard's pose
+  if (kbdDesc.flags & XR_KEYBOARD_TRACKING_CONNECTED_BIT_FB) {
+    CHECK(keyboardTrackingFB->space != XR_NULL_HANDLE);
+
+    keyboardTrackingFB->location.type = XR_TYPE_SPACE_LOCATION;
+    CHECK_XRCMD(xrLocateSpace(keyboardTrackingFB->space, baseSpace, frameState.predictedDisplayTime,
+                              &keyboardTrackingFB->location));
+  }
+}
+
+void OpenXRInput::SetKeyboardTrackingEnabled(bool enabled) {
+  if (enabled && keyboardTrackingFB == nullptr) {
+    keyboardTrackingFB = std::make_unique<KeyboardTrackingFB>();
+  } else if (!enabled && keyboardTrackingFB != nullptr) {
+    keyboardTrackingFB.reset();
+    keyboardTrackingFB = nullptr;
+  }
+}
+
 OpenXRInput::~OpenXRInput() {
+  if (keyboardTrackingFB != nullptr) {
+    keyboardTrackingFB.reset();
+    keyboardTrackingFB = nullptr;
+  }
 }
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -23,7 +23,19 @@ typedef std::shared_ptr<HandMeshBuffer> HandMeshBufferPtr;
 
 class OpenXRInput {
 private:
+  struct KeyboardTrackingFB {
+    uint64_t trackedKeyboardId { 0 };
+    XrSpace space = XR_NULL_HANDLE;
+    XrSpaceLocation location;
+    ~KeyboardTrackingFB() {
+      if (space != XR_NULL_HANDLE)
+        xrDestroySpace(space);
+    }
+  };
+  typedef std::unique_ptr<KeyboardTrackingFB> KeyboardTrackingFBPtr;
+
   OpenXRInput(XrInstance, XrSession, XrSystemProperties, ControllerDelegate& delegate);
+  void UpdateTrackedKeyboard(const XrFrameState& frameState, XrSpace baseSpace);
 
   OpenXRInputMapping* GetActiveInputMapping() const;
 
@@ -32,6 +44,7 @@ private:
   XrSystemProperties mSystemProperties;
   std::vector<OpenXRInputSourcePtr> mInputSources;
   OpenXRActionSetPtr mActionSet;
+  KeyboardTrackingFBPtr keyboardTrackingFB { nullptr };
 
 public:
   static OpenXRInputPtr Create(XrInstance, XrSession, XrSystemProperties, ControllerDelegate& delegate);
@@ -43,6 +56,7 @@ public:
   bool AreControllersReady() const;
   void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
   HandMeshBufferPtr GetNextHandMeshBuffer(const int32_t aControllerIndex);
+  void SetKeyboardTrackingEnabled(bool enabled);
   ~OpenXRInput();
 };
 


### PR DESCRIPTION
Only Quest devices support this at the moment. Tested on Quest2.

Note that this patch doesn't deal with rendering of the keyboard, nor the hands-on-keyboard passthrough functionality. It just track the keyboard's id, availability and location on every frame. A subsequent series will add the rest of the functionality to make this usable, namely, `XR_FB_render_model` and `XR_FB_passthrough_keyboard_hands` extensions support. Those are work in progress at the moment.
    
The bulk of the implementation was added to OpenXRInput, bacause OpenXRInputSource is meant for controllers and DeviceDelegateOpenXR is already bloated. In the future, we might want to move this to OpenXRTrackedKeyboard if code gets more complex.