### PR TITLE
More robust handling of HVR API key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.31"
 }
@@ -66,8 +68,13 @@ def getHVRAppId = { ->
 }
 
 def getHVRApiKey = { ->
-    if (gradle.hasProperty("userProperties.HVR_API_KEY")) {
-        return gradle."userProperties.HVR_API_KEY"
+    def jsonFile = file('agconnect-services.json')
+
+    if (jsonFile.exists()) {
+        def parsedJson = new JsonSlurper().parseText(jsonFile.text)
+        if (parsedJson.client && parsedJson.client.api_key) {
+            return parsedJson.client.api_key
+        }
     }
     return ""
 }

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -363,6 +363,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         GeolocationWrapper.INSTANCE.update(this);
 
+        initializeSpeechRecognizer();
+
         mPoorPerformanceAllowList = new HashSet<>();
         checkForCrash();
 
@@ -463,6 +465,17 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     WRuntime.CrashReportIntent getCrashReportIntent() {
         return EngineProvider.INSTANCE.getOrCreateRuntime(this).getCrashReportIntent();
+    }
+
+    private void initializeSpeechRecognizer() {
+        try {
+            String speechService = SettingsStore.getInstance(this).getVoiceSearchService();
+            SpeechRecognizer speechRecognizer = SpeechServices.getInstance(this, speechService);
+            ((VRBrowserApplication) getApplication()).setSpeechRecognizer(speechRecognizer);
+        } catch (Exception e) {
+            Log.e(LOGTAG, "Exception creating the speech recognizer: " + e);
+            ((VRBrowserApplication) getApplication()).setSpeechRecognizer(null);
+        }
     }
 
     // A dialog to tell App Lab users to download Wolvic from the Meta store.
@@ -728,17 +741,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        try {
             if (key.equals(getString(R.string.settings_key_voice_search_service))) {
-                SpeechRecognizer speechRecognizer =
-                        SpeechServices.getInstance(this, SettingsStore.getInstance(this).getVoiceSearchService());
-                ((VRBrowserApplication) getApplication()).setSpeechRecognizer(speechRecognizer);
+                initializeSpeechRecognizer();
             } else if (key.equals(getString(R.string.settings_key_head_lock))) {
                 setHeadLockEnabled(SettingsStore.getInstance(this).isHeadLockEnabled());
             }
-        } catch (ReflectiveOperationException e) {
-            e.printStackTrace();
-        }
     }
 
     void loadFromIntent(final Intent intent) {

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
@@ -69,13 +69,6 @@ public class VRBrowserApplication extends Application implements AppServicesProv
         mDictionariesManager = new DictionariesManager(activityContext);
         mDictionariesManager.init();
         mAddons = new Addons(activityContext, mSessionStore);
-
-        try {
-            String speechService = SettingsStore.getInstance(activityContext).getVoiceSearchService();
-            setSpeechRecognizer(SpeechServices.getInstance(activityContext, speechService));
-        } catch (ReflectiveOperationException e) {
-            e.printStackTrace();
-        }
     }
 
     protected void onActivityDestroy() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -260,11 +260,12 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
     }
 
     public void stopVoiceSearch() {
-        try {
-            mCurrentSpeechRecognizer.stop();
-        } catch (Exception e) {
-            Log.d(LOGTAG, e.getLocalizedMessage() != null ? e.getLocalizedMessage() : "Unknown voice error");
-            e.printStackTrace();
+        if (mCurrentSpeechRecognizer != null) {
+            try {
+                mCurrentSpeechRecognizer.stop();
+            } catch (Exception e) {
+                Log.w(LOGTAG, "Error stopping voice search: " + e);
+            }
         }
 
         mIsSpeechRecognitionRunning = false;

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -109,6 +109,8 @@ public abstract class PlatformActivity extends FragmentActivity implements Surfa
         mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         mPrefs.registerOnSharedPreferenceChangeListener(mOnSharedPreferenceChangeListener);
 
+        initializeAGConnect();
+
         DisplayManager manager = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
         if (manager.getDisplays().length < 2) {
             showPhoneUI();
@@ -230,8 +232,6 @@ public abstract class PlatformActivity extends FragmentActivity implements Surfa
         mView.getHolder().addCallback(this);
         new LibUpdateClient(this).runUpdate();
         nativeOnCreate();
-
-        initializeAGConnect();
     }
 
     private void initializeAGConnect() {
@@ -246,8 +246,9 @@ public abstract class PlatformActivity extends FragmentActivity implements Surfa
             try {
                 SpeechRecognizer speechRecognizer = SpeechServices.getInstance(this, speechService);
                 ((VRBrowserApplication) getApplicationContext()).setSpeechRecognizer(speechRecognizer);
-            } catch (ReflectiveOperationException e) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                Log.e(TAG, "Exception creating the speech recognizer: " + e);
+                ((VRBrowserApplication) getApplicationContext()).setSpeechRecognizer(null);
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
`build.gradle` will extract the API key from the configuration file for the HVR platform, instead of expecting the developer to copy that value manually.

Catch all exceptions that might arise from `SpeechServices.getInstance()`.

Ensure that we don't try to create the speech recognizer before the API key has been set.