### PR TITLE
Revert "Enable showing all build warning"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,6 @@ buildscript {
 
 allprojects {
     addRepos(repositories)
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-        }
-    }
 }
 
 task clean(type: Delete) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,3 @@ android.injected.testOnly=false
 
 android.useAndroidX=true
 android.enableJetifier=true
-
-org.gradle.warning.mode=all


### PR DESCRIPTION
They make it really hard to find errors in the build when they happen

This reverts commit b0d5864bf269129d5dec187de30fad3f5823c338.