### PR TITLE
Increase logical size and resolution of Web pages (relanded)

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -85,14 +85,20 @@ public class SettingsStore {
     public final static boolean SPEECH_DATA_COLLECTION_REVIEWED_DEFAULT = false;
     public final static int UA_MODE_DEFAULT = WSessionSettings.USER_AGENT_MODE_VR;
     public final static int INPUT_MODE_DEFAULT = 1;
-    public final static float DISPLAY_DENSITY_DEFAULT = 1.0f;
-    public final static int WINDOW_WIDTH_DEFAULT = 800;
-    public final static int WINDOW_HEIGHT_DEFAULT = 450;
-    public final static int DISPLAY_DPI_DEFAULT = 96;
+
+    // Default DPI: the resolution of the texture is twice the world size of the window.
+    public final static int DISPLAY_DPI_DEFAULT = 192;
     public final static int DISPLAY_DPI_MIN = 70;
     public final static int DISPLAY_DPI_MAX = 400;
+    // Default density: this value gives a logical width of 1024 CSS pixels for the default window.
+    public final static float DISPLAY_DENSITY_DEFAULT = 1.5f;
+    // World size: multiply by density to get the available resolution for the Web engine.
+    public final static int WINDOW_WIDTH_DEFAULT = 800;
+    public final static int WINDOW_HEIGHT_DEFAULT = 450;
+    // The maximum size is computed so the resulting texture fits within 2560x2560.
     public final static int MAX_WINDOW_WIDTH_DEFAULT = 1200;
-    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 1200;
+    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 675;
+
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;
     public final static String ENV_DEFAULT = "cyberpunk";

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
@@ -38,15 +38,18 @@ object EngineProvider {
                     .enhancedTrackingProtectionLevel(settingsStore.trackingProtectionLevel)
                     .build())
             builder.displayDensityOverride(settingsStore.displayDensity)
-            builder.remoteDebuggingEnabled(settingsStore.isRemoteDebuggingEnabled)
             builder.displayDpiOverride(settingsStore.displayDpi)
-            builder.screenSizeOverride(settingsStore.maxWindowWidth, settingsStore.maxWindowHeight)
+            builder.screenSizeOverride(
+                (settingsStore.maxWindowWidth * settingsStore.displayDensity).toInt(),
+                (settingsStore.maxWindowHeight * settingsStore.displayDensity).toInt()
+            )
             builder.enterpriseRootsEnabled(settingsStore.isSystemRootCAEnabled)
             builder.inputAutoZoomEnabled(false)
             builder.doubleTapZoomingEnabled(false)
             builder.forceUserScalableEnabled(false)
             builder.debugLogging(settingsStore.isDebugLoggingEnabled)
             builder.consoleOutput(settingsStore.isDebugLoggingEnabled)
+            builder.remoteDebuggingEnabled(settingsStore.isRemoteDebuggingEnabled)
             builder.loginAutofillEnabled(settingsStore.isAutoFillEnabled)
             builder.configFilePath(SessionUtils.prepareConfigurationPath(context))
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -105,6 +105,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public static final int DEACTIVATE_CURRENT_SESSION = 0;
     public static final int LEAVE_CURRENT_SESSION_ACTIVE = 1;
 
+    private final float DEFAULT_SCALE = 1.0f;
+    private final float MAX_SCALE = 3.0f;
+
     private Surface mSurface;
     private int mWidth;
     private int mHeight;
@@ -1497,11 +1500,27 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public @NonNull Pair<Float, Float> getSizeForScale(float aScale, float aAspect) {
-        float worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) *
-                (float)SettingsStore.getInstance(getContext()).getWindowWidth() / (float)SettingsStore.WINDOW_WIDTH_DEFAULT;
-        float worldHeight = worldWidth / aAspect;
-        float area = worldWidth * worldHeight * aScale;
-        float targetWidth = (float) Math.sqrt(area * aAspect);
+        final float defaultWorldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+        final float maxWidthWorld = SettingsStore.MAX_WINDOW_WIDTH_DEFAULT * (defaultWorldWidth/SettingsStore.WINDOW_WIDTH_DEFAULT);
+        float targetWidth;
+
+        if (aScale < DEFAULT_SCALE) {
+            // Reduce the area of the window according to the desired scale.
+            float worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+            float worldHeight = worldWidth / aAspect;
+            float targetArea = worldWidth * worldHeight * aScale;
+            targetWidth = (float) Math.sqrt(targetArea * aAspect);
+        } else if (aScale == DEFAULT_SCALE) {
+            // Default window size.
+            targetWidth = defaultWorldWidth;
+        } else if (aScale >= MAX_SCALE) {
+            // Maximum window size.
+            targetWidth = maxWidthWorld;
+        } else {
+            // Proportional between the default and maximum sizes.
+            targetWidth = defaultWorldWidth + (maxWidthWorld - defaultWorldWidth) * (aScale - DEFAULT_SCALE) / (MAX_SCALE - DEFAULT_SCALE);
+        }
+
         float targetHeight = targetWidth / aAspect;
         return Pair.create(targetWidth, targetHeight);
     }


### PR DESCRIPTION
Adjust the default DPI that we pass to the Web engine so that the texture for the default window will have twice the resolution.

Adjust the default density so that the default window has a logical size of 1024x576 CSS pixels.

Set the size of the maximum window so that its associated texture fits within 2560x2560, which is the maximum in some systems.

The window scaling will interpolate between the default and maximum values.

This commit needed to be reverted before because it clashed with recent changes related to motion event handling. See:
  https://github.com/Igalia/wolvic/pull/1105
  https://github.com/Igalia/wolvic/pull/1106
  https://github.com/Igalia/wolvic/pull/1107