### PR TITLE
[OpenXR] Add support for XR_FB_keyboard_tracking and XR_FB_render_model

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -20,6 +20,10 @@
     <uses-feature android:name="oculus.software.trackedkeyboard" android:required="false" />
     <uses-permission android:name="com.oculus.permission.TRACKED_KEYBOARD" />
 
+    <!-- Tell the system this app uses render model extensions -->
+    <uses-feature android:name="com.oculus.feature.RENDER_MODEL" android:required="true" />
+    <uses-permission android:name="com.oculus.permission.RENDER_MODEL" />
+
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -16,6 +16,10 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
+    <!-- Tell the system this app can handle tracked keyboards -->
+    <uses-feature android:name="oculus.software.trackedkeyboard" android:required="false" />
+    <uses-permission android:name="com.oculus.permission.TRACKED_KEYBOARD" />
+
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -15,6 +15,10 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
+    <!-- Tell the system this app can handle tracked keyboards -->
+    <uses-feature android:name="oculus.software.trackedkeyboard" android:required="false" />
+    <uses-permission android:name="com.oculus.permission.TRACKED_KEYBOARD" />
+
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -19,6 +19,10 @@
     <uses-feature android:name="oculus.software.trackedkeyboard" android:required="false" />
     <uses-permission android:name="com.oculus.permission.TRACKED_KEYBOARD" />
 
+    <!-- Tell the system this app uses render model extensions -->
+    <uses-feature android:name="com.oculus.feature.RENDER_MODEL" android:required="true" />
+    <uses-permission android:name="com.oculus.permission.RENDER_MODEL" />
+
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1539,6 +1539,7 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
     m.controllersReadyCallback();
     m.controllersReadyCallback = nullptr;
   }
+  m.input->SetKeyboardTrackingEnabled(m.keyboardTrackingSupported);
 
   vrb::RenderContextPtr context = m.context.lock();
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1557,7 +1557,7 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
     m.controllersReadyCallback();
     m.controllersReadyCallback = nullptr;
   }
-  m.input->SetKeyboardTrackingEnabled(m.keyboardTrackingSupported);
+  m.input->SetKeyboardTrackingEnabled(m.keyboardTrackingSupported && m.renderModelLoadingSupported);
 
   vrb::RenderContextPtr context = m.context.lock();
 

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -23,6 +23,9 @@ PFN_xrCreateHandMeshSpaceMSFT OpenXRExtensions::sXrCreateHandMeshSpaceMSFT = nul
 PFN_xrUpdateHandMeshMSFT OpenXRExtensions::sXrUpdateHandMeshMSFT = nullptr;
 PFN_xrCreateKeyboardSpaceFB OpenXRExtensions::xrCreateKeyboardSpaceFB = nullptr;
 PFN_xrQuerySystemTrackedKeyboardFB OpenXRExtensions::xrQuerySystemTrackedKeyboardFB = nullptr;
+PFN_xrEnumerateRenderModelPathsFB OpenXRExtensions::sXrEnumerateRenderModelPathsFB = nullptr;
+PFN_xrGetRenderModelPropertiesFB OpenXRExtensions::sXrGetRenderModelPropertiesFB = nullptr;
+PFN_xrLoadRenderModelFB OpenXRExtensions::sXrLoadRenderModelFB = nullptr;
 
 void OpenXRExtensions::Initialize() {
     // Extensions.
@@ -116,6 +119,15 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
                                         reinterpret_cast<PFN_xrVoidFunction *>(&xrCreateKeyboardSpaceFB)));
         CHECK_XRCMD(xrGetInstanceProcAddr(instance,"xrQuerySystemTrackedKeyboardFB",
                                         reinterpret_cast<PFN_xrVoidFunction *>(&xrQuerySystemTrackedKeyboardFB)));
+    }
+
+    if (IsExtensionSupported(XR_FB_RENDER_MODEL_EXTENSION_NAME)) {
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrEnumerateRenderModelPathsFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrEnumerateRenderModelPathsFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrGetRenderModelPropertiesFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrGetRenderModelPropertiesFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrLoadRenderModelFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrLoadRenderModelFB)));
     }
 }
 

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -21,6 +21,8 @@ PFN_xrCreatePassthroughLayerFB OpenXRExtensions::sXrCreatePassthroughLayerFB = n
 PFN_xrDestroyPassthroughLayerFB OpenXRExtensions::sXrDestroyPassthroughLayerFB = nullptr;
 PFN_xrCreateHandMeshSpaceMSFT OpenXRExtensions::sXrCreateHandMeshSpaceMSFT = nullptr;
 PFN_xrUpdateHandMeshMSFT OpenXRExtensions::sXrUpdateHandMeshMSFT = nullptr;
+PFN_xrCreateKeyboardSpaceFB OpenXRExtensions::xrCreateKeyboardSpaceFB = nullptr;
+PFN_xrQuerySystemTrackedKeyboardFB OpenXRExtensions::xrQuerySystemTrackedKeyboardFB = nullptr;
 
 void OpenXRExtensions::Initialize() {
     // Extensions.
@@ -107,6 +109,13 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
                                           reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreatePassthroughLayerFB)));
         CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrDestroyPassthroughLayerFB",
                                           reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyPassthroughLayerFB)));
