### PR TITLE
Set default density to 1.25

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,7 @@ android {
         buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "false"
         buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "false"
-        buildConfigField "Float", "DEFAULT_DENSITY", "1.5f"
+        buildConfigField "Float", "DEFAULT_DENSITY", "1.25f"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         resValue 'string', 'HOMEPAGE_URL', "https://wolvic.com/start"
         externalNativeBuild {


### PR DESCRIPTION
Lower the default density to avoid ugly visual artifacts.

On Pico and Quest 2, pages and images with very thin lines cause distortions and Moiré patterns when the density is too high. Lowering the density eliminates these effects.