### PR TITLE
[PICO] Screenshot button doesn't dismiss the keyboard

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1318,7 +1318,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
                     return false;
                 } else {
                     connection.sendKeyEvent(event);
-                    hide(UIWidget.KEEP_WIDGET);
+                    dismiss();
                 }
                 return true;
             }

--- a/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
@@ -17,8 +17,8 @@ public class PlatformActivity extends NativeActivity {
     }
 
     public static boolean isNotSpecialKey(KeyEvent event) {
-        // Dummy implementation.
-        return true;
+        // Recognize PICO's screenshot button.
+        return event.getKeyCode() != KeyEvent.KEYCODE_CAMERA;
     }
 
     public static boolean isPositionTrackingSupported() {


### PR DESCRIPTION
The keyboard should not get dismissed when the user takes a screenshot on PICO, so we need to detect the `KEYCODE_CAMERA` key event.

Additionally, the keyboard needs to be dismissed with `dismiss()` so that it is not left in an inconsistent state.