### PR TITLE
Don't use the "desktop" viewport mode

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1008,11 +1008,6 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         }
         mState.mSettings.setUserAgentMode(mode);
         mState.mSession.getSettings().setUserAgentMode(mode);
-        if (mode == WSessionSettings.USER_AGENT_MODE_DESKTOP) {
-            mState.mSettings.setViewportMode(WSessionSettings.VIEWPORT_MODE_DESKTOP);
-        } else {
-            mState.mSettings.setViewportMode(WSessionSettings.VIEWPORT_MODE_MOBILE);
-        }
         mState.mSession.getSettings().setViewportMode(mState.mSettings.getViewportMode());
         return true;
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionSettings.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionSettings.java
@@ -110,8 +110,7 @@ class SessionSettings {
 
         public Builder withDefaultSettings(Context context) {
             int ua = SettingsStore.getInstance(context).getUaMode();
-            int viewport = ua == WSessionSettings.USER_AGENT_MODE_DESKTOP ?
-                    WSessionSettings.VIEWPORT_MODE_DESKTOP : WSessionSettings.VIEWPORT_MODE_MOBILE;
+            int viewport = WSessionSettings.VIEWPORT_MODE_MOBILE;
 
             TrackingProtectionPolicy policy = TrackingProtectionStore.getTrackingProtectionPolicy(context);
             return new SessionSettings.Builder()


### PR DESCRIPTION
In the "desktop" viewport mode, the Web engine renders pages inside a special fixed-width viewport which is 980 CSS px wide.

Pages rendered on the "desktop" viewport mode keep their fixed width when the containing window becomes larger, which is not very useful.

Furthermore, since we increased the screen density used by Wolvic, this fixed width is actually smaller than our current default.

For these reasons, this PR removes usages of the "desktop" viewport mode.

Note that "desktop mode" will still exist, but it will only affect the User-Agent and not the viewport configuration.