### PR TITLE
Set Pico homepage in China

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -389,7 +389,7 @@ android {
             buildConfigField "Boolean", "FXA_USE_CHINA_SERVER", "true"
             buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
             buildConfigField "Boolean", "CN_FIRST_RUN_IN_PHONE_UI", "true"
-            resValue 'string', 'HOMEPAGE_URL', 'https://wolvic.com/welcome/'
+            resValue 'string', 'HOMEPAGE_URL', 'https://wolvic.com/zh/start/pico.html'
         }
     }
 


### PR DESCRIPTION
The Pico homepage in China points to https://wolvic.com/zh/start/pico.html