### PR TITLE
Prevent crash in release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -54,6 +54,8 @@
 -keep class com.igalia.wolvic.browser.engine.** {*;} # Keep state clases used by gson.
 -keep class com.igalia.wolvic.utils.RemoteProperties {*;} # Keep state clases used by gson.
 -keep class com.igalia.wolvic.utils.Environment {*;} # Keep state clases used by gson.
+-keep class com.google.gson.reflect.TypeToken { *; }    # Keep this specific gson class
+-keep class * extends com.google.gson.reflect.TypeToken # and its descendants.
 
 # --------------------------------------------------------------------
 # Keep classes from HTC SDK


### PR DESCRIPTION
Prevent a crash in release builds caused by proguard removing classes required by the GSON library.