+    }
+
+    if (IsExtensionSupported(XR_FB_KEYBOARD_TRACKING_EXTENSION_NAME)) {
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrCreateKeyboardSpaceFB",
+                                        reinterpret_cast<PFN_xrVoidFunction *>(&xrCreateKeyboardSpaceFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance,"xrQuerySystemTrackedKeyboardFB",
+                                        reinterpret_cast<PFN_xrVoidFunction *>(&xrQuerySystemTrackedKeyboardFB)));
     }
 }
 

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -36,6 +36,10 @@ namespace crow {
 
     static PFN_xrCreateHandMeshSpaceMSFT sXrCreateHandMeshSpaceMSFT;
     static PFN_xrUpdateHandMeshMSFT sXrUpdateHandMeshMSFT;
+
+    static PFN_xrCreateKeyboardSpaceFB xrCreateKeyboardSpaceFB;
+    static PFN_xrQuerySystemTrackedKeyboardFB xrQuerySystemTrackedKeyboardFB;
+
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
      static std::unordered_set<std::string> sSupportedApiLayers;

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -40,6 +40,9 @@ namespace crow {
     static PFN_xrCreateKeyboardSpaceFB xrCreateKeyboardSpaceFB;
     static PFN_xrQuerySystemTrackedKeyboardFB xrQuerySystemTrackedKeyboardFB;
 
+    static PFN_xrEnumerateRenderModelPathsFB sXrEnumerateRenderModelPathsFB;
+    static PFN_xrGetRenderModelPropertiesFB sXrGetRenderModelPropertiesFB;
+    static PFN_xrLoadRenderModelFB sXrLoadRenderModelFB;
   private:
      static std::unordered_set<std::string> sSupportedExtensions;
      static std::unordered_set<std::string> sSupportedApiLayers;

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -23,7 +23,19 @@ typedef std::shared_ptr<HandMeshBuffer> HandMeshBufferPtr;
 
 class OpenXRInput {
 private:
+  struct KeyboardTrackingFB {
+    XrKeyboardTrackingDescriptionFB description;
+    XrSpace space = XR_NULL_HANDLE;
+    XrSpaceLocation location;
+    ~KeyboardTrackingFB() {
+      if (space != XR_NULL_HANDLE)
+        xrDestroySpace(space);
+    }
+  };
+  typedef std::unique_ptr<KeyboardTrackingFB> KeyboardTrackingFBPtr;
+
   OpenXRInput(XrInstance, XrSession, XrSystemProperties, ControllerDelegate& delegate);
+  void UpdateTrackedKeyboard(const XrFrameState& frameState, XrSpace baseSpace);
 
   OpenXRInputMapping* GetActiveInputMapping() const;
 
@@ -32,6 +44,7 @@ private:
   XrSystemProperties mSystemProperties;
   std::vector<OpenXRInputSourcePtr> mInputSources;
   OpenXRActionSetPtr mActionSet;
+  KeyboardTrackingFBPtr keyboardTrackingFB { nullptr };
 
 public:
   static OpenXRInputPtr Create(XrInstance, XrSession, XrSystemProperties, ControllerDelegate& delegate);
@@ -43,6 +56,7 @@ public:
   bool AreControllersReady() const;
   void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
   HandMeshBufferPtr GetNextHandMeshBuffer(const int32_t aControllerIndex);
+  void SetKeyboardTrackingEnabled(bool enabled);
   ~OpenXRInput();
 };
 

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -27,15 +27,19 @@ private:
     XrKeyboardTrackingDescriptionFB description;
     XrSpace space = XR_NULL_HANDLE;
     XrSpaceLocation location;
+    std::vector<uint8_t> modelBuffer;
+    bool modelBufferChanged;
     ~KeyboardTrackingFB() {
       if (space != XR_NULL_HANDLE)
         xrDestroySpace(space);
+      modelBuffer.clear();
     }
   };
   typedef std::unique_ptr<KeyboardTrackingFB> KeyboardTrackingFBPtr;
 
   OpenXRInput(XrInstance, XrSession, XrSystemProperties, ControllerDelegate& delegate);
   void UpdateTrackedKeyboard(const XrFrameState& frameState, XrSpace baseSpace);
+  void LoadKeyboardModel();
 
   OpenXRInputMapping* GetActiveInputMapping() const;
 


### PR DESCRIPTION
https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_keyboard_tracking

This series implements both XR_FB_keyboard_tracking and XR_FB_render_model.

A new class `TrackedKeyboardRenderer` is added to draw the keyboard, but it is only boilerplate for the moment, pending to add a new library that can handle KTX2 textures, and a new glTF loader that allows loading the textures externally.

This class follows the same logic as `HandMeshRenderer`: data is updated on every world tick by calling into OpenXR backend, and the result is drawn on every frame via `TrackedKeyboardRenderer::Draw()`.