### PR TITLE
[VisionGlass] Do not rotate the Phone UI

### DIFF
--- a/app/src/visionglass/AndroidManifest.xml
+++ b/app/src/visionglass/AndroidManifest.xml
@@ -7,7 +7,8 @@
 
     <application>
         <activity
-            android:name=".VRBrowserActivity">
+            android:name=".VRBrowserActivity"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Phone UI layout used to automatically switch to landscape mode when the phone was rotated. That is an undesired capability for this particular use case in which we want the UI to stay the same no matter the rotation of the phone. That's because the phone is the controller so we don't want the UI to suddenly change when the user is pointing to some directions.