### PR TITLE
Synthesize FCP for cached pages

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -275,7 +275,9 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     private void dumpState(WSession.ProgressDelegate aListener) {
         if (mState.mIsLoading) {
             aListener.onPageStart(mState.mSession, mState.mUri);
+            aListener.onProgressChange(mState.mSession, 0);
         } else {
+            aListener.onProgressChange(mState.mSession, 100);
             aListener.onPageStop(mState.mSession, true);
         }
 
@@ -1249,6 +1251,16 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
         for (WSession.ProgressDelegate listener : mProgressListeners) {
             listener.onPageStop(aSession, b);
+        }
+    }
+
+    @Override
+    public void onProgressChange(@NonNull WSession aSession, int progress) {
+        if (mState.mSession != aSession) {
+            return;
+        }
+        for (WSession.ProgressDelegate listener : mProgressListeners) {
+            listener.onProgressChange(aSession, progress);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -273,6 +273,8 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     }
 
     private void dumpState(WSession.ProgressDelegate aListener) {
+        if (mState.mSession == null)
+            return;
         if (mState.mIsLoading) {
             aListener.onPageStart(mState.mSession, mState.mUri);
             aListener.onProgressChange(mState.mSession, 0);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1889,6 +1889,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.setIsLoading(false);
     }
 
+    @Override
+    public void onProgressChange(@NonNull WSession aSession, int progress) {
+        // Pages that are completely loaded from cache don't trigger onFirstContentfulPaint so we
+        // force it here to the get page properly rendered.
+        if (!mAfterFirstPaint)
+            mSession.onFirstContentfulPaint(aSession);
+    }
+
     public void captureImage() {
         mSession.captureBitmap();
     }


### PR DESCRIPTION
Our current code relies on the first-contentful-paint event to among other things show the currently active window. That event is neither emitted for pages loaded from back/forward cache nor for pages completely cached by the HTTP cache.

This means that whenever we start Wolvic with a page that is fully cached (like for example our start page) then Wolvic will show a transparent window even if the page is properly completelly loaded from disk.