### PR TITLE
[OpenXR] Enable hand tracking motion range

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -132,6 +132,8 @@ XrResult OpenXRInputSource::Initialize()
         RETURN_IF_XR_FAILED(OpenXRExtensions::sXrCreateHandTrackerEXT(mSession, &handTrackerInfo,
                                                                       &mHandTracker));
 
+        mSupportsHandJointsMotionRangeInfo = OpenXRExtensions::IsExtensionSupported(XR_EXT_HAND_JOINTS_MOTION_RANGE_EXTENSION_NAME);
+
 #if defined(PICOXR)
         // Pico's runtime does not advertise it but it does work.
         mSupportsFBHandTrackingAim = true;
@@ -520,6 +522,12 @@ bool OpenXRInputSource::GetHandTrackingInfo(XrTime predictedDisplayTime, XrSpace
     XrHandJointsLocateInfoEXT locateInfo { XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT };
     locateInfo.baseSpace = localSpace;
     locateInfo.time = predictedDisplayTime;
+
+    if (mSupportsHandJointsMotionRangeInfo) {
+        XrHandJointsMotionRangeInfoEXT motionRangeInfo { XR_TYPE_HAND_JOINTS_MOTION_RANGE_INFO_EXT };
+        motionRangeInfo.handJointsMotionRange = XR_HAND_JOINTS_MOTION_RANGE_UNOBSTRUCTED_EXT;
+        locateInfo.next = &motionRangeInfo;
+    }
 
     XrHandJointLocationsEXT jointLocations { XR_TYPE_HAND_JOINT_LOCATIONS_EXT };
     jointLocations.jointCount = XR_HAND_JOINT_COUNT_EXT;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -73,6 +73,7 @@ private:
     bool mHasHandJoints { false };
     bool mSupportsFBHandTrackingAim { false };
     OpenXRGesturePtr mGestureManager;
+    bool mSupportsHandJointsMotionRangeInfo { false };
 
     struct HandMeshMSFT {
         XrSpace space = XR_NULL_HANDLE;


### PR DESCRIPTION
The hand tracking motion range extensions allow applications to specify the motion range of the user's hands, so that it could take better decisions when computing the hand joints poses. In our case we'll be assuming that the user is not handling anything in their hands (otherwise it'd be using the controllers). Consequently we ask the runtime to use the hands full motion range. This allows the runtime to detect a closed fist for example.