### PR TITLE
[VisionGlass] Use the largest window distance by default

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -85,7 +85,6 @@ public class SettingsStore {
     public final static boolean NOTIFICATIONS_DEFAULT = true;
     public final static boolean SPEECH_DATA_COLLECTION_DEFAULT = false;
     public final static boolean SPEECH_DATA_COLLECTION_REVIEWED_DEFAULT = false;
-    public final static float WINDOW_DISTANCE_DEFAULT = 0.0f;
     public final static int UA_MODE_DEFAULT = WSessionSettings.USER_AGENT_MODE_VR;
     public final static int INPUT_MODE_DEFAULT = 1;
 
@@ -146,6 +145,9 @@ public class SettingsStore {
     public final static boolean TELEMETRY_DEFAULT = true;
 
     private int mCachedScrollDirection = -1;
+
+    private final static float WINDOW_DISTANCE_DEFAULT = 0.0f;
+    private final static float WINDOW_DISTANCE_DEFAULT_VISION_GLASS = 1.0f;
 
     private boolean mDisableLayers = false;
     public void setDisableLayers(final boolean aDisableLayers) {
@@ -414,8 +416,13 @@ public class SettingsStore {
     }
 
     @FloatRange(from = 0, to = 1)
+    public float getDefaultWindowDistance() {
+        return DeviceType.getType() == DeviceType.VisionGlass ? WINDOW_DISTANCE_DEFAULT_VISION_GLASS : WINDOW_DISTANCE_DEFAULT;
+    }
+
+    @FloatRange(from = 0, to = 1)
     public float getWindowDistance() {
-        return mPrefs.getFloat(mContext.getString(R.string.settings_key_window_distance), WINDOW_DISTANCE_DEFAULT);
+        return mPrefs.getFloat(mContext.getString(R.string.settings_key_window_distance), getDefaultWindowDistance());
     }
 
     public void setWindowDistance(@FloatRange(from = 0, to = 1) float distance) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -254,7 +254,7 @@ class DisplayOptionsView extends SettingsView {
         setLatinAutoComplete(SettingsStore.LATIN_AUTO_COMPLETE_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
         setWindowMovement(SettingsStore.WINDOW_MOVEMENT_DEFAULT, true);
-        setWindowDistance(SettingsStore.WINDOW_DISTANCE_DEFAULT, true);
+        setWindowDistance(SettingsStore.getInstance(getContext()).getDefaultWindowDistance(), true);
 
         if (mBinding.startWithPassthroughSwitch.isChecked() != SettingsStore.shouldStartWithPassthrougEnabled()) {
             setStartWithPassthrough(SettingsStore.shouldStartWithPassthrougEnabled());


### PR DESCRIPTION
Due to the constraints and FoV of the VisionGlass users cannot see the whole browser window by default because it's too close. We're modifying the settings so that the default window distance is the larger available.

The whole window is not entirely visible though but it's the best we can do ATM.