### PR TITLE
Lower the maximum display DPI to 300

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -97,7 +97,7 @@ public class SettingsStore {
     public final static int DISPLAY_DPI_BASE = 128;
     public final static int DISPLAY_DPI_DEFAULT = (int) (DISPLAY_DENSITY_DEFAULT * DISPLAY_DPI_BASE);
     public final static int DISPLAY_DPI_MIN = 70;
-    public final static int DISPLAY_DPI_MAX = 400;
+    public final static int DISPLAY_DPI_MAX = 300;
     // World size: multiply by density to get the available resolution for the Web engine.
     public final static int WINDOW_WIDTH_DEFAULT = 800;
     public final static int WINDOW_HEIGHT_DEFAULT = 450;


### PR DESCRIPTION
Resolves #1164

Although display DPI 400 works on my device (Meta Quest 2) without any freeze, let's still lower it down to 300 so that it can be safe for all.