### PR TITLE
Default value for `WidgetPlacement.layer`

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetPlacement.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetPlacement.java
@@ -38,6 +38,7 @@ public class WidgetPlacement {
     public WidgetPlacement(Context aContext) {
         mConext = aContext;
         density = aContext.getResources().getDisplayMetrics().density;
+        layer = SettingsStore.getInstance(mConext).getLayersEnabled();
         updateCylinderMapRadius();
         textureScale = SettingsStore.getInstance(aContext).getDisplayDpi() / 100.0f;
     }


### PR DESCRIPTION
The default value for `WidgetPlacement.layer` will use the current value from the `SettingsStore`, which depends on the platform.

This prevents us from accidentally using layers where they are not well supported.