### PR TITLE
Support head lock

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -354,6 +354,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mPoorPerformanceAllowList = new HashSet<>();
         checkForCrash();
 
+        setHeadLockEnabled(mSettings.isHeadLockEnabled());
+
         // Show the launch dialogs, if needed.
         if (!showTermsServiceDialogIfNeeded()) {
             if (!showPrivacyDialogIfNeeded()) {
@@ -720,6 +722,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 SpeechRecognizer speechRecognizer =
                         SpeechServices.getInstance(this, SettingsStore.getInstance(this).getVoiceSearchService());
                 ((VRBrowserApplication) getApplication()).setSpeechRecognizer(speechRecognizer);
+            } else if (key.equals(getString(R.string.settings_key_head_lock))) {
+                setHeadLockEnabled(SettingsStore.getInstance(this).isHeadLockEnabled());
             }
         } catch (ReflectiveOperationException e) {
             e.printStackTrace();
@@ -1920,6 +1924,16 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    public void setHeadLockEnabled(boolean isHeadLockEnabled) {
+        queueRunnable(() -> {
+            setHeadLockEnabledNative(isHeadLockEnabled);
+            if (!isHeadLockEnabled) {
+                recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL);
+            }
+        });
+    }
+
+    @Override
     public void recenterUIYaw(@YawTarget int aTarget) {
         queueRunnable(() -> recenterUIYawNative(aTarget));
     }
@@ -2062,6 +2076,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void showVRVideoNative(int aWindowHandler, int aVideoProjection);
     private native void hideVRVideoNative();
     private native void togglePassthroughNative();
