### PR TITLE
Remove the passthrough layer when entering immersive

### DIFF
--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -100,6 +100,7 @@ private:
 #if defined(OCULUSVR) && defined(STORE_BUILD)
   void ProcessOVRPlatformEvents();
 #endif
+  void resetPassthroughLayerIfNeeded();
   State& m;
   BrowserWorld() = delete;
   VRB_NO_DEFAULTS(BrowserWorld)


### PR DESCRIPTION
Some platforms (like Meta) implement passthrough via an special compositor layer called the passthrough layer. This passthrough layer is only added to the list of layers for the compositor when in non immersive mode. This means that should not visible inside immersive experiences. However that was not true for some experiences like Moonrider.

In order to make it work properly we need to destroy that layer when entering immersive and recreate it (if needed) when getting back to standalone mode.

Fixes #1351