### PR TITLE
Fixes errors encountered in the NoAPI build variant

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -314,7 +314,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         // Create broadcast receiver for getting crash messages from crash process
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(CrashReporterService.CRASH_ACTION);
-        registerReceiver(mCrashReceiver, intentFilter, BuildConfig.APPLICATION_ID + "." + getString(R.string.app_permission_name), null);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            registerReceiver(mCrashReceiver, intentFilter, BuildConfig.APPLICATION_ID + "." + getString(R.string.app_permission_name), null, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            registerReceiver(mCrashReceiver, intentFilter, BuildConfig.APPLICATION_ID + "." + getString(R.string.app_permission_name), null);
+        }
 
         mLastGesture = NoGesture;
         mWidgetUpdateListeners = new LinkedList<>();

--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -61,7 +61,12 @@ public class DownloadsManager {
     }
 
     public void init() {
-        mContext.registerReceiver(mDownloadReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+        IntentFilter filter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            mContext.registerReceiver(mDownloadReceiver, filter, null, mMainHandler, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            mContext.registerReceiver(mDownloadReceiver, filter, null, mMainHandler);
+        }
         List<Download> downloads = getDownloads();
         downloads.forEach(download -> {
             File downloadedFile = download.getOutputFile();

--- a/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/OffscreenDisplay.java
@@ -98,6 +98,8 @@ public class OffscreenDisplay {
                 mDefaultMetrics.widthPixels = bounds.width();
                 mDefaultMetrics.heightPixels = bounds.height();
                 mDefaultMetrics.density = metrics.getDensity();
+                DisplayMetrics displayMetrics = mContext.getResources().getDisplayMetrics();
+                mDefaultMetrics.densityDpi = displayMetrics.densityDpi;
             } else {
                 defaultDisplay.getMetrics(mDefaultMetrics);
             }


### PR DESCRIPTION
This pr fixes #1294.

Changes made :

1. Added Context.RECEIVER_NOT_EXPORTED flag if Android version is 12 or above, In registerReceiver call in VRBrowserActivity and DownloadsManager.
2. Added a line to set densityDpi, since an error was thrown. 
`mDefaultMetrics.densityDpi = (int) metrics.getDensity() * 160`
The line just makes a simple calculation of densityDpi from density.