### PR TITLE
[VisionGlass] Implement missing methods

### DIFF
--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -205,13 +205,16 @@ DeviceDelegateVisionGlass::ReleaseControllerDelegate() {
 
 int32_t
 DeviceDelegateVisionGlass::GetControllerModelCount() const {
-  return 0;
+  return 1;
+}
+
+bool DeviceDelegateVisionGlass::IsControllerLightEnabled() const {
+  return false;
 }
 
 const std::string
 DeviceDelegateVisionGlass::GetControllerModelName(const int32_t) const {
-  static const std::string name;
-  return name;
+  return "Vision Glass";
 }
 
 void

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
@@ -41,6 +41,7 @@ public:
   void StartFrame(const FramePrediction aPrediction) override;
   void BindEye(const device::Eye) override;
   void EndFrame(const FrameEndMode aMode) override;
+  bool IsControllerLightEnabled() const override;
   // DeviceDelegateVisionGlass interface
   void InitializeJava(JNIEnv* aEnv, jobject aActivity);
   void ShutdownJava();


### PR DESCRIPTION
There were some methods in the DeviceDelegate that were unimplemented. They don't really change any behaviour right now but it's good for correctness and might eventually prevent future bugs.