### PR TITLE
Update telemetry-related privacy options string translation

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -625,7 +625,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Giv %1$s lov til at sende tekniske data og data for brug til Mozilla</string>
+    <string name="security_options_telemetry_send_data">Giv %1$s lov til at sende tekniske data og data for brug til Huawei</string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.
      '%1$s' Will be replaced at runtime with the app name. -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -809,7 +809,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">%1$s erlauben, Daten zu technischen Details und Interaktionen an Mozilla zu senden
+    <string name="security_options_telemetry_send_data">%1$s erlauben, Daten zu technischen Details und Interaktionen an Huawei zu senden
  </string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -858,7 +858,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Allow %1$s to send technical and interaction data to Mozilla
+    <string name="security_options_telemetry_send_data">Allow %1$s to send technical and interaction data to Huawei
  </string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -625,7 +625,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Permitir que %1$s envíe datos técnicos y de interacción a Mozilla
+    <string name="security_options_telemetry_send_data">Permitir que %1$s envíe datos técnicos y de interacción a Huawei
  </string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -824,7 +824,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Permitir que %1$s envíe datos técnicos y de interacción a Mozilla
+    <string name="security_options_telemetry_send_data">Permitir que %1$s envíe datos técnicos y de interacción a Huawei
  </string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -625,7 +625,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Autoriser %1$s à envoyer des données techniques et d’interaction à Mozilla</string>
+    <string name="security_options_telemetry_send_data">Autoriser %1$s à envoyer des données techniques et d’interaction à Huawei</string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.
      '%1$s' Will be replaced at runtime with the app name. -->

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -236,7 +236,7 @@
     <string name="security_options_permission_webxr">Dispositivos de realidade virtual (WebXR)</string>
     <string name="security_options_webxr_settings">Avanzado</string>
     <string name="security_options_crash_reports_send_data">Permitir a %1$s enviar informes de erros automáticos</string>
-    <string name="security_options_telemetry_send_data">Permitir a %1$s enviar datos técnicos e de interacción a Mozilla</string>
+    <string name="security_options_telemetry_send_data">Permitir a %1$s enviar datos técnicos e de interacción a Huawei</string>
     <string name="sync">Sincronización</string>
     <string name="on">Activado</string>
     <string name="off">Desactivado</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -809,7 +809,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Consenti a %1$s di inviare a Mozilla dati tecnici e relativi all’interazione con il browser</string>
+    <string name="security_options_telemetry_send_data">Consenti a %1$s di inviare a Huawei dati tecnici e relativi all’interazione con il browser</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -622,7 +622,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">技術的な対話データを Mozilla へ送信することを %1$s に許可する
+    <string name="security_options_telemetry_send_data">技術的な対話データを Huawei へ送信することを %1$s に許可する
  </string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -623,7 +623,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">%1$s이(가) 기술 및 상호 작용 데이터를 Mozilla에 보내도록 허용
+    <string name="security_options_telemetry_send_data">%1$s이(가) 기술 및 상호 작용 데이터를 Huawei에 보내도록 허용
  </string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -810,7 +810,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Tillat %1$s å sende tekniske data og data for bruk til Mozilla
+    <string name="security_options_telemetry_send_data">Tillat %1$s å sende tekniske data og data for bruk til Huawei
  </string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -812,7 +812,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">%1$s toestaan technische en interactiegegevens naar Mozilla te verzenden
+    <string name="security_options_telemetry_send_data">%1$s toestaan technische en interactiegegevens naar Huawei te verzenden
  
  </string>
 

--- a/app/src/main/res/values-nn-rNO/strings.xml
+++ b/app/src/main/res/values-nn-rNO/strings.xml
@@ -810,7 +810,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Tillat %1$s å sende tekniske data og data for bruk til Mozilla
+    <string name="security_options_telemetry_send_data">Tillat %1$s å sende tekniske data og data for bruk til Huawei
  </string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -811,7 +811,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">%1$s może wysyłać dane techniczne i o interakcjach z programem do Mozilli
+    <string name="security_options_telemetry_send_data">%1$s może wysyłać dane techniczne i o interakcjach z programem do Huawei
  </string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -400,7 +400,7 @@
     <string name="security_options_webxr_settings">Avançado</string>
     <string name="security_options_speech_data_collection_title">%1$s Coleta e Uso de Dados</string>
     <string name="security_options_speech_data_collect">Permitir que %1$s colete dados de fala</string>
-    <string name="security_options_telemetry_send_data">Permitir que %1$s envie dados técnicos e de interação para a Mozilla</string>
+    <string name="security_options_telemetry_send_data">Permitir que %1$s envie dados técnicos e de interação para a Huawei</string>
     <string name="on">Ligado</string>
     <string name="off">Desligado</string>
     <string name="sync">Sincronizar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -555,7 +555,7 @@
     <string name="security_options_login_save">Gravar logins e palavras-passe</string>
     <string name="security_options_login_autofill">Preenchimento automático</string>
     <string name="security_options_autoplay">Mídia de reprodução automática</string>
-    <string name="security_options_telemetry_send_data">Permitir que %1$s envie dados técnicos e de interação para a Mozilla</string>
+    <string name="security_options_telemetry_send_data">Permitir que %1$s envie dados técnicos e de interação para a Huawei</string>
     <string name="sync">Sincronizar</string>
     <string name="do_not_sync">Não sincronizar</string>
     <string name="voice_search_decoding">Procurando…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -622,7 +622,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Разрешить %1$s отправлять технические данные и данные взаимодействия в Mozilla
+    <string name="security_options_telemetry_send_data">Разрешить %1$s отправлять технические данные и данные взаимодействия в Huawei
  </string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -622,7 +622,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">Tillåt %1$s att skicka tekniska data och interaktionsdata till Mozilla</string>
+    <string name="security_options_telemetry_send_data">Tillåt %1$s att skicka tekniska data och interaktionsdata till Huawei</string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.
      '%1$s' Will be replaced at runtime with the app name. -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -662,7 +662,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">允许 %1$s 向 Mozilla 发送技术信息及交互数据</string>
+    <string name="security_options_telemetry_send_data">允许 %1$s 向华为发送技术信息及交互数据</string>
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.
      '%1$s' Will be replaced at runtime with the app name. -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -863,7 +863,7 @@
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect telemetry data.
      '%1$s' Will be replaced at runtime with the app name. -->
-    <string name="security_options_telemetry_send_data">允許 %1$s 傳送技術與互動資料給 Mozilla</string>
+    <string name="security_options_telemetry_send_data">允許 %1$s 傳送技術與互動資料給華為</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to send crash reports.


### PR DESCRIPTION
Follow up of #1218

We should also update all the string translations from Mozilla to Huawei