### PR TITLE
[VisionGlass] Improve phone UI

### DIFF
--- a/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
@@ -11,6 +11,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.SystemUtils;
 
 public class PlatformActivity extends NativeActivity {
@@ -29,6 +30,8 @@ public class PlatformActivity extends NativeActivity {
         // Dummy implementation.
         return true;
     }
+
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
 
     protected Intent getStoreIntent() {
         // Dummy implementation.

--- a/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
+++ b/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
@@ -2,4 +2,5 @@ package com.igalia.wolvic;
 
 public interface PlatformActivityPlugin {
     void onKeyboardVisibilityChange(boolean isVisible);
+    void onVideoAvailabilityChange();
 }

--- a/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
+++ b/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
@@ -1,0 +1,5 @@
+package com.igalia.wolvic;
+
+public interface PlatformActivityPlugin {
+    void onKeyboardVisibilityChange(boolean isVisible);
+}

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -2118,6 +2118,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         return (AppServicesProvider)getApplication();
     }
 
+    @Override
+    public KeyboardWidget getKeyboard() { return mKeyboard; }
+
     private native void addWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateVisibleWidgetsNative();

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -245,6 +245,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private boolean mIsPassthroughEnabled = false;
     private long mLastBatteryUpdate = System.nanoTime();
     private int mLastBatteryLevel = -1;
+    private PlatformActivityPlugin mPlatformPlugin;
 
     private boolean callOnAudioManager(Consumer<AudioManager> fn) {
         if (mAudioManager == null) {
@@ -449,6 +450,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         attachToWindow(mWindows.getFocusedWindow(), null);
 
         addWidgets(Arrays.asList(mRootWidget, mNavigationBar, mKeyboard, mTray, mWebXRInterstitial));
+
+        // Create the platform plugin after widgets are created to be extra safe.
+        mPlatformPlugin = createPlatformPlugin(this);
 
         mWindows.restoreSessions();
     }
@@ -1676,6 +1680,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             view.setVisibility(visible ? View.VISIBLE : View.GONE);
         }
 
+        if (aWidget == mKeyboard && mPlatformPlugin != null) {
+            mPlatformPlugin.onKeyboardVisibilityChange(visible);
+        }
+
         for (UpdateListener listener: mWidgetUpdateListeners) {
             listener.onWidgetUpdate(aWidget);
         }
@@ -1899,6 +1907,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     public void keyboardDismissed() {
         mNavigationBar.showVoiceSearch();
+        if (mPlatformPlugin != null)
+            mPlatformPlugin.onKeyboardVisibilityChange(false);
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -440,6 +440,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                         WidgetManagerDelegate.CPU_LEVEL_NORMAL;
 
                 queueRunnable(() -> setCPULevelNative(cpuLevel));
+
+                if (mPlatformPlugin != null) {
+                    mPlatformPlugin.onVideoAvailabilityChange();
+                }
             }
         });
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1496,4 +1496,9 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         aOldSession.removeTextInputListener(this);
         aSession.addTextInputListener(this);
     }
+
+    public void simulateVoiceButtonClick() {
+        mKeyboardVoiceButton.performClick();
+    }
+
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -124,4 +124,5 @@ public interface WidgetManagerDelegate {
     void updateLocale(@NonNull Context context);
     @NonNull
     AppServicesProvider getServicesProvider();
+    KeyboardWidget getKeyboard();
 }

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -372,6 +372,8 @@ public abstract class PlatformActivity extends FragmentActivity implements Surfa
         queueRunnable(this::nativeOnSurfaceDestroyed);
     }
 
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
+
     protected boolean platformExit() {
         return false;
     }

--- a/app/src/lynx/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/lynx/java/com/igalia/wolvic/PlatformActivity.java
@@ -11,6 +11,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.SystemUtils;
 
 public class PlatformActivity extends NativeActivity {
@@ -44,6 +45,9 @@ public class PlatformActivity extends NativeActivity {
             }
         });
     }
+
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
+
     protected native void queueRunnable(Runnable aRunnable);
     protected native boolean platformExit();
 }

--- a/app/src/main/res/layout/visionglass_layout.xml
+++ b/app/src/main/res/layout/visionglass_layout.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -46,6 +47,61 @@
             android:orientation="vertical"
             android:layout_marginTop="10dp"
             android:layout_marginBottom="10dp"/>
