### PR TITLE
Fix widgets hovering in library UI when DPI is not 100

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1096,9 +1096,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
 
             float scale = widget != null ? widget.getPlacement().textureScale : SettingsStore.getInstance(this).getDisplayDpi() / 100.0f;
-            // WindowWidget is an exception to handle coordinates correctly.
+            // We shouldn't divide the scale factor when we pass the motion event to gecko
             if (widget instanceof WindowWidget) {
-                scale = 1.0f;
+                WindowWidget windowWidget = (WindowWidget) widget;
+                if (!windowWidget.isLibraryVisible()) {
+                    scale = 1.0f;
+                }
             }
             final float x = aX / scale;
             final float y = aY / scale;

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1096,7 +1096,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
 
             float scale = widget != null ? widget.getPlacement().textureScale : SettingsStore.getInstance(this).getDisplayDpi() / 100.0f;
-            // We shouldn't divide the scale factor when we pass the motion event to gecko
+            // We shouldn't divide the scale factor when we pass the motion event to the web engine
             if (widget instanceof WindowWidget) {
                 WindowWidget windowWidget = (WindowWidget) widget;
                 if (!windowWidget.isLibraryVisible()) {


### PR DESCRIPTION
The issue mentioned in PR https://github.com/Igalia/wolvic/pull/1106 is not caused by https://github.com/Igalia/wolvic/pull/1105, but rather https://github.com/Igalia/wolvic/pull/1086#discussion_r1369252299

This commit adds an exception to the library UI so that we make sure we are actually on the web page when we reset the scale to 1 for motion event handling.