### PR TITLE
Cleanup fullscreen code

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -910,6 +910,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mViewModel.setIsInVRVideo(true);
         mWidgetManager.pushBackHandler(mVRVideoBackHandler);
         mProjectionMenu.setSelectedProjection(aProjection);
+        this.setVisible(false);
         // Backup the placement because the same widget is reused in FullScreen & MediaControl menus
         mProjectionMenuPlacement.copyFrom(mProjectionMenu.getPlacement());
 
@@ -985,6 +986,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         closeFloatingMenus();
         mWidgetManager.setControllersVisible(true);
 
+        this.setVisible(!mAttachedWindow.isKioskMode());
         mAttachedWindow.disableVRVideoMode();
         mAttachedWindow.setVisible(true);
         mMediaControlsWidget.setVisible(false);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -772,6 +772,9 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
     }
 
     private void exitFullScreenMode() {
+        mWidgetPlacement = mBeforeFullscreenPlacement;
+        updateWidget();
+
         hideMenu();
         hideAllNotifications();
 
@@ -799,6 +802,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mTrayViewModel.setShouldBeVisible(!mAttachedWindow.isKioskMode());
         closeFloatingMenus();
         mWidgetManager.popWorldBrightness(mBrightnessWidget);
+        mAttachedWindow.centerFrontWindowIfNeeded();
     }
 
     private void enterResizeMode() {
@@ -987,7 +991,6 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mViewModel.setAutoEnteredVRVideo(false);
         AnimationHelper.fadeIn(mBinding.navigationBarFullscreen.fullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
 
-        mAttachedWindow.centerFrontWindowIfNeeded();
         mWidgetManager.setCylinderDensityForce(mSavedCylinderDensity);
         // Reposition UI in front of the user when exiting a VR video.
         mWidgetManager.recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -155,7 +155,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         default void onFocusRequest(@NonNull WindowWidget aWindow) {}
         default void onBorderChanged(@NonNull WindowWidget aWindow) {}
         default void onSessionChanged(@NonNull Session aOldSession, @NonNull Session aSession) {}
-        default void onFullScreen(@NonNull WindowWidget aWindow, boolean aFullScreen) {}
+        default void onContentFullScreen(@NonNull WindowWidget aWindow, boolean aFullScreen) {}
         default void onMediaFullScreen(@NonNull final WMediaSession mediaSession, boolean aFullScreen) {}
         default void onVideoAvailabilityChanged(@NonNull WindowWidget aWindow) {}
         default void onKioskMode(WindowWidget aWindow, boolean isKioskMode) {}
@@ -943,7 +943,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         if (mViewModel.getIsFullscreen().getValue().get() != isFullScreen) {
             mViewModel.setIsFullscreen(isFullScreen);
             for (WindowListener listener: mListeners) {
-                listener.onFullScreen(this, isFullScreen);
+                listener.onContentFullScreen(this, isFullScreen);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -284,7 +284,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         if (mFullscreenWindow != null) {
             mFullscreenWindow.getSession().exitFullScreen();
-            onFullScreen(mFullscreenWindow, false);
+            onContentFullScreen(mFullscreenWindow, false);
         }
 
         WindowWidget frontWindow = getFrontWindow();
@@ -1328,7 +1328,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     @Override
-    public void onFullScreen(@NonNull WindowWidget aWindow, boolean aFullScreen) {
+    public void onContentFullScreen(@NonNull WindowWidget aWindow, boolean aFullScreen) {
         if (aFullScreen) {
             mFullscreenWindow = aWindow;
             aWindow.saveBeforeFullscreenPlacement();


### PR DESCRIPTION
The current code handling fullscreen is a mess and extremelly difficult to follow. We've been adding patches over time to fix special situations and that is making it even more unmaintanable.

The root problem is that there are two different fullscreen events that are not properly handled. On the one hand we have the fullscreen event from the content delegate. That could be triggered by any HTML element that wants to go fullscreen (it does not have to be media). And the other one is the fullscreen event triggered by media. That is triggered after the previous one in the case of media content.

Our code should perfectly handle the case of media fullscreen while still allowing other HTML elements to go fullscreen as well.

This patch tries to address that by:
* splitting the code that performs the content fullscreen and the media (video) fullscreen
* moving all the code related to media fullscreen to the handlers of the media fullscreen event
* moving all the generic code that does window fullscreen to the content fullscreen handlers. We know have enterFullscreenMode and exitFullscreenMode for that.
* removing some handlers in the mAttachedWindow that are now not needed.
* moving the creation of the projection menu to the media fullscreen handlers as it is not required by content fullscreen