### PR TITLE
Select 90Hz refresh rate for Quest3

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -643,6 +643,7 @@ struct DeviceDelegateOpenXR::State {
 
     float suggestedRefreshRate = 0.0;
     switch (deviceType) {
+      case device::MetaQuest3:
       case device::OculusQuest2:
       case device::MetaQuestPro:
       // PicoXR default is 72hz, but has an experimental setting to set it to 90hz. If the setting


### PR DESCRIPTION
We use the FB_display_refresh_rate extension to dynamically select the device display refresh rate in those devices supporting the extension. The extension just returns a list of available refresh rates and we're the ones selecting one from the list of candidates.

To select one of them we return the first supported rate which is equal or higher than a suggested refresh rate. That suggested refresh rate is device specific. For the case of the Quest3 we didn't have an specific value so the fallback one (60Hz) was suggested. That's why on the Quest3 we were running at the slowest supported refresh rate 72Hz.