### PR TITLE
[ML2] Disable Hardware Acceleration for rendering UI widgets

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -370,7 +370,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     protected void initializeWidgets() {
-        UISurfaceTextureRenderer.setUseHardwareAcceleration(SettingsStore.getInstance(getBaseContext()).isUIHardwareAccelerationEnabled());
         UISurfaceTextureRenderer.setRenderActive(true);
 
         // Empty widget just for handling focus on empty space
@@ -1397,10 +1396,15 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         return SettingsStore.getInstance(this).getPointerColor();
     }
 
+    private void setUseHardwareAcceleration() {
+        UISurfaceTextureRenderer.setUseHardwareAcceleration(SettingsStore.getInstance(getBaseContext()).isUIHardwareAccelerationEnabled());
+    }
+
     @Keep
     @SuppressWarnings("unused")
     private void setDeviceType(int aType) {
         DeviceType.setType(aType);
+        setUseHardwareAcceleration();
     }
 
     @Keep

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -77,6 +77,7 @@ public class SettingsStore {
     public final static boolean SYSTEM_ROOT_CA_DEFAULT = false;
     public final static boolean UI_HARDWARE_ACCELERATION_DEFAULT = true;
     public final static boolean UI_HARDWARE_ACCELERATION_DEFAULT_WAVEVR = false;
+    public final static boolean UI_HARDWARE_ACCELERATION_DEFAULT_MAGIC_LEAP_2 = false;
     public final static boolean PERFORMANCE_MONITOR_DEFAULT = true;
     public final static boolean DRM_PLAYBACK_DEFAULT = false;
     public final static int TRACKING_DEFAULT = WContentBlocking.EtpLevel.DEFAULT;
@@ -369,6 +370,10 @@ public class SettingsStore {
         boolean defaultValue = UI_HARDWARE_ACCELERATION_DEFAULT;
         if (DeviceType.isWaveBuild()) {
             defaultValue = UI_HARDWARE_ACCELERATION_DEFAULT_WAVEVR;
+        } else if (DeviceType.getType() == DeviceType.MagicLeap2) {
+            // Hardware acceleration causes several UI glitches when rendering widgets and
+            // also locks un the UI thread for several seconds.
+            defaultValue = UI_HARDWARE_ACCELERATION_DEFAULT_MAGIC_LEAP_2;
         }
         return mPrefs.getBoolean(
                 mContext.getString(R.string.settings_key_ui_hardware_acceleration), defaultValue);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
@@ -18,6 +18,7 @@ import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.OptionsDeveloperBinding;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+import com.igalia.wolvic.utils.DeviceType;
 
 class DeveloperOptionsView extends SettingsView {
 
@@ -160,6 +161,7 @@ class DeveloperOptionsView extends SettingsView {
         mBinding.hardwareAccelerationSwitch.setOnCheckedChangeListener(null);
         mBinding.hardwareAccelerationSwitch.setValue(value, false);
         mBinding.hardwareAccelerationSwitch.setOnCheckedChangeListener(mUIHardwareAccelerationListener);
+        mBinding.hardwareAccelerationSwitch.setVisibility(DeviceType.getType() == DeviceType.MagicLeap2 ? View.GONE : View.VISIBLE);
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setUIHardwareAccelerationEnabled(value);


### PR DESCRIPTION
When hardware acceleration is used when rendering UI widgets in the Magic Leap 2 devices several things go wrong:
* The app vanishes for 3-4 seconds waiting for a dequeueBuffer() call to complete
* Several widgets are not updated although they are still working

That's why we're disabling hardware acceleration in the MagicLeap2 device until those issues are fixed in the platform. Apart from that we hide the "enable hw acceleration" switch in developer options.