### PR TITLE
Fix deprecations in build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -217,8 +217,6 @@ android {
         }
     }
 
-    flavorDimensions "platform", "abi", "backend", "store"
-
     productFlavors {
         // Supported platforms
         oculusvr {
@@ -608,6 +606,7 @@ android {
 
 
     buildFeatures {
+        flavorDimensions = [ "platform", "abi", "backend", "store" ]
         viewBinding true
         prefab true // enable prefab support for various SDK AAR
         dataBinding true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -587,8 +587,9 @@ android {
         }
     }
 
-    sourceSets.all {
+    sourceSets.configureEach { sourceSet ->
         // oculusvr needs a specific manifest file by its buildtype.
+        def name = sourceSet.name
         if (name.startsWith('oculusvr')) {
            if (name.toLowerCase().contains('debug')) {
                 manifest.srcFile "src/oculusvrArmDebug/AndroidManifest.xml"
@@ -816,7 +817,7 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
 // MLS: Read token from local file if it exists
 // -------------------------------------------------------------------------------------------------
 
-android.applicationVariants.all { variant ->
+android.applicationVariants.configureEach { variant ->
     try {
         def token = new File("${rootDir}/.mls_token").text.trim()
         buildConfigField 'String', 'MLS_TOKEN', '"' + token + '"'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 apply plugin: 'com.android.application'
 apply from: "$project.rootDir/tools/gradle/versionCode.gradle"
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
 // Apply AGConnect plugin only for Hvr builds

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,7 @@ ext.gleanGenerateMarkdownDocs = true
 ext.gleanDocsDirectory = "$rootDir/docs"
 
 android {
+    namespace 'com.igalia.wolvic'
     compileSdkVersion build_versions.compile_sdk
     defaultConfig {
         applicationId "com.igalia.wolvic"
@@ -611,19 +612,16 @@ android {
         prefab true // enable prefab support for various SDK AAR
         dataBinding true
     }
-    namespace 'com.igalia.wolvic'
-    androidResources {
-        noCompress 'ja'
-        // TODO: This statement should be moved under 'chromium' dimension or removed. So far, these
-        // options are affected to every variants when`isChromiumAvailable()` is true.
-        if (isChromiumAvailable()) {
-            noCompress 'dat'
-            noCompress 'bin'
-            noCompress 'pak'
-        }
-    }
+
     lint {
         disable 'ExtraTranslation'
+    }
+
+    aaptOptions {
+        noCompress 'ja'
+        noCompress 'dat'
+        noCompress 'bin'
+        noCompress 'pak'
     }
 }
 


### PR DESCRIPTION
This PR addresses several warnings in the build.gradle file
* flavorDimensions is deprecated
* noCompress is deprecated
* dataBinding requires a plugin
* .all() is deprecated of favour of .configureEach()