### PR TITLE
[Chromium] Add null checks for the PermissionDelegate

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/ChromiumPermissionDelegate.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/ChromiumPermissionDelegate.java
@@ -72,6 +72,9 @@ public class ChromiumPermissionDelegate implements PermissionManagerBridge.Deleg
     private WResult<PermissionManagerBridge.PermissionStatus> requestPermission(
             PermissionManagerBridge.PermissionType permissionType, String url,
             boolean isOffTheRecord) {
+        if (mPermissionDelegate == null) {
+            return WResult.fromValue(PermissionManagerBridge.PermissionStatus.PROMPT);
+        }
         // Automatically deny any Chromium permissions that are not supported by Wolvic.
         if (permissionType == PermissionManagerBridge.PermissionType.NOT_SUPPORTED) {
             return WResult.fromValue(PermissionManagerBridge.PermissionStatus.DENY);


### PR DESCRIPTION
This is the same scenario as the one described in
https://github.com/Igalia/wolvic/pull/951#issue-1881592422 but for the PermissionsDelegate object. When the session is closed the delegate is released, so any potential event coming from Chromium will find that there is no delegate to notify.