### PR TITLE
[Vision Glass] Use "Wolvic Vision Glass" for the app name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -318,7 +318,7 @@ android {
         visionglass {
             dimension "platform"
             applicationIdSuffix ".visionglass"
-            resValue "string", "app_name", "Wolvic Vision"
+            resValue "string", "app_name", "Wolvic Vision Glass"
             externalNativeBuild {
                 cmake {
                     cppFlags " -DVISIONGLASS"


### PR DESCRIPTION
Use "Wolvic Vision Glass" for the Huawei Vision Glass name, so it is easier to identify by users.