### PR TITLE
[VisionGlass] Recenter view with first valid glasses pose

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1130,6 +1130,8 @@ BrowserWorld::StartFrame() {
       m.loader->InitializeGL();
     }
   }
+  if (!m.device->GotFirstValidPose())
+    return;
 
 #if defined(OCULUSVR)
 #if defined(STORE_BUILD)
@@ -1165,6 +1167,12 @@ BrowserWorld::StartFrame() {
     }
     TickWorld();
     m.externalVR->PushSystemState();
+  }
+
+  static int firstPaint = true;
+  if (firstPaint) {
+    firstPaint = false;
+    RecenterUIYaw(YawTarget::ALL);
   }
 }
 

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -115,6 +115,7 @@ public:
   virtual void UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
                               const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) {};
   virtual void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) {};
+  virtual bool GotFirstValidPose() const { return false; }
 
 protected:
   DeviceDelegate() {}

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
@@ -411,6 +411,11 @@ DeviceDelegateNoAPI::ControllerButtonPressed(const bool aDown) {
 
 }
 
+bool
+DeviceDelegateNoAPI::GotFirstValidPose() const {
+  return true;
+}
+
 DeviceDelegateNoAPI::DeviceDelegateNoAPI(State& aState) : m(aState) {}
 DeviceDelegateNoAPI::~DeviceDelegateNoAPI() { m.Shutdown(); }
 

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.h
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.h
@@ -41,6 +41,7 @@ public:
   void StartFrame(const FramePrediction aPrediction) override;
   void BindEye(const device::Eye) override;
   void EndFrame(const FrameEndMode aMode) override;
+  bool GotFirstValidPose() const override;
   // DeviceDelegateNoAPI interface
   void InitializeJava(JNIEnv* aEnv, jobject aActivity);
   void ShutdownJava();

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -109,6 +109,7 @@ struct DeviceDelegateOculusVR::State {
   device::CPULevel minCPULevel = device::CPULevel::Normal;
   device::DeviceType deviceType = device::UnknownType;
   float ipd = 0.0f;
+  bool gotFirstValidPose { false };
 
   void UpdatePerspective() {
     float fovX = vrapi_GetSystemPropertyFloat(&java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_X);
@@ -939,6 +940,8 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
     return;
   }
 
+  m.gotFirstValidPose = true;
+
   ovrMatrix4f matrix = vrapi_GetTransformFromPose(&m.predictedTracking.HeadPose.Pose);
   vrb::Matrix head = vrb::Matrix::FromRowMajor(matrix.M[0]);
 
@@ -1389,6 +1392,11 @@ bool
 DeviceDelegateOculusVR::ExitApp() {
   vrapi_ShowSystemUI(&m.java, VRAPI_SYS_UI_CONFIRM_QUIT_MENU);
   return true;
+}
+
+bool
+DeviceDelegateOculusVR::GotFirstValidPose() const {
+    return m.gotFirstValidPose;
 }
 
 DeviceDelegateOculusVR::DeviceDelegateOculusVR(State &aState) : m(aState) {}

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -57,6 +57,7 @@ public:
   VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) override;
   VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;
+  bool GotFirstValidPose() const override;
   // Custom methods for NativeActivity render loop based devices.
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);
   void LeaveVR();

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1593,6 +1593,11 @@ DeviceDelegateOpenXR::ShouldExitRenderLoop() const
   return m.sessionState == XR_SESSION_STATE_EXITING || m.sessionState == XR_SESSION_STATE_LOSS_PENDING;
 }
 
+bool
+DeviceDelegateOpenXR::GotFirstValidPose() const {
+  return m.firstPose.has_value();
+}
+
 DeviceDelegateOpenXR::DeviceDelegateOpenXR(State &aState) : m(aState) {}
 
 DeviceDelegateOpenXR::~DeviceDelegateOpenXR() { m.Shutdown(); }

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -64,6 +64,7 @@ public:
   void UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
                       const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) override;
   void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) override;
