### PR TITLE
Do not let headlock update the position of the window while resizing

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -504,7 +504,6 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
 
     if (controller.focused && (!hitWidget || !hitWidget->IsResizing()) && resizingWidget) {
       resizingWidget->HoverExitResize();
-      resizingWidget.reset();
     }
 
     if (controller.pointer) {
@@ -1148,7 +1147,7 @@ BrowserWorld::StartFrame() {
     bool relayoutWidgets = false;
     m.UpdateGazeModeState();
     m.UpdateControllers(relayoutWidgets);
-    if (m.inHeadLockMode) {
+    if (m.inHeadLockMode && !(m.resizingWidget && m.resizingWidget->IsResizing())) {
       OnReorient();
       m.device->Reorient();
     }
@@ -1504,7 +1503,7 @@ BrowserWorld::UpdateVisibleWidgets() {
   });
 
   for (const WidgetPtr& widget: widgets) {
-    if (widget->IsVisible() && !widget->IsResizing()) {
+    if (widget->IsVisible()) {
       UpdateWidget(widget->GetHandle(), widget->GetPlacement());
     }
   }


### PR DESCRIPTION
UpdateVisibleWidgets() also update resizing ones
Avoid this:
![com oculus vrshell-20231211-112233](https://github.com/Igalia/wolvic/assets/43995067/6bccb74a-a064-4ec2-b2df-1198cb0c58e8)

Not reset resizingWidget when the widget is out of focus.

This should not happen:
![com oculus metacam-20231211-004842](https://github.com/Igalia/wolvic/assets/43995067/f41dc245-b769-40f2-b9ba-0db2048c7bdd)
