### PR TITLE
Battery level related changes

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1512,10 +1512,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Keep
     @SuppressWarnings("unused")
     private void updateControllerBatteryLevels(final int leftLevel, final int rightLevel) {
-        runOnUiThread(() -> updateBatterLevels(leftLevel, rightLevel));
+        runOnUiThread(() -> updateBatteryLevels(leftLevel, rightLevel));
     }
 
-    private void updateBatterLevels(final int leftLevel, final int rightLevel) {
+    private void updateBatteryLevels(final int leftLevel, final int rightLevel) {
         long currentTime = System.nanoTime();
         if (((currentTime - mLastBatteryUpdate) >= BATTERY_UPDATE_INTERVAL) || mLastBatteryLevel == -1) {
             mLastBatteryUpdate = currentTime;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -308,7 +308,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
                         .withDensity(R.dimen.tray_tooltip_density)
                         .withLayout(R.layout.tooltip)
                         .withString(getContext().getString(
-                                R.string.tray_status_headset,
+                                DeviceType.isTetheredDevice() ? R.string.tray_status_phone : R.string.tray_status_headset,
                                 String.format(
                                         LocaleUtils.getDisplayLanguage(
                                                 getContext()).getLocale(),

--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -161,4 +161,8 @@ public class DeviceType {
         }
         return aContext.getString(R.string.device_name, appName, deviceName);
     }
+
+    public static boolean isTetheredDevice() {
+        return mType == HVR3DoF || mType == HVR6DoF || mType == VisionGlass || mType == LenovoA3;
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2532,5 +2532,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- Shown in the tray wifi icon popup when SSID cannot be retrieved -->
     <string name="tray_wifi_unavailable_ssid">SSID unavailable</string>
+    <!-- Tooltip for the battery level when using a tethered device instead of a headset -->
+    <string name="tray_status_phone">Phone: %1$s</string>
 
 </resources>

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -241,11 +241,6 @@ DeviceDelegateVisionGlass::StartFrame(const FramePrediction aPrediction) {
   if (!m.controller)
     return;
 
-  if (auto context = m.context.lock()) {
-    float level = 100.0 - std::fmod(context->GetTimestamp(), 100.0);
-    m.controller->SetBatteryLevel(kControllerIndex, (int32_t)level);
-  }
-
   vrb::Matrix transformMatrix;
   if (auto context = m.context.lock()) {
     float* filteredOrientation = m.orientationFilter->filter(context->GetTimestamp() * 1000000000, m.controllerOrientation.Data());


### PR DESCRIPTION
This PR is made of 3 changes:
1. Remove an unneccessary call to setbatterylevel in Vision Glass system (there are not controllers apart from the phone)
2. Rename a misspelled method name
3. Use a different battery icon tooltip for tethered devices (phone instead of headset)

This requires new translations