### PR TITLE
Introduce dropFrame in VRBrowserState

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1812,7 +1812,7 @@ BrowserWorld::TickImmersive() {
           // Instead, repeat the XR frame and render the spinner while we transition
           // to one frame ahead prediction.
           state = ExternalVR::VRState::Loading;
-      } else {
+      } else if (!aDiscardFrame){
           // Predict poses for one frame ahead and push the data to shmem so Gecko
           // can start the next XR RAF ASAP.
           m.device->StartFrame(framePrediction);
@@ -1841,11 +1841,11 @@ BrowserWorld::TickImmersive() {
             DrawImmersive(aEye);
         };
       }
+      m.frameEndHandler = [=]() {
+        m.device->EndFrame(aDiscardFrame ? DeviceDelegate::FrameEndMode::DISCARD : DeviceDelegate::FrameEndMode::APPLY);
+        m.blitter->EndFrame();
+      };
     }
-    m.frameEndHandler = [=]() {
-      m.device->EndFrame(aDiscardFrame ? DeviceDelegate::FrameEndMode::DISCARD : DeviceDelegate::FrameEndMode::APPLY);
-      m.blitter->EndFrame();
-    };
   } else {
     if (surfaceHandle != 0) {
       m.blitter->CancelFrame(surfaceHandle);

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1812,7 +1812,7 @@ BrowserWorld::TickImmersive() {
           // Instead, repeat the XR frame and render the spinner while we transition
           // to one frame ahead prediction.
           state = ExternalVR::VRState::Loading;
-      } else if (!aDiscardFrame){
+      } else {
           // Predict poses for one frame ahead and push the data to shmem so Gecko
           // can start the next XR RAF ASAP.
           m.device->StartFrame(framePrediction);
@@ -1841,11 +1841,11 @@ BrowserWorld::TickImmersive() {
             DrawImmersive(aEye);
         };
       }
-      m.frameEndHandler = [=]() {
-        m.device->EndFrame(aDiscardFrame ? DeviceDelegate::FrameEndMode::DISCARD : DeviceDelegate::FrameEndMode::APPLY);
-        m.blitter->EndFrame();
-      };
     }
+    m.frameEndHandler = [=]() {
+      m.device->EndFrame(aDiscardFrame ? DeviceDelegate::FrameEndMode::DISCARD : DeviceDelegate::FrameEndMode::APPLY);
+      m.blitter->EndFrame();
+    };
   } else {
     if (surfaceHandle != 0) {
       m.blitter->CancelFrame(surfaceHandle);

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -602,6 +602,14 @@ ExternalVR::WaitFrameResult() {
       // VRB_LOG("RequestFrame BREAK %llu",  m.browser.layerState[0].layer_stereo_immersive.frameId);
       break;
     }
+
+#if CHROMIUM
+    if(m.browser.dropFame) {
+       m.system.displayState.droppedFrameCount++;
+       return false;
+    }
+#endif
+
     if (m.firstPresentingFrame || m.waitingForExit) {
       return true; // Do not block to show loading screen until the first frame arrives.
     }

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -544,6 +544,9 @@ struct VRBrowserState {
   bool detectRuntimesOnly;
   bool presentationActive;
   bool navigationTransitionActive;
+#if CHROMIUM
+  bool dropFame;
+#endif
   VRLayerState layerState[kVRLayerMaxCount];
   VRHapticState hapticState[kVRHapticsMaxCount];
 


### PR DESCRIPTION
This patch introduces `dropFrame` in VRBrowserState for chromium backend to discard the current frame and wait for the next tick of vsync. Also, this prevents from visiting StartFrame/EndFrame to keep the current scene when discarding frame.