### PR TITLE
Improve Vision Glass start process

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -33,7 +33,6 @@ import android.widget.SeekBar;
 import androidx.activity.ComponentActivity;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
-import androidx.lifecycle.Lifecycle;
 
 import com.google.android.material.button.MaterialButton;
 import com.huawei.usblib.DisplayMode;
@@ -252,11 +251,6 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
                 }
             }
         });
-
-        // Show the app
-        if (getLifecycle().getCurrentState() == Lifecycle.State.RESUMED) {
-            updateDisplays();
-        }
     }
 
     // SensorEventListener overrides

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -64,7 +64,7 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
     private View mVoiceSearchButton;
     private int mDisplayModeRetryCount = 0;
     private int mUSBPermissionRequestCount = 0;
-
+    private boolean mSwitchedTo3DMode = false;
 
     @SuppressWarnings("unused")
     public static boolean filterPermission(final String aPermission) {
@@ -234,10 +234,15 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
             return;
         }
 
+        // Don't try to set the 3D mode if we've already switched to it or if we're retrying.
+        if (mSwitchedTo3DMode || mDisplayModeRetryCount > 1)
+            return;
+
         VisionGlass.getInstance().setDisplayMode(DisplayMode.vr3d, new DisplayModeCallback() {
             @Override
             public void onSuccess(DisplayMode displayMode) {
                 Log.d(LOGTAG, "Successfully switched to 3D mode");
+                mSwitchedTo3DMode = true;
                 updateDisplays();
             }
 

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -65,6 +65,8 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
     private VisionGlassPresentation mActivePresentation;
     private View mVoiceSearchButton;
     private int mDisplayModeRetryCount = 0;
+    private int mUSBPermissionRequestCount = 0;
+
 
     @SuppressWarnings("unused")
     public static boolean filterPermission(final String aPermission) {
@@ -230,6 +232,11 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
 
         if (!VisionGlass.getInstance().hasUsbPermission()) {
             if (!mIsAskingForPermission) {
+                // Note that the system will ask for permissions by itself. This is just a fallback.
+                if (mUSBPermissionRequestCount++ > 1) {
+                    showAlertDialog(getString(R.string.phone_ui_usb_alert_dialog_description));
+                    return;
+                }
                 Log.d(LOGTAG, "Asking for USB permission");
                 mIsAskingForPermission = true;
                 VisionGlass.getInstance().requestUsbPermission();

--- a/app/src/visionglass/res/values/strings.xml
+++ b/app/src/visionglass/res/values/strings.xml
@@ -3,4 +3,5 @@
     <!-- Title of an alert dialog in the Phone UI -->
     <string name="phone_ui_alert_dialog_title">Error</string>
     <string name="phone_ui_set3dmode_alert_dialog_description">Failed to switch to 3D mode. Try unplugging the glasses and plugging them back and restart Wolvic.</string>
+    <string name="phone_ui_usb_alert_dialog_description">Failed to get USB permissions. Try unplugging the glasses and plugging them back and restart Wolvic.</string>
 </resources>

--- a/app/src/visionglass/res/values/strings.xml
+++ b/app/src/visionglass/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="phone_ui_alert_dialog_title">Error</string>
     <string name="phone_ui_set3dmode_alert_dialog_description">Failed to switch to 3D mode. Try unplugging the glasses and plugging them back and restart Wolvic.</string>
     <string name="phone_ui_usb_alert_dialog_description">Failed to get USB permissions. Try unplugging the glasses and plugging them back and restart Wolvic.</string>
+    <string name="phone_ui_no_presentation_display_alert_dialog_description">Failed to present in glasses. Try unplugging the glasses and plugging them back and restart Wolvic.</string>
 </resources>

--- a/app/src/visionglass/res/values/strings.xml
+++ b/app/src/visionglass/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of an alert dialog in the Phone UI -->
+    <string name="phone_ui_alert_dialog_title">Error</string>
+    <string name="phone_ui_set3dmode_alert_dialog_description">Failed to switch to 3D mode. Try unplugging the glasses and plugging them back and restart Wolvic.</string>
+</resources>


### PR DESCRIPTION
This is a large patch split in several meaningful commits. The main issues fixed by this PR are:
* Try setting the 3D mode up to 3 times in case of error
* Try requesting the USB permission twice in case of error
* Delay IMU initialization until presentation dialog is ready
* Don't try to set the 3D mode multiple times
* Reduce the amount of calls to updateDisplays to sanitize the presentation creation

Some of this changes involve the addition of modal alert dialogs that close the application in case of error. They're useful for the user as they provide information about what happened and also suggest actions to correct the problems.
