### PR TITLE
Add a null check to Session.getUAMode()

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -963,7 +963,8 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     // Session Settings
 
     public int getUaMode() {
-        return mState.mSession.getSettings().getUserAgentMode();
+        return mState.mSession != null ? mState.mSession.getSettings().getUserAgentMode() :
+                WSessionSettings.USER_AGENT_MODE_MOBILE;
     }
 
     public boolean isActive() {


### PR DESCRIPTION
It was not protected against null sessions. This was causing crashes during the initialization process of Wolvic with the Chromium backend as in this trace:

java.lang.NullPointerException: Attempt to invoke interface method 'com.igalia.wolvic.browser.api.WSessionSettings com.igalia.wolvic.browser.api.WSession.getSettings()' on a null object reference at com.igalia.wolvic.browser.engine.Session.getUaMode(Session.java:966) at com.igalia.wolvic.ui.widgets.WindowWidget.onLoadRequest(WindowWidget.java:1996) at com.igalia.wolvic.browser.engine.Session.onLoadRequest(Session.java:1191) at com.igalia.wolvic.browser.api.impl.TabWebContentsObserver.didStartNavigationInPrimaryMainFrame(TabWebContentsObserver.java:54) at org.chromium.content.browser.webcontents.WebContentsObserverProxy.didStartNavigationInPrimaryMainFrame(WebContentsObserverProxy.java:133) at J.N.MAqmDh4t(Native Method)
at org.jni_zero.GEN_JNI.org_chromium_content_browser_framehost_NavigationControllerImpl_loadUrl(GEN_JNI.java:1800) at org.chromium.content.browser.framehost.NavigationControllerImplJni.loadUrl(NavigationControllerImplJni.java:156) at org.chromium.content.browser.framehost.NavigationControllerImpl.loadUrl(NavigationControllerImpl.java:178) at org.chromium.wolvic.Tab.loadUrl(Tab.java:91)
at com.igalia.wolvic.browser.api.impl.SessionImpl$ReadyCallback.onReady(SessionImpl.java:58) at com.igalia.wolvic.browser.api.impl.RuntimeImpl$1.lambda$onSuccess$0(RuntimeImpl.java:200) at com.igalia.wolvic.browser.api.impl.RuntimeImpl$1$$ExternalSyntheticLambda0.accept(Unknown Source:2) at java.util.ArrayList.forEach(ArrayList.java:1262) at com.igalia.wolvic.browser.api.impl.RuntimeImpl$1.onSuccess(RuntimeImpl.java:199) at org.chromium.content.browser.BrowserStartupControllerImpl.executeEnqueuedCallbacks(BrowserStartupControllerImpl.java:387) at org.chromium.content.browser.BrowserStartupControllerImpl.browserStartupComplete(BrowserStartupControllerImpl.java:65) at android.os.MessageQueue.nativePollOnce(Native Method) at android.os.MessageQueue.next(MessageQueue.java:336) at android.os.Looper.loop(Looper.java:174)