### PR TITLE
Launch immersive experiences directly

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
@@ -58,7 +58,7 @@ public class VRBrowserApplication extends Application implements AppServicesProv
         mConnectivityManager.init();
         mPlaces = new Places(activityContext);
         mServices = new Services(activityContext, mPlaces);
-        mLoginStorage = new LoginStorage(this);
+        mLoginStorage = new LoginStorage(activityContext);
         mAccounts = new Accounts(activityContext);
         mSessionStore = SessionStore.get();
         mSessionStore.initialize(activityContext);

--- a/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/LoginStorage.kt
@@ -16,7 +16,7 @@ class LoginStorage(
         val context: Context
 ) {
 
-    private val places = (context as AppServicesProvider).places
+    private val places = (context.applicationContext as AppServicesProvider).places
     private var storage = places.logins
     private val passwordsKeyProvider by lazy { storage.value.crypto }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/PermissionDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/PermissionDelegate.java
@@ -221,7 +221,8 @@ public class PermissionDelegate implements WSession.PermissionDelegate, WidgetMa
             // https://hacks.mozilla.org/2019/02/firefox-66-to-block-automatically-playing-audible-video-and-audio/
             return WResult.fromValue(ContentPermission.VALUE_ALLOW);
         } else if(perm.permission == PERMISSION_AUTOPLAY_AUDIBLE) {
-            if (SettingsStore.getInstance(mContext).isAutoplayEnabled()) {
+            // allow autoplay when we launch Wolvic in immersive mode automatically
+            if (SettingsStore.getInstance(mContext).isAutoplayEnabled() || mWidgetManager.isLaunchImmersive()) {
                 return WResult.fromValue(ContentPermission.VALUE_ALLOW);
             } else {
                 return WResult.fromValue(ContentPermission.VALUE_DENY);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -121,6 +121,7 @@ public interface WidgetManagerDelegate {
     boolean isWebXRIntersitialHidden();
     boolean isWebXRPresenting();
     boolean isPermissionGranted(@NonNull String permission);
+    boolean isLaunchImmersive();
     void requestPermission(String originator, @NonNull String permission, OriginatorType originatorType, WSession.PermissionDelegate.Callback aCallback);
     boolean canOpenNewWindow();
     void openNewWindow(String uri);

--- a/app/src/main/assets/extensions/wolvic_launchimmersive/content.js
+++ b/app/src/main/assets/extensions/wolvic_launchimmersive/content.js
@@ -1,0 +1,152 @@
+const LOGTAG = '[wolvic:launchimmersive]';
+const ENABLE_LOGS = true;
+const logDebug = (...args) => ENABLE_LOGS && console.log(LOGTAG, ...args);
+
+const PARENT_ELEMENT_XPATH_PARAMETER = 'wolvic-launchimmersive-parentElementXPath';
+const TARGET_ELEMENT_XPATH_PARAMETER = 'wolvic-launchimmersive-targetElementXPath';
+
+const IFRAME_READY_MSG = 'wolvic-launchimmersive-iframeReady';
+const TARGET_ELEMENT_MSG = 'wolvic-launchimmersive-targetElement';
+
+var parentElementXPath;
+var targetElementXPath;
+
+function getElementByXPath(document, xpath) {
+    let result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+    return result.singleNodeValue;
+}
+
+// Limit the number of times that we can try to launch the experience, to avoid an infinite loop.
+var retryCounter = 0;
+const RETRY_LIMIT = 20;
+function retryAfterTimeout(code, delay) {
+    if (retryCounter < RETRY_LIMIT) {
+        retryCounter++;
+        setTimeout(code, delay);
+    } else {
+        logDebug('Retry limit reached, will not try again');
+    }
+}
+
+function clickImmersiveElement() {
+    // Check if the current URL has extra query parameters
+    parentElementXPath = undefined;
+    targetElementXPath = undefined;
+
+    let url = document.URL;
+    let params = new URLSearchParams(new URL(url).search);
+    for (let [key, value] of params) {
+        if (key === PARENT_ELEMENT_XPATH_PARAMETER)
+            parentElementXPath = value;
+        else if (key === TARGET_ELEMENT_XPATH_PARAMETER)
+            targetElementXPath = value;
+    }
+
+    // We need at least the target element to click
+    if (!targetElementXPath)
+        return;
+
+    logDebug('Preparing to open immersive WebXR; parentElementXPath: ' + parentElementXPath + ' ; targetElementXPath: ' + targetElementXPath);
+
+    // The parent element is typically an iframe and, if it comes from a different origin,
+    // we might not be able to access its contents directly.
+    // If parentElementXPath is null, we will use the root to find the target element.
+
+    var parent, parentDocument;
+    if (parentElementXPath) {
+        parent = getElementByXPath(document, parentElementXPath);
+        if (!parent) {
+            logDebug('Parent element not found, retrying');
+            retryAfterTimeout(clickImmersiveElement, 1000);
+            return;
+        }
+
+        try {
+            parentDocument = parent.contentDocument || parent.contentWindow.document;
+        } catch (e) {
+            logDebug('Parent iframe is from a different origin');
+            const iframeWindow = parent.contentWindow;
+
+            const targetElementMsg = {
+                action: TARGET_ELEMENT_MSG,
+                targetElementXPath: targetElementXPath
+            };
+
+            iframeWindow.postMessage(targetElementMsg, '*');
+
+            // The iframe might not be ready yet, so we set up a listener for the "iframe ready" message.
+            const handleIframeReady = (event) => {
+                if (event.source === iframeWindow && event.data === IFRAME_READY_MSG) {
+                    window.removeEventListener('message', handleIframeReady);
+                    iframeWindow.postMessage(targetElementMsg, '*');
+                }
+            };
+            window.addEventListener('message', handleIframeReady);
+
+            return;
+        }
+    } else {
+        parent = window;
+        parentDocument = document;
+    }
+
+    if (parentDocument.readyState !== 'complete') {
+        logDebug('Parent is still loading');
+        parent.addEventListener('load', function() {
+            logDebug('Parent has finished loading');
+            clickImmersiveElement();
+        });
+        return;
+    } else {
+        logDebug('Parent is loaded');
+    }
+
+    let targetElement = getElementByXPath(parentDocument, targetElementXPath);
+
+    if (targetElement) {
+        logDebug('Target element found, calling click()');
+        targetElement.click();
+    } else {
+        logDebug('Target element not found, we will try again');
+        retryAfterTimeout(clickImmersiveElement, 1000);
+    }
+}
+
+function launchImmersiveFromIframe() {
+    window.addEventListener('message', function(event) {
+        if (event.data.action === TARGET_ELEMENT_MSG) {
+            let targetElement = getElementByXPath(document, event.data.targetElementXPath);
+
+            if (targetElement) {
+                logDebug('Target element found in iframe, calling click()');
+                targetElement.click();
+            } else {
+                logDebug('Target element not found in iframe, retrying');
+                retryAfterTimeout(function() {
+                    window.postMessage(event.data, '*');
+                }, 1000);
+            }
+        }
+    });
+
+    window.parent.postMessage(IFRAME_READY_MSG, '*');
+}
+
+// Main script execution
+if (window.top === window.self) {
+    if (document.readyState === 'complete') {
+        logDebug('Root document is completely ready');
+        clickImmersiveElement();
+    } else {
+        logDebug('Root document is not ready yet');
+        window.addEventListener('load', clickImmersiveElement);
+    }
+} else {
+    if (document.readyState === 'complete') {
+        logDebug('Iframe is completely ready');
+        launchImmersiveFromIframe();
+    } else {
+        logDebug('Iframe is not ready yet');
+        window.addEventListener('load', launchImmersiveFromIframe);
+    }
+}

--- a/app/src/main/assets/extensions/wolvic_launchimmersive/manifest.json
+++ b/app/src/main/assets/extensions/wolvic_launchimmersive/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 2,
+  "name": "Wolvic Launch Immersive",
+  "version": "1.0",
+  "description": "Launch Immersive Experiences Automatically",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "wolvic-launchimmersive@igalia.com"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_idle",
+      "all_frames": true
+    }
+  ]
+}


### PR DESCRIPTION
This PR implements support for opening immersive experiences directly as soon as the application is launched.

We do this by adding a built-in extension which will activate a particular element in the page.

We need to set the preference `dom.vr.require-gesture` to false so this script can launch immersive WebXR experiences without user input. Media autoplay also need to be allowed in this mode.

The information required to identify the element to activate is passed as parameters to the Intent:

- `launch_immersive`
- `launch_immersive_parent_xpath`
- `launch_immersive_element_xpath`
- a target URL to open

One additional concern is that we should only change the configuration prefs when that is needed for launching Wolvic directly in immersive mode.

The problem is that we only write that prefs file the first time that we create the browser engine, which happens several times at launch time **before** we have parsed the incoming Intent and we can know in which mode we are launching.

The solution is that `WidgetManagerDelegate.isOpenInImmersive()` internally will check the current Intent, to cover the case where it is being called too early.

We then pass `VRBrowserActivity` as the context to the objects that may initialize the engine, so eventually `SessionUtils.prepareConfigurationPath()` is able to decide whether specific prefs should be added to the configuration file.

For launching Wolvic directly in immersive mode, these prefs are:

```
  dom.vr.require-gesture: false
  media.autoplay.default: 0
```