### PR TITLE
Add shrinkResources to the release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,6 +170,7 @@ android {
     buildTypes {
         release {
             minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig getUseDebugSigningOnRelease() ? debug.signingConfig : release.signingConfig
             buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props.json"'


### PR DESCRIPTION
This will instruct Gradle plugin to try to shrink the resources included in the package so the size of the APK is smaller.