### PR TITLE
Remove assert when xrEndFrame call fails

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1162,7 +1162,7 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
       frameEndInfo.environmentBlendMode = blendMode;
       frameEndInfo.layerCount = (uint32_t) layers.size();
       frameEndInfo.layers = layers.data();
-      CHECK_XRCMD(xrEndFrame(session, &frameEndInfo));
+      MessageXrResult(xrEndFrame(session, &frameEndInfo));
   };
 
   auto canAddLayers = [&layers, maxLayers = m.systemProperties.graphicsProperties.maxLayerCount]() {


### PR DESCRIPTION
We have detected that this call fails sometimes for unknwon reasons, although the app continue operating normally. This change would allow us to get more information about the root cause.