### PR TITLE
Copied links can be pasted on web forms

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
@@ -6,6 +6,7 @@
 package com.igalia.wolvic.ui.widgets.menus;
 
 import android.content.ClipData;
+import android.content.ClipDescription;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.Configuration;
@@ -129,7 +130,11 @@ public class ContextMenuWidget extends MenuWidget {
                     if (StringUtils.isEmpty(label)) {
                         label = uri.toString();
                     }
-                    ClipData clip = ClipData.newRawUri(label, uri);
+                    // The clip data contains the URI in two formats: as an URI and as plain text.
+                    ClipData clip = new ClipData(label,
+                            new String[]{ClipDescription.MIMETYPE_TEXT_URILIST, ClipDescription.MIMETYPE_TEXT_PLAIN},
+                            new ClipData.Item(uri));
+                    clip.addItem(new ClipData.Item(uri.toString()));
                     if (clipboard != null) {
                         clipboard.setPrimaryClip(clip);
                     }


### PR DESCRIPTION
"Copy link" from the contextual menu adds the URL as data with MIME type text/uri-list to the clipboard.

This data can be pasted on Android widgets like the URL bar, but not on a form in a website.

The problem is that Gecko is only able to paste content of type "text/plain". The solution is to store the link in both formats (as URI and as text) in the clipboard.