### PR TITLE
Fix SnapdragonSpaces build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repo is only available to Igalia members. If you have access to the relevan
  - `third_party/wavesdk/` for Vive (should contain a `build` folder, among other things)
  - `third_party/picoxr` [Pico OpenXR Mobile SDK](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11) (should contain `include` and `libs` folders, among other things that are not necessary for Wolvic)
  - `third_party/lynx` [for Lynx](https://portal.lynx-r.com)(should contain a `loader-release.aar` file)
- - `third_party/snapdragon-spaces` [for Snapdragon Spaces](https://spaces.qualcomm.com/)(should contain `libopenxr_loader.aar` and `qxrclients.aar` files)
+ - `third_party/spaces` [for Snapdragon Spaces](https://spaces.qualcomm.com/)(should contain `libopenxr_loader.aar`)
  - `third_party/OpenXR-SDK/` [OpenXR-SDK](https://github.com/KhronosGroup/OpenXR-SDK) (should contain an `include` folder)
  - `third_party/aliceimu/` for [Huawei Vision Glass](https://consumer.huawei.com/cn/wearables/vision-glass/) (should contain an `.aar` file with the IMU library for the glasses)
 


### PR DESCRIPTION
It was mentioning that the OpenXR loader should be placed under third_party/snapdragon-spaces but the actual dir that gradle is expecting is third_party/spaces.

Also qxrclients.aar is not needed so let's remove that from the documentation as well.

Fixes #1122