### PR TITLE
Remove NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,0 @@
-# Wolvic Release Notes
-
-## version 0.9.5
-* Restored Firefox Accounts synchronization. You can now sync your bookmarks and send tabs between devices running Firefox and Wolvic.
-* Ability to select a default search engine. To change your search engine, open the Settings window, select “Privacy & Security”, and then the “Edit” button that accompanies the “Search engine” option. The engine you have set will appear below the “Search engine” label.
-* Added Wolvic's privacy policy.
-* Added some changes to address 6DoF controller problems in the latest Huawei VR SDK.


### PR DESCRIPTION
It was used just for a 0.9.x release. We aren't using it so let's remove it. We might think about restoring it in the future, but at the moment is useless and outdated.

Fixes #1188