### PR TITLE
Reset windows position when user tries to reorient via controllers

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1392,6 +1392,15 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Keep
     @SuppressWarnings("unused")
+    public void resetWindowsPosition() {
+        // Reset the position of the windows when we are not in headlock and window movement is enabled.
+        if (!mSettings.isHeadLockEnabled() && mSettings.isWindowMovementEnabled()) {
+            runOnUiThread(() -> mWindows.resetWindowsPosition());
+        }
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
     public boolean areLayersEnabled() {
         return SettingsStore.getInstance(this).getLayersEnabled();
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -1058,6 +1058,14 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         }
     }
 
+    public void resetWindowsPosition() {
+        WindowWidget frontWindow = getFrontWindow();
+        if (frontWindow != null) {
+            placeWindow(frontWindow, WindowPlacement.FRONT);
+        }
+        updateViews();
+    }
+
     private final SharedPreferences.OnSharedPreferenceChangeListener mPreferencesListener =
             new SharedPreferences.OnSharedPreferenceChangeListener() {
                 @Override
@@ -1065,13 +1073,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                     WindowWidget frontWindow = getFrontWindow();
 
                     if (Objects.equals(key, mContext.getString(R.string.settings_key_window_movement))) {
-                        boolean isWindowMovementEnabled = sharedPreferences.getBoolean(key, SettingsStore.WINDOW_MOVEMENT_DEFAULT);
-
                         // Reset the position of the windows when the setting becomes disabled.
-                        if (frontWindow != null && !isWindowMovementEnabled) {
-                            placeWindow(frontWindow, WindowPlacement.FRONT);
+                        if (!sharedPreferences.getBoolean(key, SettingsStore.WINDOW_MOVEMENT_DEFAULT)) {
+                            resetWindowsPosition();
                         }
-                        updateViews();
                     }
 
                     if (!Objects.equals(key, mContext.getString(R.string.settings_key_window_distance)))

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1973,6 +1973,7 @@ BrowserWorld::CreateSkyBox(const std::string& aBasePath, const std::string& aExt
 
 void BrowserWorld::OnReorient() {
   m.reorientRequested = true;
+  VRBrowser::ResetWindowsPosition();
 }
 
 } // namespace crow

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -48,6 +48,8 @@ const char* const kIsOverrideEnvPathEnabledName = "isOverrideEnvPathEnabled";
 const char* const kIsOverrideEnvPathEnabledSignature = "()Z";
 const char* const kCheckTogglePassthrough = "checkTogglePassthrough";
 const char* const kCheckTogglePassthroughSignature = "()V";
+const char* const kResetWindowsPosition = "resetWindowsPosition";
+const char* const kResetWindowsPositionSignature = "()V";
 const char* const kGetActiveEnvironment = "getActiveEnvironment";
 const char* const kGetActiveEnvironmentSignature = "()Ljava/lang/String;";
 const char* const kGetPointerColor = "getPointerColor";
@@ -93,6 +95,7 @@ jmethodID sRenderPointerLayer = nullptr;
 jmethodID sGetStorageAbsolutePath = nullptr;
 jmethodID sIsOverrideEnvPathEnabled = nullptr;
 jmethodID sCheckTogglePassthrough = nullptr;
+jmethodID sResetWindowsPosition = nullptr;
 jmethodID sGetActiveEnvironment = nullptr;
 jmethodID sGetPointerColor = nullptr;
 jmethodID sAreLayersEnabled = nullptr;
@@ -142,6 +145,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sGetStorageAbsolutePath = FindJNIMethodID(sEnv, sBrowserClass, kGetStorageAbsolutePathName, kGetStorageAbsolutePathSignature);
   sIsOverrideEnvPathEnabled = FindJNIMethodID(sEnv, sBrowserClass, kIsOverrideEnvPathEnabledName, kIsOverrideEnvPathEnabledSignature);
   sCheckTogglePassthrough = FindJNIMethodID(sEnv, sBrowserClass, kCheckTogglePassthrough, kCheckTogglePassthroughSignature);
+  sResetWindowsPosition = FindJNIMethodID(sEnv, sBrowserClass, kResetWindowsPosition, kResetWindowsPositionSignature);
   sGetActiveEnvironment = FindJNIMethodID(sEnv, sBrowserClass, kGetActiveEnvironment, kGetActiveEnvironmentSignature);
   sGetPointerColor = FindJNIMethodID(sEnv, sBrowserClass, kGetPointerColor, kGetPointerColorSignature);
   sAreLayersEnabled = FindJNIMethodID(sEnv, sBrowserClass, kAreLayersEnabled, kAreLayersEnabledSignature);
@@ -192,6 +196,7 @@ VRBrowser::ShutdownJava() {
   sGetStorageAbsolutePath = nullptr;
   sIsOverrideEnvPathEnabled = nullptr;
   sCheckTogglePassthrough = nullptr;
+  sResetWindowsPosition = nullptr;
   sGetActiveEnvironment = nullptr;
   sGetPointerColor = nullptr;
   sAreLayersEnabled = nullptr;
@@ -360,6 +365,13 @@ void
 VRBrowser::CheckTogglePassthrough() {
   if (!ValidateMethodID(sEnv, sActivity, sCheckTogglePassthrough, __FUNCTION__)) { return; }
   sEnv->CallVoidMethod(sActivity, sCheckTogglePassthrough);
+  CheckJNIException(sEnv, __FUNCTION__);
+}
+
+void
+VRBrowser::ResetWindowsPosition() {
+  if (!ValidateMethodID(sEnv, sActivity, sResetWindowsPosition, __FUNCTION__)) { return; }
+  sEnv->CallVoidMethod(sActivity, sResetWindowsPosition);
   CheckJNIException(sEnv, __FUNCTION__);
 }
 

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -38,6 +38,7 @@ void RenderPointerLayer(jobject aSurface, const int32_t color, const std::functi
 std::string GetStorageAbsolutePath(const std::string& aRelativePath);
 bool isOverrideEnvPathEnabled();
 void CheckTogglePassthrough();
+void ResetWindowsPosition();
 std::string GetActiveEnvironment();
 int32_t GetPointerColor();
 bool AreLayersEnabled();


### PR DESCRIPTION
Otherwise, it can be confusing to users if they have moved those windows manually via our `Drag to move windows` feature before reorientation.