### PR TITLE
[VisionGlass] Use ElboxModel for the phone controller

### DIFF
--- a/app/src/main/cpp/ElbowModel.cpp
+++ b/app/src/main/cpp/ElbowModel.cpp
@@ -13,12 +13,14 @@ namespace crow {
 struct ElbowModel::State {
   const vrb::Vector rightElbowOffset;
   const vrb::Vector leftElbowOffset;
+  const vrb::Vector centerElbowOffset;
   const vrb::Vector lowerArm;
   vrb::Matrix result;
 
   State()
       : rightElbowOffset(0.2f, -0.3f, -0.15f)
       , leftElbowOffset(-rightElbowOffset.x(), rightElbowOffset.y(), rightElbowOffset.z())
+      , centerElbowOffset(0.f, rightElbowOffset.y(), rightElbowOffset.z())
       , lowerArm(0.0f, 0.0f, -0.4f) {}
 };
 
@@ -30,7 +32,17 @@ ElbowModel::Create() {
 const vrb::Matrix&
 ElbowModel::GetTransform(const HandEnum aHand, const vrb::Matrix& aHeadTransform, const vrb::Matrix& aDeviceRotation) {
   vrb::Vector arm = aDeviceRotation.MultiplyDirection(m.lowerArm);
-  vrb::Vector offset = aHeadTransform.MultiplyPosition(aHand == HandEnum::Right ? m.rightElbowOffset : m.leftElbowOffset);
+  vrb::Vector offset;
+  switch (aHand) {
+    case HandEnum::Left:
+      offset = aHeadTransform.MultiplyPosition(m.leftElbowOffset);
+      break;
+    case HandEnum::Right:
+      offset = aHeadTransform.MultiplyPosition(m.rightElbowOffset);
+      break;
+    case HandEnum::None:
+      offset = aHeadTransform.MultiplyPosition(m.centerElbowOffset);
+  }
   m.result = aDeviceRotation.PreMultiply(vrb::Matrix::Position(offset + arm));
   return m.result;
 }

--- a/app/src/main/cpp/ElbowModel.h
+++ b/app/src/main/cpp/ElbowModel.h
@@ -17,7 +17,7 @@ typedef std::shared_ptr<ElbowModel> ElbowModelPtr;
 
 class ElbowModel {
 public:
-  enum class HandEnum { Left, Right };
+  enum class HandEnum { Left, Right, None };
   static ElbowModelPtr Create();
   const vrb::Matrix& GetTransform(const HandEnum aHand, const vrb::Matrix& aHeadTransform, const vrb::Matrix& aDeviceRotation);
 protected:

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -38,7 +38,6 @@ namespace crow {
 static const float kHorizontalFOV = 36.0f;
 static const float kVerticalFOV = 21.0f;
 const vrb::Vector kAverageHeight(0.0f, 1.6f, 0.0f);
-const vrb::Vector kControllerAverageHeight = kAverageHeight * 2/3;
 static const int32_t kControllerIndex = 0;
 
 struct DeviceDelegateVisionGlass::State {
@@ -54,6 +53,7 @@ struct DeviceDelegateVisionGlass::State {
   GLsizei glWidth, glHeight;
   float near, far;
   vrb::Matrix reorientMatrix;
+  crow::ElbowModelPtr elbow;
   State()
       : renderMode(device::RenderMode::StandAlone)
       , headingMatrix(vrb::Matrix::Identity())
@@ -63,6 +63,7 @@ struct DeviceDelegateVisionGlass::State {
       , near(0.1f)
       , far(1000.0f)
       , reorientMatrix(vrb::Matrix::Identity())
+      , elbow(ElbowModel::Create())
   {
   }
 
@@ -95,7 +96,7 @@ struct DeviceDelegateVisionGlass::State {
     immersiveDisplay->SetFieldOfView(device::Eye::Left, left, right, top, bottom);
     immersiveDisplay->SetFieldOfView(device::Eye::Right, left, right, top, bottom);
 
-    immersiveDisplay->SetCapabilityFlags(device::Orientation | device::Present | device::InlineSession | device::ImmersiveVRSession);
+    immersiveDisplay->SetCapabilityFlags(device::PositionEmulated | device::Orientation | device::Present | device::InlineSession | device::ImmersiveVRSession);
   }
 };
 
@@ -238,10 +239,9 @@ DeviceDelegateVisionGlass::StartFrame(const FramePrediction aPrediction) {
     float level = 100.0 - std::fmod(context->GetTimestamp(), 100.0);
     m.controller->SetBatteryLevel(kControllerIndex, (int32_t)level);
   }
-  auto transformMatrix = vrb::Matrix::Rotation(m.controllerOrientation).Translate(kControllerAverageHeight);
-  m.controller->SetTransform(kControllerIndex, transformMatrix);
-  m.controller->SetBeamTransform(kControllerIndex, vrb::Matrix::Identity());
-  m.controller->SetImmersiveBeamTransform(kControllerIndex, vrb::Matrix::Identity());
+  auto transformMatrix = vrb::Matrix::Rotation(m.controllerOrientation);
+  auto pointerTransform = m.elbow->GetTransform(ElbowModel::HandEnum::None, headTransform, transformMatrix);
+  m.controller->SetTransform(kControllerIndex, pointerTransform);
 }
 
 void


### PR DESCRIPTION
The VisionGlass system uses the phone as controller. It's a 3DoF device as it does not report position, only orientation via the accelerometer. This means that we need then to estimate the position of the phone in users' hands to create a beam and a pointer.

We were not doing it properly and thus, the direction of the pointer and the direction of the beam didn't really match. Fortunately we do already have an utility class, ElbowModel, that properly computes that for us. It's used for other 3DoF devices.