### PR TITLE
[VisionGlass] Render Wolvic in glasses and control UI on phone screen

### DIFF
--- a/app/src/main/res/layout/visionglass_layout.xml
+++ b/app/src/main/res/layout/visionglass_layout.xml
@@ -1,26 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.opengl.GLSurfaceView
-        android:id="@+id/gl_view"
+    <View
+        android:id="@+id/touchpad"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:background="#333333" />
 
-    <TextView
-        android:id="@+id/frame_rate_text"
+    <Button
+        android:id="@+id/back_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:background="#000000"
-        app:layout_constraintStart_toStartOf="@+id/gl_view"
-        app:layout_constraintTop_toTopOf="@+id/gl_view" />
+        android:text="@string/back_button"
+        android:drawableStart="@drawable/ic_icon_back"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentStart="true" />
 
+    <Button
+        android:id="@+id/home_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/home_tooltip"
+        android:drawableStart="@drawable/ic_icon_home"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true"
+        android:visibility="gone"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/visionglass_presentation_layout.xml
+++ b/app/src/main/res/layout/visionglass_presentation_layout.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.opengl.GLSurfaceView
+        android:id="@+id/gl_presentation_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/visionglass/AndroidManifest.xml
+++ b/app/src/visionglass/AndroidManifest.xml
@@ -7,8 +7,7 @@
 
     <application>
         <activity
-            android:name=".VRBrowserActivity"
-            android:screenOrientation="landscape">
+            android:name=".VRBrowserActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
@@ -50,6 +50,7 @@ public:
   void TouchEvent(const bool aDown, const float aX, const float aY);
   void ControllerButtonPressed(const bool aDown);
   void setHead(const float aX, const float aY, const float aZ, const float aW);
+  void setControllerOrientation(const float aX, const float aY, const float aZ, const float aW);
 protected:
   struct State;
   DeviceDelegateVisionGlass(State& aState);

--- a/app/src/visionglass/cpp/native-lib.cpp
+++ b/app/src/visionglass/cpp/native-lib.cpp
@@ -85,12 +85,23 @@ JNI_METHOD(void, drawGL)
 
 JNI_METHOD(void, touchEvent)
 (JNIEnv*, jobject, jboolean aDown, jfloat aX, jfloat aY) {
-    sAppContext->mDevice->TouchEvent(aDown, aX, aY);
+    sAppContext->mDevice->ControllerButtonPressed(aDown);
 }
 
 JNI_METHOD(void, setHead)
 (JNIEnv*, jobject, jdouble aX, jdouble aY, jdouble aZ, jdouble aW) {
+    if (!sAppContext || !sAppContext->mDevice) {
+        return;
+    }
     sAppContext->mDevice->setHead(aX, aY, aZ, aW);
+}
+
+JNI_METHOD(void, setControllerOrientation)
+(JNIEnv*, jobject, jdouble aX, jdouble aY, jdouble aZ, jdouble aW) {
+    if (!sAppContext || !sAppContext->mDevice) {
+        return;
+    }
+    sAppContext->mDevice->setControllerOrientation(aX, aY, aZ, aW);
 }
 
 jint JNI_OnLoad(JavaVM* aVm, void*) {


### PR DESCRIPTION
This is a large change because it's difficult to split it in smaller chunks as we're revamping the way Wolvic works in the VisionGlass. In general this is not a good idea but provided that we're in early stages of VisionGlass port this should be fine as there should not be regressions as the previous funtionality was quite limited.

These are the main changes:
   * Wolvic is now rendered just in the external screen (the glasses) using Android's Presentation API.
   * The phone screen shows a different UI which consists on a quite minimalistic and simple UI that allows users to performs clicks on a touchpad and also a "back" button.

Apart from that there are some other changes:
   * Fix a crash with early setControllerOrientation call
   * Enable WebXR by properly setting EyeResolution
   * Enable clicks on WebXR experiences
   * Use the actual FOV of the device
   * Improved the "wait for USB permissions" code