### PR TITLE
Handle URL bar editor commands in the UI thread

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
@@ -6,6 +6,7 @@
 package com.igalia.wolvic.ui.views;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -157,7 +158,9 @@ public class NavigationURLBar extends FrameLayout {
         mBinding.urlEditText.setOnEditorActionListener((aTextView, actionId, event) -> {
             if (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_SEARCH
                     || actionId == EditorInfo.IME_ACTION_GO || actionId == EditorInfo.IME_ACTION_SEND) {
-                handleURLEdit(aTextView.getText().toString());
+                ((Activity)getContext()).runOnUiThread(() -> {
+                    handleURLEdit(aTextView.getText().toString());
+                });
                 return true;
             }
             return false;


### PR DESCRIPTION
The OnEditorActionListener handler is not being executed in the UI thread. This hasn't surprisingly caused many issues so far but it's a real problem for the Chromium backend because it will eventually invoke Tab's loadUrl(). The issue is that loadUrl() cannot be invoked from multiple threads (it's normally invoked from the UI thread).

Fixes #1201 