### PR TITLE
Enhance detection of hand tracking availability

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -535,6 +535,18 @@ bool OpenXRInputSource::GetHandTrackingInfo(XrTime predictedDisplayTime, XrSpace
         mHasHandJoints = true;
 #endif
 
+    // Even if the SDK reports the hand tracking as active we still need to check the validity
+    // of the joint positions to determine if we should render the hands or not. Some SDKs return
+    // isActive as TRUE even if the joints are not valid.
+    auto hasAtLeastOneValidJoint = [](const XrHandJointLocationsEXT& jointLocations) {
+        for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; ++i) {
+            if (jointLocations.jointLocations[i].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT)
+                return true;
+        }
+        return false;
+    };
+    mHasHandJoints = mHasHandJoints && hasAtLeastOneValidJoint(jointLocations);
+
     // Rest of the method deal with XR_MSFT_hand_tracking_mesh extension
 
     if (!OpenXRExtensions::IsExtensionSupported(XR_MSFT_HAND_TRACKING_MESH_EXTENSION_NAME) || !mHasHandJoints)


### PR DESCRIPTION
So far we've been using XrHandJointLocationsEXT::isActive to determine whether or not hand tracking was active for a given hand. However that is not a reliable way to detect that because we've seen SDKs that return true for isActive when all the hand joints poses are invalid.

That's why we added an extra computation to check that we have at least one valid joint before considering that the hand tracking is active for a given source.

This fixes a crash in the Chromium port when entering a WebXR experience with just one hand active.