### PR TITLE
[Vision Glass] Fix size of windows and dialogs 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -325,6 +325,7 @@ android {
                     arguments "-DVISIONGLASS=ON"
                 }
             }
+            buildConfigField "Float", "DEFAULT_DENSITY", "1.0f"
         }
 
         // Supported ABIs

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,6 +130,7 @@ android {
         buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         buildConfigField "Boolean", "SUPPORTS_SYSTEM_NOTIFICATIONS", "false"
         buildConfigField "Float", "DEFAULT_DENSITY", "1.25f"
+        buildConfigField "Float", "DEFAULT_WINDOW_DISTANCE", "0.0f"
         buildConfigField "Boolean", "ENABLE_PAGE_ZOOM", "false"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -326,6 +327,7 @@ android {
                 }
             }
             buildConfigField "Float", "DEFAULT_DENSITY", "1.0f"
+            buildConfigField "Float", "DEFAULT_WINDOW_DISTANCE", "0.5f"
         }
 
         // Supported ABIs

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -85,6 +85,7 @@ public class SettingsStore {
     public final static boolean NOTIFICATIONS_DEFAULT = true;
     public final static boolean SPEECH_DATA_COLLECTION_DEFAULT = false;
     public final static boolean SPEECH_DATA_COLLECTION_REVIEWED_DEFAULT = false;
+    public final static float WINDOW_DISTANCE_DEFAULT = 0.0f;
     public final static int UA_MODE_DEFAULT = WSessionSettings.USER_AGENT_MODE_VR;
     public final static int INPUT_MODE_DEFAULT = 1;
 
@@ -145,9 +146,6 @@ public class SettingsStore {
     public final static boolean TELEMETRY_DEFAULT = true;
 
     private int mCachedScrollDirection = -1;
-
-    private final static float WINDOW_DISTANCE_DEFAULT = 0.0f;
-    private final static float WINDOW_DISTANCE_DEFAULT_VISION_GLASS = 1.0f;
 
     private boolean mDisableLayers = false;
     public void setDisableLayers(final boolean aDisableLayers) {
@@ -416,13 +414,8 @@ public class SettingsStore {
     }
 
     @FloatRange(from = 0, to = 1)
-    public float getDefaultWindowDistance() {
-        return DeviceType.getType() == DeviceType.VisionGlass ? WINDOW_DISTANCE_DEFAULT_VISION_GLASS : WINDOW_DISTANCE_DEFAULT;
-    }
-
-    @FloatRange(from = 0, to = 1)
     public float getWindowDistance() {
-        return mPrefs.getFloat(mContext.getString(R.string.settings_key_window_distance), getDefaultWindowDistance());
+        return mPrefs.getFloat(mContext.getString(R.string.settings_key_window_distance), WINDOW_DISTANCE_DEFAULT);
     }
 
     public void setWindowDistance(@FloatRange(from = 0, to = 1) float distance) {

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -85,7 +85,7 @@ public class SettingsStore {
     public final static boolean NOTIFICATIONS_DEFAULT = true;
     public final static boolean SPEECH_DATA_COLLECTION_DEFAULT = false;
     public final static boolean SPEECH_DATA_COLLECTION_REVIEWED_DEFAULT = false;
-    public final static float WINDOW_DISTANCE_DEFAULT = 0.0f;
+    public final static float WINDOW_DISTANCE_DEFAULT = BuildConfig.DEFAULT_WINDOW_DISTANCE;
     public final static int UA_MODE_DEFAULT = WSessionSettings.USER_AGENT_MODE_VR;
     public final static int INPUT_MODE_DEFAULT = 1;
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -254,7 +254,7 @@ class DisplayOptionsView extends SettingsView {
         setLatinAutoComplete(SettingsStore.LATIN_AUTO_COMPLETE_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
         setWindowMovement(SettingsStore.WINDOW_MOVEMENT_DEFAULT, true);
-        setWindowDistance(SettingsStore.getInstance(getContext()).getDefaultWindowDistance(), true);
+        setWindowDistance(SettingsStore.WINDOW_DISTANCE_DEFAULT, true);
 
         if (mBinding.startWithPassthroughSwitch.isChecked() != SettingsStore.shouldStartWithPassthrougEnabled()) {
             setStartWithPassthrough(SettingsStore.shouldStartWithPassthrougEnabled());

--- a/app/src/visionglass/res/values/dimen.xml
+++ b/app/src/visionglass/res/values/dimen.xml
@@ -1,0 +1,9 @@
+<resources>
+    <item name="settings_world_z" format="float" type="dimen">-3.8</item>
+    <item name="browser_children_z_distance" format="float" type="dimen">0.3</item>
+    <item name="window_world_z_min" format="float" type="dimen">-4.2</item>
+    <item name="window_world_z_max" format="float" type="dimen">-6.2</item>
+    <dimen name="media_controls_world_z" format="float" type="dimen">2.5</dimen>
+    <item name="tray_world_z" format="float" type="dimen">-3.0</item>
+    <item name="keyboard_z" format="float" type="dimen">-3.0</item>
+</resources>


### PR DESCRIPTION
This PR overwrites some of the default dimensions for Vision Glass
so windows and dialogs will fit better in the small screen space available.

Vision Glass will also use a density of 1.0 by default, same as HVR.

Fixes https://github.com/Igalia/wolvic/issues/1275