### PR TITLE
Clean composing text when resetting the keyboard layout

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -455,6 +455,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             mKeyboardView.setKeyboard(mCurrentKeyboard.getAlphabeticKeyboard());
         }
         handleShift(false);
+        cleanComposingText();
         updateCandidates();
     }
 


### PR DESCRIPTION
#1104 enabled word autocompletion in latin keyboard. However it also caused regressions like the following. Whenever there are multiple text entries in a webpage, switching between them does not clear the text used for autocompletion (the composing text) on time, meaning that the content of the newly focused entry is filled in with the text coming from the previously focused entry.

A way to fix that is by clearing the composing text whenever resetKeyboardLayout is called.

Fixes #1177