### PR TITLE
Remove GoogleVR leftover

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
@@ -133,12 +133,6 @@ public class OffscreenDisplay {
         }
 
         @Override
-        public void onCreate(Bundle savedInstanceState) {
-
-            super.onCreate(savedInstanceState);
-        }
-
-        @Override
         public boolean dispatchKeyEvent(KeyEvent event) {
             return ((VRBrowserActivity)mContext).dispatchKeyEvent(event);
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
@@ -136,27 +136,6 @@ public class OffscreenDisplay {
         public void onCreate(Bundle savedInstanceState) {
 
             super.onCreate(savedInstanceState);
-            try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    getWindow().setDecorFitsSystemWindows(false);
-                    WindowInsetsController controller = getWindow().getInsetsController();
-                    if (controller != null) {
-                        controller.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
-                        controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
-                    }
-                } else {
-                    getWindow()
-                            .getDecorView()
-                            .setSystemUiVisibility(
-                                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                                            | View.SYSTEM_UI_FLAG_FULLSCREEN
-                                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-                }
-            } catch (Exception e) {
-            }
         }
 
         @Override


### PR DESCRIPTION
GoogleVR was supported by FxR at some point but then the support was removed as it was not maintained. This PR removes some of code that was added for GoogleVR but not removed.

As that code was deprecated we added a more modern version of it as part of our effort to remove warnings in the code without realizing that the code was added for an unsupported platform. We're removing that code as well.