### PR TITLE
Use doApply for setHeadLock and setWindowMovement

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -85,7 +85,7 @@ class DisplayOptionsView extends SettingsView {
         }
 
         mBinding.soundEffectSwitch.setOnCheckedChangeListener(mSoundEffectListener);
-        setSoundEffect(SettingsStore.getInstance(getContext()).isAudioEnabled(), true);
+        setSoundEffect(SettingsStore.getInstance(getContext()).isAudioEnabled(), false);
 
         mBinding.latinAutoCompleteSwitch.setOnCheckedChangeListener(mLatinAutoCompleteListener);
         setLatinAutoComplete(SettingsStore.getInstance(getContext()).isLatinAutoCompleteEnabled(), false);


### PR DESCRIPTION
We shouldn't set the value when we just want to update the UI. Also, we should check the value manually before we call set instead of simply calling them since setting values can cause unnecessary side effects on the UI (e.g. reorientation).

On a freshly installed Wolvic without any user data:

https://github.com/Igalia/wolvic/assets/43995067/032dc423-fee8-4c48-90bc-4be48e053bbd