### PR TITLE
[Chromium] Add support for target=_blank navigations

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -422,4 +422,15 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     public ViewGroup getContentView() {
         return mTab != null ? mTab.getContentView() : null;
     }
+
+    // The onReadyCallback() mechanism is really limited because it heavily depends on renderers
+    // being created by the client (Wolvic). There are cases in which the renderer is created by the
+    // web engine (like target=_blank navigations) so we need to explicitly call onReady ourselves.
+    public void invokeOnReady(RuntimeImpl runtime, String uri) {
+        assert !isOpen();
+        mRuntime = runtime;
+        mInitialUri = uri;
+        mReadyCallback.onReady();
+    }
+
 }

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsDelegate.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsDelegate.java
@@ -5,14 +5,16 @@ import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.browser.api.WSession;
 
+import org.chromium.base.task.PostTask;
+import org.chromium.base.task.TaskTraits;
 import org.chromium.blink.mojom.DisplayMode;
-import org.chromium.components.embedder_support.delegate.WebContentsDelegateAndroid;
 import org.chromium.content_public.browser.InvalidateTypes;
 import org.chromium.content_public.browser.LoadUrlParams;
 import org.chromium.content_public.browser.WebContents;
 import org.chromium.url.GURL;
+import org.chromium.wolvic.WolvicWebContentsDelegate;
 
-public class TabWebContentsDelegate extends WebContentsDelegateAndroid {
+public class TabWebContentsDelegate extends WolvicWebContentsDelegate {
     private @NonNull SessionImpl mSession;
     private @NonNull final WebContents mWebContents;
 
@@ -69,6 +71,35 @@ public class TabWebContentsDelegate extends WebContentsDelegateAndroid {
                 delegate.onTitleChange(mSession, mWebContents.getTitle());
             }
         }
+    }
+
+    public class OnNewSessionCallback implements WSession.NavigationDelegate.OnNewSessionCallback {
+        public OnNewSessionCallback(RuntimeImpl runtime, GURL url) {
+            mRuntime = runtime;
+            mURL = url;
+        }
+
+        @Override
+        public void onNewSession(WSession session) {
+            ((SessionImpl) session).invokeOnReady(mRuntime, mURL.getSpec());
+        }
+
+        private RuntimeImpl mRuntime;
+        private GURL mURL;
+    }
+
+    @Override
+    public void onCreateNewWindow(GURL url) {
+        WSession.NavigationDelegate delegate = mSession.getNavigationDelegate();
+        assert delegate != null;
+
+        // We must return before executing this, otherwise we might end up messing around the native
+        // objects that chromium uses to back up some of the Java objects we use. For example the
+        // WebContentsDelegate created by Chromium might be freed by the onNewSession() call when it
+        // sets the new WebContentsDelegate object created by Wolvic.
+        PostTask.postDelayedTask(TaskTraits.UI_DEFAULT, () -> {
+            delegate.onNewSession(mSession, url.getSpec(), new OnNewSessionCallback(mSession.mRuntime, url));
+        }, 0);
     }
 
     @Override

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/NavigationDelegateImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/NavigationDelegateImpl.java
@@ -53,7 +53,7 @@ class NavigationDelegateImpl implements GeckoSession.NavigationDelegate {
     @Nullable
     @Override
     public GeckoResult<GeckoSession> onNewSession(@NonNull GeckoSession session, @NonNull String uri) {
-        GeckoResult<WSession> result = ResultImpl.from(mDelegate.onNewSession(mSession, uri));
+        GeckoResult<WSession> result = ResultImpl.from(mDelegate.onNewSession(mSession, uri, null));
         if (result == null) {
             return null;
         }

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -465,6 +465,9 @@ public interface WSession {
             return null;
         }
 
+        public interface OnNewSessionCallback {
+            void onNewSession(WSession session);
+        }
         /**
          * A request has been made to open a new session. The URI is provided only for informational
          * purposes. Do not call ISession.load here. Additionally, the returned ISession must be
@@ -472,6 +475,8 @@ public interface WSession {
          *
          * @param session The ISession that initiated the callback.
          * @param uri The URI to be loaded.
+         * @param callback A callback with extra work that will be performed after creating the
+         *                 session but before notifying the observers/clients.
          * @return A {@link WResult} which holds the returned ISession. May be null, in which
          *     case the request for a new window by web content will fail. e.g., <code>window.open()
          *     </code> will return null. The implementation of onNewSession is responsible for
@@ -481,7 +486,7 @@ public interface WSession {
         @UiThread
         default @Nullable
         WResult<WSession> onNewSession(
-                @NonNull final WSession session, @NonNull final String uri) {
+                @NonNull final WSession session, @NonNull final String uri, OnNewSessionCallback callback) {
             return null;
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1198,13 +1198,18 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     }
 
     @Override
-    public WResult<WSession> onNewSession(@NonNull WSession aSession, @NonNull String aUri) {
+    public WResult<WSession> onNewSession(@NonNull WSession aSession, @NonNull String aUri, OnNewSessionCallback callback) {
         mKeepAlive = System.currentTimeMillis() + KEEP_ALIVE_DURATION_MS;
         Log.d(LOGTAG, "onNewSession: " + aUri);
 
         Session session = SessionStore.get().createSession(mState.mSettings, SESSION_DO_NOT_OPEN);
         session.mState.mParentId = mState.mId;
         session.mKeepAlive = mKeepAlive;
+
+        if (callback != null) {
+            callback.onNewSession((WSession) session.mState.mSession);
+        }
+
         for (SessionChangeListener listener: mSessionChangeListeners) {
             listener.onStackSession(session);
         }

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -23,6 +23,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.Media;
 import com.igalia.wolvic.browser.SessionChangeListener;
@@ -652,7 +653,10 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     }
 
     public CompletableFuture<Void> captureBackgroundBitmap(int displayWidth, int displayHeight) {
-        if (mState.mSession == null || !mFirstContentfulPaint) {
+        // FIXME: calling acquireDisplay() is not well supported in the Chromium backend because
+        // that method incorrectly does some extra work handling widgets. Disable the bitmap
+        // capture in the meantime (it was not working anyway yet).
+        if (mState.mSession == null || !mFirstContentfulPaint || BuildConfig.FLAVOR_backend == "chromium") {
             return CompletableFuture.completedFuture(null);
         }
         Surface captureSurface = BitmapCache.getInstance(mContext).acquireCaptureSurface(displayWidth, displayHeight);


### PR DESCRIPTION
It requires several changes in wolvic-chromium that are already handled [here](https://github.com/Igalia/wolvic-chromium/pull/50/).

From the Wolvic side we need 3 different things
1. Disable the creation of a bitmap for the new tab. It has never been implemented in Chromium but the current code can badly interfere with new window creation
2. Add support to execute a `Runnable` after creating a new `Session` but just before notifying the observers. This is needed to properly initialize the new session with the new target URL (since the current code only does that after getting the notification of a new render process being created)
3. Use the newly added method onCreateNewWindow() to get the URL to be opened, and create a new session with that.