+
+        <LinearLayout
+            android:id="@+id/phoneUIMediaControls"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <SeekBar
+                android:id="@+id/phoneUIMediaSeekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="0.10"
+                android:orientation="horizontal">
+
+                <Space
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <ImageButton
+                    android:id="@+id/phoneUISeekBackward10Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.8"
+                    android:src="@drawable/ic_icon_media_seek_backward_10" />
+
+                <ImageButton
+                    android:id="@+id/phoneUIPlayButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:src="@android:drawable/ic_media_play" />
+
+                <ImageButton
+                    android:id="@+id/phoneUISeekForward30Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.8"
+                    android:src="@drawable/ic_icon_media_seek_forward_30" />
+
+                <ImageButton
+                    android:id="@+id/phoneUIMuteButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.2"
+                    android:src="@drawable/ic_icon_media_volume" />
+            </LinearLayout>
+
+        </LinearLayout>
 
         <LinearLayout
             android:gravity="center_vertical"

--- a/app/src/main/res/layout/visionglass_layout.xml
+++ b/app/src/main/res/layout/visionglass_layout.xml
@@ -28,14 +28,13 @@
                 android:textOn="" />
 
             <ImageButton
-                android:id="@+id/voice_button"
+                android:id="@+id/phoneUIVoiceButton"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:contentDescription="@string/voice_search_tooltip"
                 android:scaleType="fitCenter"
-                android:src="@drawable/ic_icon_microphone"
-                android:visibility="invisible"/>
+                android:src="@drawable/ic_icon_microphone" />
         </LinearLayout>
 
         <View

--- a/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 
 import androidx.annotation.Keep;
 
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import java.util.ArrayList;
@@ -162,6 +163,8 @@ public class PlatformActivity extends ComponentActivity {
         queueRunnable(() -> touchEvent(false, xx, yy));
         return true;
     }
