### PR TITLE
[Vision Glass] Dynamic realign button

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/AlignDynamicButton.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/AlignDynamicButton.java
@@ -1,0 +1,94 @@
+package com.igalia.wolvic;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.PointF;
+import android.graphics.RectF;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.button.MaterialButton;
+
+public class AlignDynamicButton extends MaterialButton {
+
+    private PointF mPointPosition = new PointF();
+    private RectF mSquareRect = new RectF();
+    private Paint mPaint;
+    private float mStrokeWidth;
+    private float mCornerRadius;
+    private float mSquarePadding;
+    private float mCirclePadding;
+
+    private final int PAINT_COLOR = 0xFFFFFFFF;
+
+    public AlignDynamicButton(@NonNull Context context) {
+        super(context);
+        init();
+    }
+
+    public AlignDynamicButton(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public AlignDynamicButton(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        // metrics
+        mStrokeWidth = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2, getResources().getDisplayMetrics());
+        mCornerRadius = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4, getResources().getDisplayMetrics());
+        mSquarePadding = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8, getResources().getDisplayMetrics());
+        mCirclePadding = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 10, getResources().getDisplayMetrics());
+
+        mPaint = new Paint();
+        mPaint.setColor(PAINT_COLOR);
+        mPaint.setStrokeWidth(mStrokeWidth);
+        mPaint.setAntiAlias(true);
+
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        // Draw square
+        mPaint.setStyle(Paint.Style.STROKE);
+        mPaint.setAlpha(150);
+        mSquareRect.set(mSquarePadding, mSquarePadding, getWidth() - mSquarePadding, getHeight() - mSquarePadding);
+
+        canvas.drawRoundRect(mSquareRect, mCornerRadius, mCornerRadius, mPaint);
+
+        // Draw circle
+        mPaint.setStyle(Paint.Style.FILL);
+        mPaint.setAlpha(255);
+        float radius = Math.min(getWidth(), getHeight()) / 10f;
+        float centerX = mCirclePadding + ((mPointPosition.x + 1) * (getWidth() - mCirclePadding) / 2f);
+        float centerY = mCirclePadding + ((mPointPosition.y + 1) * (getHeight() - mCirclePadding) / 2f);
+
+        canvas.drawCircle(centerX, centerY, radius, mPaint);
+    }
+
+    public void updatePosition(float x, float y) {
+        mPointPosition.set(Math.max(-1.0f, Math.min(1.0f, x)),
+                Math.max(-1.0f, Math.min(1.0f, y)));
+
+        invalidate();
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+        int width = MeasureSpec.getSize(widthMeasureSpec);
+        int height = MeasureSpec.getSize(heightMeasureSpec);
+        int size = Math.min(width, height);
+        setMeasuredDimension(size, size);
+    }
+}

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -197,6 +197,10 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         mVoiceSearchButton = findViewById(R.id.phoneUIVoiceButton);
         mVoiceSearchButton.setEnabled(false);
 
+        mBinding.realignButton.setOnClickListener(v -> {
+            queueRunnable(() -> calibrateController());
+        });
+
         View touchpad = findViewById(R.id.touchpad);
         touchpad.setOnClickListener(v -> {
             // We don't really need the coordinates of the click because we use the position
@@ -308,6 +312,8 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         // The quaternion is returned in the form [w, x, z, y] but we use it as [x, y, z, w].
         // See https://developer.android.com/reference/android/hardware/Sensor#TYPE_ROTATION_VECTOR
         queueRunnable(() -> setControllerOrientation(quaternion[1], quaternion[3], quaternion[2], quaternion[0]));
+
+        mBinding.realignButton.updatePosition(-quaternion[3], -quaternion[1]);
     }
 
     @Override

--- a/app/src/visionglass/res/layout/visionglass_layout.xml
+++ b/app/src/visionglass/res/layout/visionglass_layout.xml
@@ -80,8 +80,18 @@
                 app:iconGravity="textStart"
                 app:iconPadding="0dp"
                 app:iconTint="@color/white"
-                app:layout_constraintEnd_toStartOf="@id/phoneUIVoiceButton"
+                app:layout_constraintEnd_toStartOf="@id/realign_button"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.igalia.wolvic.AlignDynamicButton
+                android:id="@+id/realign_button"
+                android:layout_width="?attr/actionBarSize"
+                android:layout_height="?attr/actionBarSize"
+                android:backgroundTint="@color/azure"
+                app:iconTint="@color/white"
+                app:layout_constraintEnd_toStartOf="@id/phoneUIVoiceButton"
+                app:layout_constraintStart_toEndOf="@id/headlock_toggle_button"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.button.MaterialButton
@@ -98,7 +108,7 @@
                 app:iconPadding="0dp"
                 app:iconTint="@color/white"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/headlock_toggle_button"
+                app:layout_constraintStart_toEndOf="@id/realign_button"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <View


### PR DESCRIPTION
Add a button to realign the controller and the view.

This button displays a dynamic view of the controller's position in order to better communicate its purpose.

The circle in the button tracks the controller position, tapping the button will reset that position and place the circle in the middle again.
This functionality is not implemented in this PR.