### PR TITLE
Fix crash in keyboard widget

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1179,6 +1179,11 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     }
 
     private void postDisplayCommand(Runnable aRunnable) {
+        if (mInputConnection == null) {
+            Log.e(LOGTAG, "InputConnection was null, display command not submitted");
+            return;
+        }
+
         Handler handler = mInputConnection.getHandler();
         if (handler != null) {
             aRunnable.run();


### PR DESCRIPTION
Fix a crash that happens because the InputConnection might be null when we try to submit a display command.