### PR TITLE
Fix several issues when playing VR videos

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -913,10 +913,8 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
         // Remember the cylinder density before we enter VR video
         mSavedCylinderDensity = mWidgetManager.getCylinderDensity();
-        // We have to disable curved display temporary if we are playing front facing VR videos
-        if (isFrontFacingVRProjection(aProjection)) {
-            mWidgetManager.setCylinderDensityForce(0.0f);
-        }
+        // Disable curved display temporary
+        mWidgetManager.setCylinderDensityForce(0.0f);
 
         mViewModel.setIsInVRVideo(true);
         mWidgetManager.pushBackHandler(mVRVideoBackHandler);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -109,6 +109,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private final float MAX_SCALE = 3.0f;
 
     private Surface mSurface;
+    private int mSurfaceWidth;
+    private int mSurfaceHeight;
     private int mWidth;
     private int mHeight;
     private int mHandle;
@@ -744,8 +746,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 setWillNotDraw(true);
                 return;
             }
-            mWidth = aWidth;
-            mHeight = aHeight;
+            mSurfaceWidth = aWidth;
+            mSurfaceHeight = aHeight;
+            mWidth = (int) (aWidth / getPlacement().textureScale);
+            mHeight = (int) (aHeight / getPlacement().textureScale);
             mTexture = aTexture;
             aTexture.setDefaultBufferSize(aWidth, aHeight);
             mSurface = new Surface(aTexture);
@@ -759,8 +763,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             super.setSurface(aSurface, aWidth, aHeight, aFirstDrawCallback);
 
         } else {
-            mWidth = aWidth;
-            mHeight = aHeight;
+            mSurfaceWidth = aWidth;
+            mSurfaceHeight = aHeight;
+            mWidth = (int) (aWidth / getPlacement().textureScale);
+            mHeight = (int) (aHeight / getPlacement().textureScale);
             mSurface = aSurface;
             mFirstDrawCallback = aFirstDrawCallback;
             if (mSurface != null) {
@@ -773,7 +779,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     private void callSurfaceChanged() {
         if (mSession != null && mSurface != null) {
-            mSession.surfaceChanged(mSurface, mBorderWidth, mBorderWidth, mWidth - mBorderWidth * 2, mHeight - mBorderWidth * 2);
+            mSession.surfaceChanged(mSurface, mBorderWidth, mBorderWidth, mSurfaceWidth - mBorderWidth * 2, mSurfaceHeight - mBorderWidth * 2);
             mSession.updateLastUse();
         }
     }
@@ -784,8 +790,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             super.resizeSurface(aWidth, aHeight);
         }
 
-        mWidth = aWidth;
-        mHeight = aHeight;
+        mSurfaceWidth = aWidth;
+        mSurfaceHeight = aHeight;
+        mWidth = (int) (aWidth / getPlacement().textureScale);
+        mHeight = (int) (aHeight / getPlacement().textureScale);
         if (mTexture != null) {
             mTexture.setDefaultBufferSize(aWidth, aHeight);
         }


### PR DESCRIPTION
- Disable curved display no matter the kind of VR video
`enterVRVideo` will not be called again even if we switch the projection mode. So, with curved display enabled, things can still go wrong if users enter with a non-front-facing VR projection and then switch to a front-facing one.
- Fix display density when exiting VR video mode
We should also take the texture scale into account to compute the actual width and height for the placement.
Bug (notice the display density change):

https://github.com/Igalia/wolvic/assets/43995067/0ae7e369-3b91-40b8-a66e-f7c1c7e89a6a