+  bool GotFirstValidPose() const override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -56,6 +56,7 @@ struct DeviceDelegateVisionGlass::State {
   vrb::Matrix reorientMatrix;
   crow::ElbowModelPtr elbow;
   std::unique_ptr<OneEuroFilterQuaternion> orientationFilter;
+  bool gotFirstValidPose;
   State()
       : renderMode(device::RenderMode::StandAlone)
       , headingMatrix(vrb::Matrix::Identity())
@@ -66,6 +67,7 @@ struct DeviceDelegateVisionGlass::State {
       , far(1000.0f)
       , reorientMatrix(vrb::Matrix::Identity())
       , elbow(ElbowModel::Create())
+      , gotFirstValidPose(false)
   {
       orientationFilter = std::make_unique<OneEuroFilterQuaternion>(0.1, 0.5, 1.0);
   }
@@ -345,12 +347,20 @@ DeviceDelegateVisionGlass::ControllerButtonPressed(const bool aDown) {
 void
 DeviceDelegateVisionGlass::setHead(const float aX, const float aY, const float aZ, const float aW) {
   // We need to flip the Z axis comming from the SDK to get the proper rotation.
+  if (aX == 0.0f && aY == 0.0f && aZ == 0.0f)
+    return;
+
   m.headingMatrix = vrb::Matrix::Rotation({aX,aY,-aZ,-aW});
+  m.gotFirstValidPose = true;
 }
 
 void
 DeviceDelegateVisionGlass::setControllerOrientation(const float aX, const float aY, const float aZ, const float aW) {
     m.controllerOrientation = vrb::Quaternion(aX, aY, aZ, aW);
+}
+
+bool DeviceDelegateVisionGlass::GotFirstValidPose() const {
+  return m.gotFirstValidPose;
 }
 
 DeviceDelegateVisionGlass::DeviceDelegateVisionGlass(State& aState) : m(aState) {}

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
@@ -52,6 +52,8 @@ public:
   void ControllerButtonPressed(const bool aDown);
   void setHead(const float aX, const float aY, const float aZ, const float aW);
   void setControllerOrientation(const float aX, const float aY, const float aZ, const float aW);
+  bool GotFirstValidPose() const override;
+
 protected:
   struct State;
   DeviceDelegateVisionGlass(State& aState);

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -109,6 +109,7 @@ struct DeviceDelegateWaveVR::State {
   WVR_CtrlerModel_t * modelCachedData[2];
   bool isModelDataReady[2];
   std::mutex mCachedDataMutex[2];
+  bool gotFirstValidPose;
   State()
       : isRunning(true)
       , near(0.1f)
@@ -131,6 +132,7 @@ struct DeviceDelegateWaveVR::State {
       , handsCalculated(false)
       , modelCachedData {}
       , isModelDataReady {}
+      , gotFirstValidPose(false)
   {
     memset((void*)devicePairs, 0, sizeof(WVR_DevicePosePair_t) * 2);
     memset((void*)modelCachedData, 0, sizeof(WVR_CtrlerModel_t) * 2);
@@ -281,6 +283,7 @@ struct DeviceDelegateWaveVR::State {
       immersiveDisplay->SetSittingToStandingTransform(vrb::Matrix::Translation(kAverageHeight));
       return;
     }
+    gotFirstValidPose = true;
     const float delta = ground.poseMatrix.m[1][3] - head.poseMatrix.m[1][3];
     immersiveDisplay->SetSittingToStandingTransform(vrb::Matrix::Translation(vrb::Vector(0.0f, delta, 0.0f)));
   }
@@ -1172,6 +1175,11 @@ vrb::LoadTask DeviceDelegateWaveVR::GetControllerModelTask(int32_t aModelIndex) 
 bool
 DeviceDelegateWaveVR::IsRunning() {
   return m.isRunning;
+}
+
+bool
+DeviceDelegateWaveVR::GotFirstValidPose() {
+    return m.gotFirstValidPose;
 }
 
 DeviceDelegateWaveVR::DeviceDelegateWaveVR(State& aState) : m(aState) {}

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
@@ -37,6 +37,7 @@ public:
   void BindEye(const device::Eye aWhich) override;
   void EndFrame(const FrameEndMode aMode) override;
   vrb::LoadTask GetControllerModelTask(int32_t index) override;
+  bool GotFirstValidPose() const override;
   // DeviceDelegateWaveVR interface
   bool IsRunning();
 protected:


### PR DESCRIPTION
In VisionGlass the view is not properly shown "in front of" the user in cases in which the user is moving their head while Wolvic is starting. The reasons are multiple:
1. we were incorrectly getting identity quaternions sometimes in positions where the glasses orientation was not precisely that
2. the recenter caused by setting the head lock state was not issued on time, so it was not doing anything in the practice

From now on we don't render any frame until a valid head pose is received and also we do perform a full widget recenter after the first drawn frame.