### PR TITLE
[Chromium] Update the YouTube UA override

### DIFF
--- a/app/src/chromium/assets/userAgentOverride.json
+++ b/app/src/chromium/assets/userAgentOverride.json
@@ -1,5 +1,5 @@
 {
-  "ae0755740e4354ac67025056e775ad06d8a529ae4f37244fbb02d72199e2c780311e47aa9895079b980ec4bfa676f1f39c4ab41ea995c524e52bde9a73623da2": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
-  "e6137b4c2f49a3917c2c90a50fb270a5eebb962f2c72344ae2e29e321bb21891e5ca4fec06cae78e14f4a8510473e934234e9ec3f60e8415f5f6da754c55b9b1": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36"
+  "ae0755740e4354ac67025056e775ad06d8a529ae4f37244fbb02d72199e2c780311e47aa9895079b980ec4bfa676f1f39c4ab41ea995c524e52bde9a73623da2": "Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/32.1.0.37.133.575621010 Chrome/122.0.6261.64 VR Safari/537.36",
+  "e6137b4c2f49a3917c2c90a50fb270a5eebb962f2c72344ae2e29e321bb21891e5ca4fec06cae78e14f4a8510473e934234e9ec3f60e8415f5f6da754c55b9b1": "Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/32.1.0.37.133.575621010 Chrome/122.0.6261.64 VR Safari/537.36"
 }
 


### PR DESCRIPTION
The UA we were using to instruct YouTube to offer us the immersive versions of the videos has recently stopped to work. Upgraded it to the Meta Browser latest UA which works fine.