### PR TITLE
Update telemetry-related privacy options

### DIFF
--- a/app/src/main/res/layout/options_privacy.xml
+++ b/app/src/main/res/layout/options_privacy.xml
@@ -268,6 +268,7 @@
                     android:layout_marginStart="40dp"
                     app:on_text="@string/permission_allow"
                     app:off_text="@string/permission_reject"
+                    app:visibleGone="@{DeviceType.isHVRBuild()}"
                     app:description="@{String.format(@string/security_options_telemetry_send_data, @string/app_name)}" />
 
                 <com.igalia.wolvic.ui.views.settings.SwitchSetting
@@ -275,6 +276,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="40dp"
+                    android:visibility="gone"
                     app:on_text="@string/permission_allow"
                     app:off_text="@string/permission_reject"
                     app:description="@{String.format(@string/security_options_crash_reports_send_data, @string/app_name)}" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -910,7 +910,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Allow %1$s to send technical and interaction data to Mozilla
+    <string name="security_options_telemetry_send_data">Allow %1$s to send technical and interaction data to Huawei
  </string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog


### PR DESCRIPTION
We had a switch in the privacy options view to enable/disable sending telemetry data to Mozilla. That was inherited from FxR and has not been doing anything for a while. However it was still in the UI which is confusing for users.

We're removing it except for the case of the HVR port as it has an implementation using Huawei services. Users can still decide whether to send that data or not.

Apart from that we're removing the crash reporting switch as we are not sending any crash report anywhere. In the future it'd be nice to collect that information but that requires some server side infra that is not currently available/ready.