### PR TITLE
HVR uses the local space for determining aim's pose

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -752,8 +752,9 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     // Pose transforms.
     bool isPoseActive { false };
     XrSpaceLocation poseLocation { XR_TYPE_SPACE_LOCATION };
-#ifdef CHROMIUM
+#if defined(CHROMIUM) && !defined(HVR)
     // Chromium's WebXR code expects aim space to be based on the grip space.
+    // FIXME: HVR doesn´t retrieve a poseLocation with a valid orientaton bit if we use the grip space.
     XrSpace baseSpace = renderMode == device::RenderMode::StandAlone ? localSpace : mGripSpace;
 #else
     XrSpace baseSpace = localSpace;


### PR DESCRIPTION
The Chromium backend expects the aim's pose to be determined based on the grip space. However, the pose returned by HVR OpenXR runtime has an invalid orientation bit, so our code assume there is no controller available. This problem causes that there is no way of dismissing the interstitial screen an entering the webxr session, as described in the issue #1329. 

This PR tries to workaround the issue by forcing the use of the local space in HVR devices, even that we know Chromium expects to be based on the grip space.

Fixes #1329 