### PR TITLE
Properly support vertical videos

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -997,7 +997,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
     }
 
     private void setResizePreset(float aMultiplier) {
-        final float aspect = SettingsStore.getInstance(getContext()).getWindowAspect();
+        final float aspect = (float) mAttachedWindow.getWindowWidth() / (float) mAttachedWindow.getWindowHeight();
         mAttachedWindow.resizeByMultiplier(aspect, aMultiplier);
     }
 
@@ -1307,9 +1307,10 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
     private void startWidgetResize() {
         if (mAttachedWindow != null) {
-            Pair<Float, Float> maxSize = mAttachedWindow.getSizeForScale(mAttachedWindow.getMaxWindowScale());
-            Pair<Float, Float> minSize = mAttachedWindow.getSizeForScale(0.5f);
-            mWidgetManager.startWidgetResize(mAttachedWindow, maxSize.first, 4.5f, minSize.first, minSize.second);
+            final float aspect = (float) mAttachedWindow.getWindowWidth() / (float) mAttachedWindow.getWindowHeight();
+            Pair<Float, Float> maxSize = mAttachedWindow.getSizeForScale(mAttachedWindow.getMaxWindowScale(), aspect);
+            Pair<Float, Float> minSize = mAttachedWindow.getSizeForScale(0.5f, aspect);
+            mWidgetManager.startWidgetResize(mAttachedWindow, maxSize.first, maxSize.second, minSize.first, minSize.second);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1540,29 +1540,35 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public @NonNull Pair<Float, Float> getSizeForScale(float aScale, float aAspect) {
-        final float defaultWorldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
-        final float maxWidthWorld = SettingsStore.MAX_WINDOW_WIDTH_DEFAULT * (defaultWorldWidth/SettingsStore.WINDOW_WIDTH_DEFAULT);
-        float targetWidth;
+        float defaultWorldSize = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+        float maxWorldSize = SettingsStore.MAX_WINDOW_WIDTH_DEFAULT * (defaultWorldSize/SettingsStore.WINDOW_WIDTH_DEFAULT);
+        float targetSize;
+
+        boolean isHorizontal = aAspect >= 1.0;
+        if (!isHorizontal) {
+            defaultWorldSize = defaultWorldSize * aAspect;
+            maxWorldSize = SettingsStore.MAX_WINDOW_HEIGHT_DEFAULT * (defaultWorldSize/SettingsStore.WINDOW_HEIGHT_DEFAULT);
+        }
 
         if (aScale < DEFAULT_SCALE) {
             // Reduce the area of the window according to the desired scale.
-            float worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
-            float worldHeight = worldWidth / aAspect;
-            float targetArea = worldWidth * worldHeight * aScale;
-            targetWidth = (float) Math.sqrt(targetArea * aAspect);
+            float worldSize = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+            float worldOrthogonalSize = isHorizontal ? worldSize / aAspect : worldSize * aAspect;
+            float targetArea = worldSize * worldOrthogonalSize * aScale;
+            targetSize = (float) Math.sqrt(targetArea * aAspect);
         } else if (aScale == DEFAULT_SCALE) {
             // Default window size.
-            targetWidth = defaultWorldWidth;
+            targetSize = defaultWorldSize;
         } else if (aScale >= MAX_SCALE) {
             // Maximum window size.
-            targetWidth = maxWidthWorld;
+            targetSize = maxWorldSize;
         } else {
             // Proportional between the default and maximum sizes.
-            targetWidth = defaultWorldWidth + (maxWidthWorld - defaultWorldWidth) * (aScale - DEFAULT_SCALE) / (MAX_SCALE - DEFAULT_SCALE);
+            targetSize = defaultWorldSize + (maxWorldSize - defaultWorldSize) * (aScale - DEFAULT_SCALE) / (MAX_SCALE - DEFAULT_SCALE);
         }
 
-        float targetHeight = targetWidth / aAspect;
-        return Pair.create(targetWidth, targetHeight);
+        float targetOrthogonalSize = isHorizontal ? targetSize / aAspect : targetSize * aAspect;
+        return isHorizontal ? Pair.create(targetSize, targetOrthogonalSize) : Pair.create(targetOrthogonalSize, targetSize);
     }
 
     private int getWindowWidth(float aWorldWidth) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -22,6 +22,7 @@ import com.igalia.wolvic.browser.Media;
 import com.igalia.wolvic.browser.Services;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.adapter.ComponentsAdapter;
+import com.igalia.wolvic.browser.api.WMediaSession;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.components.WolvicEngineSession;
 import com.igalia.wolvic.browser.engine.Session;
@@ -1325,6 +1326,15 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (mDelegate != null) {
             mDelegate.onWindowVideoAvailabilityChanged(aWindow);
         }
+    }
+
+    @Override
+    public void onMediaFullScreen(@NonNull WMediaSession mediaSession, boolean aFullScreen) {
+        if (!aFullScreen)
+            return;
+
+        assert mFullscreenWindow != null;
+        setFullScreenSize(mFullscreenWindow);
     }
 
     @Override


### PR DESCRIPTION
Popular streaming services host more and more videos in vertical format usually recorded with mobile phones. Wolvic was not properly handling the case of watching them in fullscreen mode. There were 2 reasons for that:
1. The code resizing the window for fullscreen assumed horizontal formats
2. The code handling fullscreen events was not properly retrieving the media information (like size) from the web engine
