### PR TITLE
Auto-generate app version code

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ useDebugSigningOnRelease=true
 
 Note: the release APKs generated with a debug keystore can't be used for production.
 
+## Generate builds with a static version code
+
+By default, each build will be assigned an auto-generated version code, which is derived from the date when the build was created. This behavior interferes with Gradle's caching mechanism and unnecessarily re-runs tasks that depend on the version code, leading to longer build times. You can work around this by temporarily using a static version code that persists between builds. This can be done by setting this property in your `user.properties` file:
+
+```ini
+useStaticVersionCode=true
+```
+
 ## Compress assets
 
 ETC2 compression is used to improve performance and memory usage. Raw assets are placed in the `uncompressed_assets` folder. You can generate the compressed textures using the compressor utility in `tools/compressor`. You need to set up [etc2comp](https://github.com/google/etc2comp) and make it available on your PATH before running the script. Run this command to generate the compressed assets:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,13 @@ def getGitHash = { ->
     return stdout.toString().trim()
 }
 
+def shouldUseStaticVersionCode = { ->
+    if (gradle.hasProperty("userProperties.useStaticVersionCode")) {
+        return gradle."userProperties.useStaticVersionCode" == "true"
+    }
+    return false
+}
+
 def getCrashRestartDisabled = { ->
     if (gradle.hasProperty("userProperties.disableCrashRestart")) {
         return gradle."userProperties.disableCrashRestart"
@@ -200,6 +207,14 @@ android {
         }
     }
 
+    applicationVariants.configureEach { variant ->
+        variant.outputs.each { output ->
+            if (shouldUseStaticVersionCode()) {
+                // Overrides any build created with a generated version code from now to 2115
+                output.versionCodeOverride = 1_99_365_2300
+            }
+        }
+    }
 
     flavorDimensions "platform", "abi", "backend", "store"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,7 +119,7 @@ android {
         applicationId "com.igalia.wolvic"
         minSdkVersion build_versions.min_sdk
         targetSdkVersion build_versions.target_sdk
-        versionCode 350
+        versionCode generatedVersionCode
         versionName "1.7"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
         buildConfigField "Boolean", "DISABLE_CRASH_RESTART", getCrashRestartDisabled()


### PR DESCRIPTION
Closes #977 

I also introduced and documented a property in `user.properties` to enable switching between static and auto-generated version code. Using a static version code leads to more cache efficiency as Gradle tasks that depend on the version code wouldn't have to re-run and can use the cached task results. 

https://developer.android.com/build/optimize-your-build#use_static_build_properties