### PR TITLE
[VisionGlass] Do not draw the environment (skybox)

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -325,7 +325,7 @@ public class SettingsStore {
     }
 
     public static boolean shouldStartWithPassthrougEnabled() {
-        return DeviceType.getType() == DeviceType.LenovoA3;
+        return DeviceType.getType() == DeviceType.LenovoA3 || DeviceType.getType() == DeviceType.VisionGlass;
     }
 
     public boolean isStartWithPassthroughEnabled() {


### PR DESCRIPTION
We could completely prevent the environment from rendering by enabling passthrough at startup in the settings. We do the same for other see-through devices like the Lenovo A3. This is not a "real" passthrough as we aren't showing the real world by getting a video stream from a camera. That's because we don't need it as the device is not fully immersive but rather an AR device.

Current Wolvic's code defaults to not rendering the skybox if passthrough is enabled and there is no passthrough layer.