### PR TITLE
Hide brightness button when playing video in Passthrough

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -719,6 +719,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         hideMenu();
         hideAllNotifications();
 
+        mBinding.navigationBarFullscreen.brightnessButton.setVisibility(mWidgetManager.isPassthroughEnabled() ? GONE : VISIBLE);
         mWidgetManager.pushBackHandler(mFullScreenBackHandler);
 
         mWidgetManager.setControllersVisible(false);

--- a/app/src/main/res/layout/navigation_bar_fullscreen.xml
+++ b/app/src/main/res/layout/navigation_bar_fullscreen.xml
@@ -46,17 +46,17 @@
                 app:privateMode="@{viewmodel.isPrivateSession}"/>
 
             <com.igalia.wolvic.ui.views.UIButton
-                android:id="@+id/projectionButton"
+                android:id="@+id/brightnessButton"
                 style="@style/fullScreenButtonTheme"
-                android:src="@drawable/ic_icon_vr_projection"
-                android:tooltipText="@string/video_mode_tooltip"
+                android:src="@drawable/ic_icon_brightness"
+                android:tooltipText="@string/brightness_mode_tooltip"
                 app:privateMode="@{viewmodel.isPrivateSession}"/>
 
             <com.igalia.wolvic.ui.views.UIButton
-                android:id="@+id/brightnessButton"
+                android:id="@+id/projectionButton"
                 style="@style/fullScreenLastButtonTheme"
-                android:src="@drawable/ic_icon_brightness"
-                android:tooltipText="@string/brightness_mode_tooltip"
+                android:src="@drawable/ic_icon_vr_projection"
+                android:tooltipText="@string/video_mode_tooltip"
                 app:privateMode="@{viewmodel.isPrivateSession}"/>
         </LinearLayout>
     </FrameLayout>


### PR DESCRIPTION
Also move the brightness button to the middle (so that we don't need to rearrange the style to other buttons)

Motivation:
Those brightness settings don't work for passthrough environment