### PR TITLE
Display China license number in the Settings

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -859,7 +859,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
                 // Getting the SSID, even if it's just to show it to the user, is considered
                 // "recollection of personal information" by Huawei store in Mainland China so avoid
                 // getting it.
-                if (BuildConfig.FLAVOR_store.toLowerCase().contains("mainlandchina") && DeviceType.isHVRBuild()) {
+                if (DeviceType.isHVRBuild() && DeviceType.getStoreType() == DeviceType.StoreType.MAINLAND_CHINA) {
                     mWifiSSID = getContext().getString(R.string.tray_wifi_unavailable_ssid);
                 } else {
                     WifiInfo currentWifi = wifiManager.getConnectionInfo();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -45,6 +45,7 @@ import com.igalia.wolvic.ui.widgets.WindowWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.ClearUserDataDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.UIDialog;
+import com.igalia.wolvic.utils.DeviceType;
 import com.igalia.wolvic.utils.RemoteProperties;
 import com.igalia.wolvic.utils.StringUtils;
 
@@ -202,14 +203,23 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             return view.performClick();
         });
 
-        mBinding.surveyLink.setOnClickListener(v -> {
-            if (mAudio != null) {
-                mAudio.playSound(AudioEngine.Sound.CLICK);
-            }
-
-            mWidgetManager.openNewTabForeground(getResources().getString(R.string.survey_link));
-            exitWholeSettings();
-        });
+        if (DeviceType.getStoreType() == DeviceType.StoreType.MAINLAND_CHINA) {
+            mBinding.chinaLicenseNumber.setOnClickListener(v -> {
+                if (mAudio != null) {
+                    mAudio.playSound(AudioEngine.Sound.CLICK);
+                }
+                mWidgetManager.openNewTabForeground(getResources().getString(R.string.rCN_license_link));
+                exitWholeSettings();
+            });
+        } else {
+            mBinding.surveyLink.setOnClickListener(v -> {
+                if (mAudio != null) {
+                    mAudio.playSound(AudioEngine.Sound.CLICK);
+                }
+                mWidgetManager.openNewTabForeground(getResources().getString(R.string.survey_link));
+                exitWholeSettings();
+            });
+        }
 
         mBinding.helpButton.setOnClickListener(view -> {
             if (mAudio != null) {

--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -140,13 +140,15 @@ public class DeviceType {
     }
 
     // Identifiers for store-specific builds.
-    public enum StoreType {NONE, META_STORE, META_APP_LAB}
+    public enum StoreType {NONE, META_STORE, META_APP_LAB, MAINLAND_CHINA}
 
     public static StoreType getStoreType() {
         if (BuildConfig.FLAVOR_store.toLowerCase().contains("metastore"))
             return StoreType.META_STORE;
         else if (BuildConfig.FLAVOR_store.toLowerCase().contains("applab"))
             return StoreType.META_APP_LAB;
+        else if (BuildConfig.FLAVOR_store.toLowerCase().contains("mainlandchina"))
+            return StoreType.MAINLAND_CHINA;
         else
             return StoreType.NONE;
     }

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -7,6 +7,7 @@
             name="settingsmodel"
             type="com.igalia.wolvic.ui.viewmodel.SettingsViewModel" />
         <import type="com.igalia.wolvic.BuildConfig"/>
+        <import type="com.igalia.wolvic.utils.DeviceType" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -82,7 +83,23 @@
                 android:textColor="@color/azure"
                 android:autoLink="all"
                 android:textStyle="bold"
-                android:textSize="@dimen/text_smaller_size" />
+                android:textSize="@dimen/text_smaller_size"
+                app:visibleGone="@{DeviceType.getStoreType() != DeviceType.StoreType.MAINLAND_CHINA}" />
+
+            <TextView
+                android:id="@+id/chinaLicenseNumber"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:text="@string/rCN_license_number"
+                android:textColor="@color/azure"
+                android:textColorHighlight="@android:color/transparent"
+                android:textColorLink="@color/azure"
+                android:textSize="@dimen/text_medium_size"
+                android:textStyle="bold"
+                app:visibleGone="@{DeviceType.getStoreType() == DeviceType.StoreType.MAINLAND_CHINA}" />
 
             <TextView
                 android:id="@+id/buildText"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -231,4 +231,8 @@
     <!-- Shared preferences key to store the list of installed Web apps (JSON string) -->
     <string name="settings_key_web_apps_data" translatable="false">settings_key_web_apps_data</string>
 
+    <!-- China license number -->
+    <string name="rCN_license_number" translatable="false">ICP备案号：京ICP备2022006476号-10A</string>
+    <string name="rCN_license_link" translatable="false">https://beian.miit.gov.cn/</string>
+
 </resources>


### PR DESCRIPTION
Add mainland China to DeviceType.getStoreType().

Display the China ICP license number in the Settings.