### PR TITLE
[Chromium] Open the new window with WebContents

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabImpl.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 
 import org.chromium.content_public.browser.MediaSessionObserver;
 import org.chromium.content_public.browser.SelectionPopupController;
+import org.chromium.content_public.browser.WebContents;
 import org.chromium.wolvic.Tab;
 
 /**
@@ -16,8 +17,8 @@ public class TabImpl extends Tab {
     private TabWebContentsDelegate mTabWebContentsDelegate;
     private TabWebContentsObserver mWebContentsObserver;
 
-    public TabImpl(@NonNull Context context, @NonNull SessionImpl session) {
-        super(context, session.getSettings().getUsePrivateMode());
+    public TabImpl(@NonNull Context context, @NonNull SessionImpl session, WebContents webContents) {
+        super(context, session.getSettings().getUsePrivateMode(), webContents);
         registerCallbacks(session);
     }
 


### PR DESCRIPTION
This patch changes the opening new window's parameter as WebContents to keep the parent/child window's connection.