### PR TITLE
[VisionGlass] Use mBinding to access the media seek bar

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -450,7 +450,6 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
     private class PlatformActivityPluginVisionGlass implements PlatformActivityPlugin {
         private WidgetManagerDelegate mDelegate;
         private WMediaSession.Delegate mMediaSessionDelegate;
-        private SeekBar mMediaSeekbar;
 
         PlatformActivityPluginVisionGlass(WidgetManagerDelegate delegate) {
             mDelegate = delegate;
@@ -491,7 +490,7 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
 
                 @Override
                 public void onPositionState(@NonNull WSession session, @NonNull WMediaSession mediaSession, @NonNull WMediaSession.PositionState state) {
-                    mMediaSeekbar.setProgress((int) ((state.position / state.duration) * 100), false);
+                    mBinding.mediaSeekbar.setProgress((int) ((state.position / state.duration) * 100), false);
                 }
             });
         }


### PR DESCRIPTION
In 4ccfb3ba we replaced the findViewById calls by calls to mBinding. The one for the media seek bar was not properly migrated and it was causing crashes as the object was null