### PR TITLE
[ML2] Add MagicLeap2 device type to VRControllerType

### DIFF
--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -154,6 +154,7 @@ enum class VRControllerType : uint8_t {
   PicoNeo3,
   Pico4,
   MetaQuest3,
+  MagicLeap2,
   _end
 };
 


### PR DESCRIPTION
Now that we have added the ML2 device type to both Gecko[1] and Chromium[2] backends, we can safely add it also to Wolvic so that we get the proper controller models inside WebXR experiences.

[1] https://github.com/Igalia/wolvic-gecko-patches/commit/a376a3df
[2] https://github.com/Igalia/wolvic-chromium/pull/60