### PR TITLE
Set the current WebContent in the session's settings

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -57,6 +57,7 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
             assert mTab == null;
             mTab = new TabImpl(
                     mRuntime.getContainerView().getContext(), SessionImpl.this);
+            mSettings.setWebContents(mTab.getContentView().getWebContents());
             if (mInitialUri != null) {
                 mTab.loadUrl(mInitialUri);
                 mInitialUri = null;

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SettingsImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SettingsImpl.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.api.WSessionSettings;
 
+import org.chromium.content_public.browser.WebContents;
 import org.chromium.wolvic.SessionSettings;
 
 public class SettingsImpl implements WSessionSettings {
@@ -121,6 +122,11 @@ public class SettingsImpl implements WSessionSettings {
     @Override
     public String getUserAgentOverride() {
         return mSessionSettings.getUserAgentOverride();
+    }
+
+    @Override
+    public void setWebContents(@Nullable WebContents webContents) {
+        mSessionSettings.setWebContents(webContents);
     }
 
     public String getDefaultUserAgent(int mode) {

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSessionSettings.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSessionSettings.java
@@ -4,6 +4,8 @@ import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.browser.api.impl.SettingsImpl;
 
+import org.chromium.content_public.browser.WebContents;
+
 public interface WSessionSettings {
 
     static WSessionSettings create(boolean usePrivateMode) {
@@ -167,4 +169,6 @@ public interface WSessionSettings {
      * @return The current user agent string or null if the agent is specified by ISessionSettings#USER_AGENT_MODE}
      */
     @Nullable String getUserAgentOverride();
+
+    void setWebContents(final @Nullable WebContents webContents);
 }


### PR DESCRIPTION
The UA override needs to be propagated to the WebContents, so we need to assign the current's tab web content into the session's settings.