### PR TITLE
Allow asking the soft keyboard from outside the window widget

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
@@ -40,7 +40,7 @@ public class TextInputImpl implements WTextInput {
             EditorInfo outAttrs = new EditorInfo();
             view.onCreateInputConnection(outAttrs);
             if (mDelegate != null)
-                mDelegate.showSoftInput(mSession);
+                mDelegate.showSoftInput(mSession, (View) mSession.getContentView());
 
             // We don't take content space for the keyboard, and we report back to the ImeAdapter
             // that the keyboard was always showing.

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
@@ -92,7 +92,7 @@ public class TextInputImpl implements WTextInput {
 
             @Override
             public void showSoftInput(@NonNull GeckoSession session) {
-                mDelegate.showSoftInput(mSession);
+                mDelegate.showSoftInput(mSession, null);
             }
 
             @Override

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.view.PointerIcon;
 import android.view.Surface;
+import android.view.View;
 import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
@@ -1761,10 +1762,16 @@ public interface WSession {
          * This method is always called, even in viewless mode.
          *
          * @param session Session instance.
+         * @param requestView View requesting the soft input. This can be set to allow the soft
+         *                    keyboard to be requested from a view that exist outside a hierarchy of
+         *                    the window widget which the keyboard widget is attached to.
+         *                    If this is null, this method will treat the focused view is the window
+         *                    widget.
          * @see #hideSoftInput
          */
+
         @UiThread
-        default void showSoftInput(@NonNull final WSession session) {}
+        default void showSoftInput(@NonNull final WSession session, @Nullable View requestView) {}
 
         /**
          * Hide the soft input. May be called consecutively, even if the soft input is already hidden.

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -14,6 +14,7 @@ import android.graphics.Bitmap;
 import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Surface;
+import android.view.View;
 import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
@@ -1433,11 +1434,11 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     }
 
     @Override
-    public void showSoftInput(@NonNull WSession aSession) {
+    public void showSoftInput(@NonNull WSession aSession, @Nullable View requestView) {
         if (mState.mSession == aSession) {
             mState.mIsInputActive = true;
             for (WSession.TextInputDelegate listener : mTextInputListeners) {
-                listener.showSoftInput(aSession);
+                listener.showSoftInput(aSession, requestView);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -90,6 +90,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     private Drawable mShiftDisabledIcon;
     private Drawable mCapsLockOnIcon;
     private View mFocusedView;
+    private View mExternalFocusedView;
     private LinearLayout mKeyboardLayout;
     private RelativeLayout mKeyboardContainer;
     private WindowWidget mAttachedWindow;
@@ -1373,9 +1374,12 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     }
 
     @Override
-    public void showSoftInput(@NonNull WSession session) {
+    public void showSoftInput(@NonNull WSession session, View requestView) {
+        mExternalFocusedView = requestView;
         if (mFocusedView != mAttachedWindow || getVisibility() != View.VISIBLE || mInputRestarted) {
-            post(() -> updateFocusedView(mAttachedWindow));
+            post(() -> {
+                updateFocusedView(mAttachedWindow);
+            });
         }
         mInputRestarted = false;
     }
@@ -1409,7 +1413,10 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        updateFocusedView(newFocus);
+        if (mExternalFocusedView == newFocus)
+            updateFocusedView(mAttachedWindow);
+        else
+            updateFocusedView(newFocus);
     }
 
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1377,9 +1377,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     public void showSoftInput(@NonNull WSession session, View requestView) {
         mExternalFocusedView = requestView;
         if (mFocusedView != mAttachedWindow || getVisibility() != View.VISIBLE || mInputRestarted) {
-            post(() -> {
-                updateFocusedView(mAttachedWindow);
-            });
+            post(() -> updateFocusedView(mAttachedWindow));
         }
         mInputRestarted = false;
     }
@@ -1413,10 +1411,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (mExternalFocusedView == newFocus)
-            updateFocusedView(mAttachedWindow);
-        else
-            updateFocusedView(newFocus);
+        updateFocusedView(mExternalFocusedView == newFocus ? mAttachedWindow : newFocus);
     }
 
 


### PR DESCRIPTION
This patch fixes the issue that Chromium doesn't type nothing in the form. The problem was that the focused view notified from the system is not involved in the window widget which the keyboard widget is attached to. Since Chromium has a content view outside of the windows widget's layer, the focus view could be different with the window widget.

This patch allows asking the soft keyboard from the out side of the window widget.