### PR TITLE
[VisionGlass] Use 3D operation mode & set a default height

### DIFF
--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -217,18 +217,12 @@ DeviceDelegateVisionGlass::ProcessEvents() {}
 void
 DeviceDelegateVisionGlass::StartFrame(const FramePrediction aPrediction) {
   VRB_GL_CHECK(glClearColor(m.clearColor.Red(), m.clearColor.Green(), m.clearColor.Blue(), m.clearColor.Alpha()));
-  VRB_GL_CHECK(glEnable(GL_DEPTH_TEST));
-  VRB_GL_CHECK(glEnable(GL_CULL_FACE));
-  VRB_GL_CHECK(glEnable(GL_BLEND));
   VRB_GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
   mShouldRender = true;
 
-  const float IPD = 0.064f;
   auto headTransform = m.headingMatrix.Translate(kAverageHeight);
   m.cameras[0]->SetHeadTransform(headTransform);
   m.cameras[1]->SetHeadTransform(headTransform);
-  m.cameras[0]->SetEyeTransform(vrb::Matrix::Translation(vrb::Vector(-IPD * 0.5f, 0.f, 0.f)));
-  m.cameras[1]->SetEyeTransform(vrb::Matrix::Translation(vrb::Vector(IPD * 0.5f, 0.f, 0.f)));
   m.immersiveDisplay->SetEyeTransform(device::Eye::Left, m.cameras[0]->GetEyeTransform());
   m.immersiveDisplay->SetEyeTransform(device::Eye::Right, m.cameras[1]->GetEyeTransform());
   m.immersiveDisplay->SetSittingToStandingTransform(vrb::Matrix::Translation(kAverageHeight));
@@ -249,7 +243,7 @@ DeviceDelegateVisionGlass::StartFrame(const FramePrediction aPrediction) {
 
 void
 DeviceDelegateVisionGlass::BindEye(const device::Eye aEye) {
-  // noop
+  VRB_GL_CHECK(glViewport(aEye == device::Eye::Left ? 0 : m.glWidth / 2, 0, m.glWidth / 2, m.glHeight));
 }
 
 void

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -128,13 +128,13 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         } while (!wasImuStarted);
 
 
-        VisionGlass.getInstance().setDisplayMode(DisplayMode.vr2d, new DisplayModeCallback() {
+        VisionGlass.getInstance().setDisplayMode(DisplayMode.vr3d, new DisplayModeCallback() {
             @Override
-            public void onSuccess(DisplayMode displayMode) { Log.d(LOGTAG, "Successfully switched to 2D mode"); }
+            public void onSuccess(DisplayMode displayMode) { Log.d(LOGTAG, "Successfully switched to 3D mode"); }
 
             @Override
             public void onError(String s, int i) {
-                Log.d(LOGTAG, "Error " + i + " failed to switch to 2D mode " + s);
+                Log.d(LOGTAG, "Error " + i + " failed to switch to 3D mode " + s);
             }
         });
 


### PR DESCRIPTION
This PR includes two changes:
1. Set the height of the glasses and the controller to some good default values so that we don't enter experiences at the floor level.
2. Use the glasses 3D operation mode. For that we need to generate the left eye image in the left half of the viewport and the right eye image in the right side of the viewport 