### PR TITLE
[NoAPI] Remove assert for unknown devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -296,7 +296,7 @@ android {
             dimension "platform"
             externalNativeBuild {
                 cmake {
-                    cppFlags " -DVRBROWSER_NO_VR_API"
+                    cppFlags " -DNOAPI"
                     arguments "-DNOAPI=ON"
                 }
             }

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -268,8 +268,9 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
     case device::UnknownType:
     default:
       result = mozilla::gfx::VRControllerType::_empty;
+#ifndef NOAPI
       assert(!"Unknown controller type.");
-      VRB_LOG("Unknown controller type.");
+#endif
       break;
   }
   return  result;


### PR DESCRIPTION
An assert was added to the code that translates from Wolvic device types to the web engine device types in order to quickly identify those devices that were not properly setup in Wolvic.

However that assert is backfiring as it does not allow the NoAPI flavour to launch WebXR experiences because the device is very likely to be unknown (since it's meant to be run in any android device like phones).