+    private native void setHeadLockEnabledNative(boolean isEnabled);
     private native void recenterUIYawNative(@YawTarget int aTarget);
     private native void setControllersVisibleNative(boolean aVisible);
     private native void runCallbackNative(long aCallback);

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -5,13 +5,13 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.StrictMode;
-import androidx.preference.PreferenceManager;
 import android.util.Log;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.preference.PreferenceManager;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -111,6 +111,7 @@ public class SettingsStore {
     public final static boolean CENTER_WINDOWS_DEFAULT = false;
     private final static long CRASH_RESTART_DELTA = 2000;
     public final static boolean AUTOPLAY_ENABLED = false;
+    public final static boolean HEAD_LOCK_DEFAULT = false;
     public final static boolean DEBUG_LOGGING_DEFAULT = BuildConfig.DEBUG;
     public final static boolean POP_UPS_BLOCKING_DEFAULT = true;
     public final static boolean WEBXR_ENABLED_DEFAULT = true;
@@ -325,6 +326,17 @@ public class SettingsStore {
     public void setStartWithPassthroughEnabled(boolean isEnabled) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putBoolean(mContext.getString(R.string.settings_key_start_with_passthrough), isEnabled);
+        editor.commit();
+    }
+
+    public boolean isHeadLockEnabled() {
+        return mPrefs.getBoolean(
+                mContext.getString(R.string.settings_key_head_lock), shouldStartWithPassthrougEnabled());
+    }
+
+    public void setHeadLockEnabled(boolean isEnabled) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(mContext.getString(R.string.settings_key_head_lock), isEnabled);
         editor.commit();
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -88,6 +88,7 @@ public interface WidgetManagerDelegate {
     void togglePassthrough();
     boolean isPassthroughEnabled();
     boolean isPassthroughSupported();
+    void setHeadLockEnabled(boolean isHeadLockEnabled);
     void recenterUIYaw(@YawTarget int target);
     void setCylinderDensity(float aDensity);
     void setCylinderDensityForce(float aDensity);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -82,6 +82,9 @@ class DisplayOptionsView extends SettingsView {
         mBinding.soundEffectSwitch.setOnCheckedChangeListener(mSoundEffectListener);
         setSoundEffect(SettingsStore.getInstance(getContext()).isAudioEnabled(), true);
 
+        mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
+        setHeadLock(SettingsStore.getInstance(getContext()).isHeadLockEnabled());
+
         mDefaultHomepageUrl = getContext().getString(R.string.HOMEPAGE_URL);
 
         mBinding.homepageEdit.setHint1(getContext().getString(R.string.homepage_hint, getContext().getString(R.string.app_name)));
@@ -159,6 +162,11 @@ class DisplayOptionsView extends SettingsView {
         setSoundEffect(enabled, true);
     };
 
+
+    private SwitchSetting.OnCheckedChangeListener mHeadLockListener = (compoundButton, value, doApply) -> {
+        setHeadLock(value);
+    };
+
     private OnClickListener mHomepageListener = (view) -> {
         if (!mBinding.homepageEdit.getFirstText().isEmpty()) {
             setHomepage(mBinding.homepageEdit.getFirstText());
@@ -219,6 +227,7 @@ class DisplayOptionsView extends SettingsView {
         setHomepage(mDefaultHomepageUrl);
         setAutoplay(SettingsStore.AUTOPLAY_ENABLED, true);
         setCurvedDisplay(false, true);
+        setHeadLock(SettingsStore.HEAD_LOCK_DEFAULT);
         setSoundEffect(SettingsStore.AUDIO_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
 
@@ -270,6 +279,14 @@ class DisplayOptionsView extends SettingsView {
         mBinding.startWithPassthroughSwitch.setOnCheckedChangeListener(mStartWithPassthroughListener);
 
         SettingsStore.getInstance(getContext()).setStartWithPassthroughEnabled(value);
+    }
+
+    private void setHeadLock(boolean value) {
+        mBinding.headLockSwitch.setOnCheckedChangeListener(null);
+        mBinding.headLockSwitch.setValue(value, false);
+        mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
+
+        SettingsStore.getInstance(getContext()).setHeadLockEnabled(value);
     }
 
     private void setSoundEffect(boolean value, boolean doApply) {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -208,6 +208,7 @@ struct BrowserWorld::State {
   bool wasWebXRRendering = false;
   double lastBatteryLevelUpdate = -1.0;
   bool reorientRequested = false;
+  bool inHeadLockMode = false;
   VRLayerPassthroughPtr layerPassthrough;
 #if HVR
   bool wasButtonAppPressed = false;
@@ -1144,6 +1145,10 @@ BrowserWorld::StartFrame() {
     bool relayoutWidgets = false;
     m.UpdateGazeModeState();
     m.UpdateControllers(relayoutWidgets);
+    if (m.inHeadLockMode) {
+      OnReorient();
+      m.device->Reorient();
+    }
     if (m.reorientRequested)
       relayoutWidgets = std::exchange(m.reorientRequested, false);
     if (relayoutWidgets) {
@@ -1216,6 +1221,12 @@ BrowserWorld::TogglePassthrough() {
     // Make environment changes during pass through mode on to take effect
     UpdateEnvironment();
   }
+}
+
+void
+BrowserWorld::SetHeadLockEnabled(const bool isEnabled) {
+  ASSERT_ON_RENDER_THREAD();
+  m.inHeadLockMode = isEnabled;
 }
 
 void
@@ -2043,6 +2054,11 @@ JNI_METHOD(void, setTemporaryFilePath)
 JNI_METHOD(void, togglePassthroughNative)
 (JNIEnv*, jobject) {
   crow::BrowserWorld::Instance().TogglePassthrough();
+}
+
+JNI_METHOD(void, setHeadLockEnabledNative)
+(JNIEnv*, jobject, jboolean isEnabled) {
+  crow::BrowserWorld::Instance().SetHeadLockEnabled(isEnabled);
 }
 
 JNI_METHOD(void, exitImmersiveNative)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -49,6 +49,7 @@ public:
   void EndFrame();
   void TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity);
   void TogglePassthrough();
+  void SetHeadLockEnabled(const bool isEnabled);
   void SetTemporaryFilePath(const std::string& aPath);
   void UpdateEnvironment();
   void UpdatePointerColor();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -67,6 +67,7 @@ public:
   virtual const vrb::Matrix& GetHeadTransform() const = 0;
   virtual const vrb::Matrix& GetReorientTransform() const = 0;
   virtual void SetReorientTransform(const vrb::Matrix& aMatrix) = 0;
+  virtual void Reorient() = 0;
   virtual void SetClearColor(const vrb::Color& aColor) = 0;
   virtual void SetClipPlanes(const float aNear, const float aFar) = 0;
   virtual void SetControllerDelegate(ControllerDelegatePtr& aController) = 0;

--- a/app/src/main/cpp/DeviceUtils.cpp
+++ b/app/src/main/cpp/DeviceUtils.cpp
@@ -16,10 +16,16 @@ std::unordered_map<std::string, device::DeviceType> DeviceUtils::deviceNamesMap;
 
 vrb::Matrix
 DeviceUtils::CalculateReorientationMatrix(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition) {
-  const float kPitchUpThreshold = 0.2f;
-  const float kPitchDownThreshold = 0.5f;
-  const float kRollThreshold = 0.35f;
+  return CalculateReorientationMatrixWithThreshold(aHeadTransform, aHeightPosition, 0.2f, 0.5f, 0.35f);
+}
 
+vrb::Matrix
+DeviceUtils::CalculateReorientationMatrixOnHeadLock(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition) {
+  return CalculateReorientationMatrixWithThreshold(aHeadTransform, aHeightPosition, 0.0f, 0.0f, 0.0f);
+}
+
+vrb::Matrix
+DeviceUtils::CalculateReorientationMatrixWithThreshold(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition, const float kPitchUpThreshold, const float kPitchDownThreshold, const float kRollThreshold) {
   float rx, ry, rz;
   vrb::Quaternion quat(aHeadTransform);
   quat.ToEulerAngles(rx, ry, rz);

--- a/app/src/main/cpp/DeviceUtils.h
+++ b/app/src/main/cpp/DeviceUtils.h
@@ -18,6 +18,7 @@ namespace crow {
 class DeviceUtils {
 public:
   static vrb::Matrix CalculateReorientationMatrix(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition);
+  static vrb::Matrix CalculateReorientationMatrixOnHeadLock(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition);
   static void GetTargetImmersiveSize(const uint32_t aRequestedWidth, const uint32_t  aRequestedHeight,
                                      const uint32_t aRecommendedWidth, const uint32_t aRecommendedHeight,
                                      uint32_t& aTargetWidth, uint32_t& aTargetHeight) {
@@ -32,6 +33,8 @@ public:
   static device::DeviceType GetDeviceTypeFromSystem(bool is6DoF);
 
 private:
+  static vrb::Matrix CalculateReorientationMatrixWithThreshold(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition,
+                                                               const float kPitchUpThreshold, const float kPitchDownThreshold, const float kRollThreshold);
   static std::unordered_map<std::string, device::DeviceType> deviceNamesMap;
   VRB_NO_DEFAULTS(DeviceUtils)
 };

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -122,6 +122,12 @@
                     android:layout_height="wrap_content"
                     app:description="@string/developer_options_center_windows" />
 
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/headLockSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/display_options_head_lock" />
+
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1778,6 +1778,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="clear_user_data_dialog_title">Borrar %1$s datos de usuario</string>
     <string name="clear_user_data_dialog_text">%1$s se restablecerá. Todos los datos, incluidos los inicios de sesión guardados, el historial y los marcadores, se eliminarán permanentemente si no se han sincronizado. %1$s se cerrará automáticamente una vez finalizado el restablecimiento. ¿Quieres continuar\?</string>
     <string name="display_options_start_with_passthrough">Empezar en modo Passthrough</string>
+    <string name="display_options_head_lock">Fijar la ventana en tu campo visual</string>
     <string name="tray_wifi_unavailable_ssid">SSID no disponible</string>
     <string name="voice_input_start">¿Qué te gustaría decir?</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -429,6 +429,7 @@
     <string name="developer_options_save">Gravar</string>
     <string name="developer_options_msaa_disabled">Desativado</string>
     <string name="settings_accounts_sign_out">Sair</string>
+    <string name="display_options_head_lock">Fixar a janela no seu campo visual</string>
     <string name="display_options_reset">Redefinir configurações de exibição</string>
     <string name="settings_privacy_policy">Política de Privacidade</string>
     <string name="settings_privacy_policy_webxr_description">Os sites a seguir bloqueiam a WebXR API de acessar o seu aparelho RV.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -346,6 +346,9 @@
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">使用音效</string>
+    <!-- This string labels an On/Off switch in the 'Display Options' dialog
+         and is used to customize if head lock should be enabled in the app. -->
+    <string name="display_options_head_lock">头部锁定</string>
     <!-- This string labels an On/Off switch in the developer options dialog
          and is used to customize background environments of the app. -->
     <string name="developer_options_env_override">启用环境覆盖</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -446,6 +446,10 @@
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">使用音效</string>
 
+    <!-- This string labels an On/Off switch in the 'Display Options' dialog
+     and is used to customize if head lock should be enabled in the app. -->
+    <string name="display_options_head_lock">頭部鎖定</string>
+
     <!-- This string labels an On/Off switch in the developer options dialog
          and is used to customize background environments of the app. -->
     <string name="developer_options_env_override">啟用環境覆蓋</string>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -11,6 +11,7 @@
     <string name="settings_key_console_logs" translatable="false">settings_console_logs</string>
     <string name="settings_key_system_root_ca" translatable="false">settings_system_root_ca</string>
     <string name="settings_key_start_with_passthrough" translatable="false">settings_start_with_passthrough</string>
+    <string name="settings_key_head_lock" translatable="false">settings_head_lock</string>
     <string name="settings_key_environment_override" translatable="false">settings_environment_override</string>
     <string name="settings_key_performance_monitor" translatable="false">settings_performance_monitor</string>
     <string name="settings_key_servo" translatable="false">settings_environment_servo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,6 +493,10 @@
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Use Sound Effects</string>
 
+    <!-- This string labels an On/Off switch in the 'Display Options' dialog
+         and is used to customize if head lock should be enabled in the app. -->
+    <string name="display_options_head_lock">Enable Head Lock</string>
+
     <!-- This string labels an On/Off switch in the developer options dialog
          and is used to customize background environments of the app. -->
     <string name="developer_options_env_override">Enable Environment Override</string>

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
@@ -166,6 +166,11 @@ DeviceDelegateNoAPI::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
+DeviceDelegateNoAPI::Reorient() {
+  // Ignore reorient
+}
+
+void
 DeviceDelegateNoAPI::SetClearColor(const vrb::Color& aColor) {
   m.clearColor = aColor;
 }

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.h
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.h
@@ -30,6 +30,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
+  void Reorient() override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -792,6 +792,12 @@ DeviceDelegateOculusVR::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
+DeviceDelegateOculusVR::Reorient() {
+  vrb::Matrix head = GetHeadTransform();
+  m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(head, kAverageHeight);
+}
+
+void
 DeviceDelegateOculusVR::SetClearColor(const vrb::Color& aColor) {
   m.clearColor = aColor;
 }

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -34,6 +34,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
+  void Reorient() override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -820,6 +820,12 @@ DeviceDelegateOpenXR::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
+DeviceDelegateOpenXR::Reorient() {
+  vrb::Matrix head = GetHeadTransform();
+  m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(head, kAverageHeight);
+}
+
+void
 DeviceDelegateOpenXR::SetClearColor(const vrb::Color& aColor) {
   m.clearColor = aColor;
 }

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -34,6 +34,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
+  void Reorient() override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -168,6 +168,11 @@ DeviceDelegateVisionGlass::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
+DeviceDelegateVisionGlass::Reorient() {
+  // Ignore reorient
+}
+
+void
 DeviceDelegateVisionGlass::SetClearColor(const vrb::Color& aColor) {
   m.clearColor = aColor;
 }

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
@@ -30,6 +30,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
+  void Reorient() override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -657,6 +657,12 @@ DeviceDelegateWaveVR::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
+DeviceDelegateWaveVR::Reorient() {
+  vrb::Matrix head = GetHeadTransform();
+  m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(head, kAverageHeight);
+}
+
+void
 DeviceDelegateWaveVR::SetClearColor(const vrb::Color& aColor) {
   m.clearColor = aColor;
 }

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
@@ -26,6 +26,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
+  void Reorient() override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;


### PR DESCRIPTION
When head lock is enabled, the browser window remains in the center of your vision.

This functionality can be enabled in the Display section in the Settings.

According to user feedback, this can be useful for watching video while not in an upright position.

It will also be useful for devices with a very narrow field of view.

This can also help mitigate issue #927, where users can temporarily enable the mode to rotate the window, so they can continue watching it easily when laying down, which can be a good help with #1050

Based on work by Songlin Jiang <sjiang@igalia.com>

See also issue https://github.com/Igalia/wolvic/pull/1111