### PR TITLE
Clean-up of resizing logic

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1754,16 +1754,18 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
-    public void startWidgetResize(final Widget aWidget, float aMaxWidth, float aMaxHeight, float minWidth, float minHeight) {
+    public void startWidgetResize(final WindowWidget aWidget) {
         if (aWidget == null) {
             return;
         }
         mWindows.enterResizeMode();
-        queueRunnable(() -> startWidgetResizeNative(aWidget.getHandle(), aMaxWidth, aMaxHeight, minWidth, minHeight));
+        Pair<Float, Float> maxSize = aWidget.getMaxWorldSize();
+        Pair<Float, Float> minSize = aWidget.getMinWorldSize();
+        queueRunnable(() -> startWidgetResizeNative(aWidget.getHandle(), maxSize.first, maxSize.second, minSize.first, minSize.second));
     }
 
     @Override
-    public void finishWidgetResize(final Widget aWidget) {
+    public void finishWidgetResize(final WindowWidget aWidget) {
         if (aWidget == null) {
             return;
         }
@@ -1927,11 +1929,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     public void setControllersVisible(final boolean aVisible) {
         queueRunnable(() -> setControllersVisibleNative(aVisible));
-    }
-
-    @Override
-    public void setWindowSize(float targetWidth, float targetHeight) {
-        mWindows.getFocusedWindow().resizeByMultiplier(targetWidth / targetHeight, 1.0f);
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -103,7 +103,7 @@ public class SettingsStore {
     public final static int WINDOW_HEIGHT_DEFAULT = 450;
     // The maximum size is computed so the resulting texture fits within 2560x2560.
     public final static int MAX_WINDOW_WIDTH_DEFAULT = 1200;
-    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 675;
+    public final static int MAX_WINDOW_HEIGHT_DEFAULT = 800;
 
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1307,10 +1307,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
     private void startWidgetResize() {
         if (mAttachedWindow != null) {
-            final float aspect = (float) mAttachedWindow.getWindowWidth() / (float) mAttachedWindow.getWindowHeight();
-            Pair<Float, Float> maxSize = mAttachedWindow.getSizeForScale(mAttachedWindow.getMaxWindowScale(), aspect);
-            Pair<Float, Float> minSize = mAttachedWindow.getSizeForScale(0.5f, aspect);
-            mWidgetManager.startWidgetResize(mAttachedWindow, maxSize.first, maxSize.second, minSize.first, minSize.second);
+            mWidgetManager.startWidgetResize(mAttachedWindow);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -70,8 +70,8 @@ public interface WidgetManagerDelegate {
     void updateWidgetsPlacementTranslationZ();
     void updateVisibleWidgets();
     void recreateWidgetSurface(Widget aWidget);
-    void startWidgetResize(Widget aWidget, float maxWidth, float maxHeight, float minWidth, float minHeight);
-    void finishWidgetResize(Widget aWidget);
+    void startWidgetResize(WindowWidget aWidget);
+    void finishWidgetResize(WindowWidget aWidget);
     void startWidgetMove(Widget aWidget, @WidgetMoveBehaviourFlags int aMoveBehaviour);
     void finishWidgetMove();
     void addUpdateListener(@NonNull UpdateListener aUpdateListener);
@@ -83,7 +83,6 @@ public interface WidgetManagerDelegate {
     void popWorldBrightness(Object aKey);
     void triggerHapticFeedback();
     void setControllersVisible(boolean visible);
-    void setWindowSize(float targetWidth, float targetHeight);
     void keyboardDismissed();
     void updateEnvironment();
     void updatePointerColor();


### PR DESCRIPTION
Clean-up of our resizing logic to make it more consistent and to remove some edge cases. This logic is now mostly encapsulated inside of `WindowWidget`.

Manual mode allows the window to be resized freely within the allowed boundaries. The maximum width depends on the number of active windows. The maximum height has been increased slightly to accommodate vertical videos better.

`WindowWidget.getSizeForScale()` is used to resize the window when using one of the preset sizes and when entering fullscreen. It will keep the window size within the boundaries while trying to preserve the current aspect ratio.