### PR TITLE
Add a new proguard rule for an AC class

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -64,9 +64,10 @@
 -keep class com.qualcomm.** {*;}
 
 # --------------------------------------------------------------------
-# App Services
+# AppServices & Components
 # --------------------------------------------------------------------
 -keep class mozilla.appservices.** {*;}
+-keep class mozilla.components.concept.engine.manifest.** {*;}
 
 # --------------------------------------------------------------------
 # Android ViewModel


### PR DESCRIPTION
We're getting crashes on release builds like this:

java.lang.ClassCastException: com.google.gson.internal.LinkedTreeMap cannot be cast to mozilla.components.concept.engine.manifest.WebAppManifest$Icon at com.igalia.wolvic.ui.views.TabView$$ExternalSyntheticLambda1.apply(SourceFile:127)

The minification process was overoptimizing a map() call in an ArrayList effectively removing the WebAppManifest class from the final package. We need to add an exception to keep it.

Fixes #1297