+
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
 
     @Override
     protected void onPause() {

--- a/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -21,6 +21,7 @@ import android.view.WindowManager;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.SystemUtils;
 
 public class PlatformActivity extends NativeActivity {
@@ -122,6 +123,7 @@ public class PlatformActivity extends NativeActivity {
         );
     }
 
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
 
     protected native void queueRunnable(Runnable aRunnable);
     protected native boolean platformExit();

--- a/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
@@ -9,6 +9,8 @@ import android.app.NativeActivity;
 import android.content.Intent;
 import android.view.KeyEvent;
 
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+
 public class PlatformActivity extends NativeActivity {
 
     public static boolean filterPermission(final String aPermission) {
@@ -25,6 +27,8 @@ public class PlatformActivity extends NativeActivity {
         // Dummy implementation.
         return true;
     }
+
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
 
     protected Intent getStoreIntent() {
         // Dummy implementation.

--- a/app/src/spaces/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/spaces/java/com/igalia/wolvic/PlatformActivity.java
@@ -11,6 +11,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.SystemUtils;
 
 public class PlatformActivity extends NativeActivity {
@@ -34,6 +35,8 @@ public class PlatformActivity extends NativeActivity {
         // Dummy implementation.
         return null;
     }
+
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
 
     @Override
     public void onBackPressed() {

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -141,6 +141,8 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         usbPermissionFilter.addAction(HUAWEI_USB_PERMISSION);
         registerReceiver(mUsbPermissionReceiver, usbPermissionFilter);
 
+        initVisionGlassPhoneUI();
+
         VisionGlass.getInstance().init(getApplication());
         VisionGlass.getInstance().setOnConnectionListener(this);
         initVisionGlass();
@@ -160,49 +162,7 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         }
     }
 
-    private void initVisionGlass() {
-        Log.d(LOGTAG, "initVisionGlass");
-
-        if (mWasImuStarted) {
-            Log.d(LOGTAG, "Duplicated call to init the Vision Glass system");
-            updateDisplays();
-            return;
-        }
-
-        if (!VisionGlass.getInstance().isConnected()) {
-            Log.d(LOGTAG, "Glasses not connected yet");
-            return;
-        }
-
-        if (!VisionGlass.getInstance().hasUsbPermission()) {
-            if (!mIsAskingForPermission) {
-                Log.d(LOGTAG, "Asking for USB permission");
-                mIsAskingForPermission = true;
-                VisionGlass.getInstance().requestUsbPermission();
-            }
-            return;
-        }
-
-        Log.d(LOGTAG, "Starting IMU");
-
-        mWasImuStarted = true;
-        VisionGlass.getInstance().startImu((w, x, y, z) -> queueRunnable(() -> setHead(x, y, z, w)));
-
-        VisionGlass.getInstance().setDisplayMode(DisplayMode.vr3d, new DisplayModeCallback() {
-            @Override
-            public void onSuccess(DisplayMode displayMode) {
-                Log.d(LOGTAG, "Successfully switched to 3D mode");
-                updateDisplays();
-            }
-
-            @Override
-            public void onError(String s, int i) {
-                Log.d(LOGTAG, "Error " + i + "; failed to switch to 3D mode: " + s);
-                mWasImuStarted = false;
-                updateDisplays();
-            }
-        });
-
+    private void initVisionGlassPhoneUI() {
         setContentView(R.layout.visionglass_layout);
 
         View touchpad = findViewById(R.id.touchpad);
@@ -250,6 +210,51 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         }));
 
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
+
+
+    private void initVisionGlass() {
+        Log.d(LOGTAG, "initVisionGlass");
+
+        if (mWasImuStarted) {
+            Log.d(LOGTAG, "Duplicated call to init the Vision Glass system");
+            updateDisplays();
+            return;
+        }
+
+        if (!VisionGlass.getInstance().isConnected()) {
+            Log.d(LOGTAG, "Glasses not connected yet");
+            return;
+        }
+
+        if (!VisionGlass.getInstance().hasUsbPermission()) {
+            if (!mIsAskingForPermission) {
+                Log.d(LOGTAG, "Asking for USB permission");
+                mIsAskingForPermission = true;
+                VisionGlass.getInstance().requestUsbPermission();
+            }
+            return;
+        }
+
+        Log.d(LOGTAG, "Starting IMU");
+
+        mWasImuStarted = true;
+        VisionGlass.getInstance().startImu((w, x, y, z) -> queueRunnable(() -> setHead(x, y, z, w)));
+
+        VisionGlass.getInstance().setDisplayMode(DisplayMode.vr3d, new DisplayModeCallback() {
+            @Override
+            public void onSuccess(DisplayMode displayMode) {
+                Log.d(LOGTAG, "Successfully switched to 3D mode");
+                updateDisplays();
+            }
+
+            @Override
+            public void onError(String s, int i) {
+                Log.d(LOGTAG, "Error " + i + "; failed to switch to 3D mode: " + s);
+                mWasImuStarted = false;
+                updateDisplays();
+            }
+        });
 
         // Show the app
         if (getLifecycle().getCurrentState() == Lifecycle.State.RESUMED) {

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -59,6 +59,7 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
     private DisplayManager mDisplayManager;
     private Display mPresentationDisplay;
     private VisionGlassPresentation mActivePresentation;
+    private View mVoiceSearchButton;
 
     @SuppressWarnings("unused")
     public static boolean filterPermission(final String aPermission) {
@@ -164,6 +165,9 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
 
     private void initVisionGlassPhoneUI() {
         setContentView(R.layout.visionglass_layout);
+
+        mVoiceSearchButton = findViewById(R.id.phoneUIVoiceButton);
+        mVoiceSearchButton.setEnabled(false);
 
         View touchpad = findViewById(R.id.touchpad);
         touchpad.setOnClickListener(v -> {
@@ -423,6 +427,7 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
 
         @Override
         public void onKeyboardVisibilityChange(boolean isVisible) {
+            mVoiceSearchButton.setEnabled(isVisible);
         }
 
         // Setup the phone UI callbacks that require access to the WindowManagerDelegate.
@@ -436,6 +441,11 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
                 mDelegate.setHeadLockEnabled(headlockButton.isChecked());
             });
 
+            findViewById(R.id.phoneUIVoiceButton).setOnClickListener(v -> {
+                // Delegate all the voice input handling in the KeyboardWidget which already handles
+                // all the potential voice input cases.
+                mDelegate.getKeyboard().simulateVoiceButtonClick();
+            });
         }
     }
 

--- a/app/src/wavevr/java/org/mozilla/vrbrowser/PlatformActivity.java
+++ b/app/src/wavevr/java/org/mozilla/vrbrowser/PlatformActivity.java
@@ -13,6 +13,7 @@ import android.content.res.AssetManager;
 import android.os.Bundle;
 import android.view.KeyEvent;
 
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.utils.SystemUtils;
 
 public class PlatformActivity extends VRActivity {
@@ -59,6 +60,8 @@ public class PlatformActivity extends VRActivity {
         // as the UI standard on this platform is to require the use of
         // the system menu to exit applications.
     }
+
+    public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
 
     protected native void queueRunnable(Runnable aRunnable);
     protected native void initializeJava(AssetManager aAssets);


### PR DESCRIPTION
This PR adds some major changes to the Phone UI in the VisionGlass. It's based in two important refactorings:
1. Decouple phone UI initialization from glasses initialization. The latter is an async process that might fail. We should not depend on that to initialize the UI widgets.
2. Introduce a new `PlatformActivityPlugin` interface that will be called by `VRBrowserActivity` to perform platform specific tasks. It's needed because the different `PlatformActivity`s are superclasses of `VRBrowserActivity` and thus don't have access to data and interface implementations of the latter.

Once these two are in place the following changes were implemented in the phone UI:
1. Added a voice search button. Only active whenever the on screen keyboard is shown, as it's the only time were it's really needed
2. Added media controls playback. Only visible when playing media. It contains a play/pause button, a mute/volume button, and a fast forward and fast backward buttons.