### PR TITLE
Add support for tracked keyboards via OpenXR's XR_FB_keyboard_tracking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 	path = app/src/main/cpp/tinygltf
 	url = https://github.com/Igalia/tinygltf.git
 	branch = igalia.com/wolvic
+[submodule "app/src/KTX-Software"]
+	path = app/src/KTX-Software
+	url = https://github.com/KhronosGroup/KTX-Software.git
+	branch = 4.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,6 @@
 	url = https://github.com/Igalia/tinygltf.git
 	branch = igalia.com/wolvic
 [submodule "app/src/KTX-Software"]
-	path = app/src/KTX-Software
+	path = app/src/main/cpp/KTX-Software
 	url = https://github.com/KhronosGroup/KTX-Software.git
 	branch = 4.2

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library( # Sets the name of the library.
              src/main/cpp/Pointer.cpp
              src/main/cpp/Skybox.cpp
              src/main/cpp/SplashAnimation.cpp
+             src/main/cpp/TrackedKeyboardRenderer.cpp
              src/main/cpp/VRBrowser.cpp
              src/main/cpp/VRVideo.cpp
              src/main/cpp/VRLayer.cpp

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -207,6 +207,11 @@ target_sources(native-lib PUBLIC
 include_directories(
     ${CMAKE_SOURCE_DIR}/../app/src/main/cpp/tinygltf)
 
+# Add dependency on KTX-Software
+add_subdirectory(${CMAKE_SOURCE_DIR}/src/KTX-Software)
+target_link_libraries(native-lib ktx_read)
+target_include_directories(native-lib PRIVATE ${CMAKE_SOURCE_DIR}/src/KTX-Software/include)
+
 # Specifies libraries CMake should link to your target library. You
 # can link multiple libraries, such as libraries you define in this
 # build script, prebuilt third-party libraries, or system libraries.

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -209,9 +209,9 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/../app/src/main/cpp/tinygltf)
 
 # Add dependency on KTX-Software
-add_subdirectory(${CMAKE_SOURCE_DIR}/src/KTX-Software)
+add_subdirectory(${CMAKE_SOURCE_DIR}/src/main/cpp/KTX-Software)
 target_link_libraries(native-lib ktx_read)
-target_include_directories(native-lib PRIVATE ${CMAKE_SOURCE_DIR}/src/KTX-Software/include)
+target_include_directories(native-lib PRIVATE ${CMAKE_SOURCE_DIR}/src/main/cpp/KTX-Software/include)
 
 # Specifies libraries CMake should link to your target library. You
 # can link multiple libraries, such as libraries you define in this

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             android:name="com.igalia.wolvic.VRBrowserActivity"
             android:launchMode="singleInstance"
             android:exported="true"
-            android:configChanges="density|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
+            android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
             android:windowSoftInputMode="stateAlwaysHidden">
             <!-- Declares Wolvic as a browser app -->
             <intent-filter>

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -13,6 +13,7 @@
 #include "GestureDelegate.h"
 #include "VRLayer.h"
 #include "vrb/LoaderThread.h"
+#include "vrb/Matrix.h"
 
 #include <memory>
 
@@ -61,6 +62,11 @@ public:
   enum class ImmersiveXRSessionType {
       VR,
       AR
+  };
+  struct TrackedKeyboardInfo {
+      bool isActive;
+      vrb::Matrix transform;
+      std::vector<uint8_t> modelBuffer;
   };
   virtual device::DeviceType GetDeviceType() { return device::UnknownType; }
   virtual void SetRenderMode(const device::RenderMode aMode) = 0;
@@ -130,6 +136,7 @@ public:
   };
   virtual void SetPointerMode(const PointerMode) {};
   virtual void SetImmersiveBlendMode(device::BlendMode) {};
+  virtual bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) { return false; };
 
 protected:
   DeviceDelegate() {}

--- a/app/src/main/cpp/TrackedKeyboardRenderer.cpp
+++ b/app/src/main/cpp/TrackedKeyboardRenderer.cpp
@@ -1,0 +1,435 @@
+/* -*- Mode: C++; tab-width: 20; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "DeviceUtils.h"
+#include "TrackedKeyboardRenderer.h"
+
+#include "vrb/Camera.h"
+#include "vrb/ConcreteClass.h"
+#include "vrb/GLError.h"
+#include "vrb/Matrix.h"
+#include "vrb/ProgramFactory.h"
+#include "vrb/ShaderUtil.h"
+#include "vrb/Transform.h"
+#include "vrb/gl.h"
+
+#include <ktx.h>
+
+namespace crow {
+
+namespace {
+const char* sVertexShader = R"SHADER(
+precision highp float;
+
+uniform mat4 u_perspective;
+uniform mat4 u_view;
+uniform mat4 u_model;
+
+attribute vec3 a_position;
+attribute vec3 a_normal;
+attribute vec2 a_texcoord;
+
+varying vec4 v_color;
+varying vec2 v_texcoord;
+
+struct Light {
+  vec3 direction;
+  vec4 ambient;
+  vec4 diffuse;
+  vec4 specular;
+};
+
+struct Material {
+  vec4 ambient;
+  vec4 diffuse;
+  vec4 specular;
+  float specularExponent;
+};
+
+const Light u_lights = Light(
+  vec3(1.0, -1.0, 0.0),
+  vec4(0.25, 0.25, 0.25, 1.0),
+  vec4(0.25, 0.25, 0.25, 1.0),
+  vec4(0.4, 0.4, 0.4, 1.0)
+);
+
+const Material u_material = Material(
+  vec4(0.5, 0.5, 0.5, 1.0),
+  vec4(0.5, 0.5, 0.5, 1.0),
+  vec4(0.5, 0.5, 0.5, 1.0),
+  0.75
+);
+
+vec4 calculate_light(vec4 norm, Light light, Material material) {
+  vec4 result = vec4(0.0, 0.0, 0.0, 0.0);
+  vec4 direction = -normalize(u_view * vec4(light.direction.xyz, 0.0));
+  vec4 hvec;
+  float ndotl;
+  float ndoth;
+  result += light.ambient * material.ambient;
+  ndotl = max(0.0, dot(norm, direction));
+  result += (ndotl * light.diffuse * material.diffuse);
+  hvec = normalize(direction + vec4(0.0, 0.0, 1.0, 0.0));
+  ndoth = dot(norm, hvec);
+  if (ndoth > 0.0) {
+    result += (pow(ndoth, material.specularExponent) * material.specular * light.specular);
+  }
+  return result;
+}
+
+void main(void) {
+  vec4 pos = vec4(a_position, 1.0);
+  gl_Position = u_perspective * u_view * u_model * pos;
+
+  vec4 normal = vec4(a_normal, 0.0);
+  normal = normalize(u_model * normal);
+  v_color = calculate_light(normal, u_lights, u_material);
+
+  v_texcoord = a_texcoord;
+}
+)SHADER";
+
+const char* sFragmentShader = R"SHADER(
+precision mediump float;
+
+uniform sampler2D u_sampler;
+
+varying vec4 v_color;
+varying vec2 v_texcoord;
+
+void main() {
+  vec4 tex = texture2D(u_sampler, v_texcoord);
+  gl_FragColor = vec4(mix(v_color.xyz, tex.xyz, 0.65), 1.0);
+}
+)SHADER";
+}
+
+struct GLTFModel {
+    tinygltf::Model gltf;
+    ktxTexture* ktxTex { nullptr };
+    int indicesAttrIndex { -1 };
+    int positionAttrIndex { -1 };
+    int normalAttrIndex { -1 };
+    int texcoordAttrIndex { -1 };
+
+    ~GLTFModel() {
+        for (auto& bufferObj: bufferObjs) {
+            if (bufferObj)
+                glDeleteBuffers(1, &bufferObj);
+        }
+        if (tex)
+            glDeleteTextures(1, &tex);
+        if (ktxTex)
+            ktxTexture_Destroy(ktxTex);
+    }
+    void Draw(GLint positionAttrLocation, GLint normalAttrLocation, GLint texcoordAttrLocation);
+private:
+    GLuint tex { 0 };
+    GLuint texTarget { 0 };
+    std::vector<GLuint> bufferObjs;
+
+    void InitializeGL();
+    void UploadAttributeBuffer(GLuint targetBuffer, int attrIndex);
+    void SetupAttribute(GLint location, int attrIndex);
+};
+
+void GLTFModel::UploadAttributeBuffer(GLuint targetBuffer, int attrIndex) {
+    auto& accessor = gltf.accessors[attrIndex];
+    auto& bufferView = gltf.bufferViews[accessor.bufferView];
+    auto& buffer = gltf.buffers[bufferView.buffer];
+
+    auto stride = accessor.ByteStride(gltf.bufferViews[accessor.bufferView]);
+    auto attrSize = accessor.byteOffset + accessor.count * stride;
+
+    auto& bufferObj = bufferObjs[bufferView.buffer];
+    if (bufferObj == 0) {
+        VRB_GL_CHECK(glGenBuffers(1, &bufferObj));
+        glBindBuffer(targetBuffer, bufferObj);
+        glBufferData(targetBuffer, buffer.data.size(), buffer.data.data(), GL_STATIC_DRAW);
+    }
+}
+
+static int GetNumComponentsInType(const int type) {
+    switch (type) {
+        case TINYGLTF_TYPE_VEC2: return 2;
+        case TINYGLTF_TYPE_VEC3: return 3;
+        default: {
+            break;
+        }
+    }
+    return -1;
+}
+
+static int GetGLComponentType(const int componentType) {
+    switch (componentType) {
+        case TINYGLTF_COMPONENT_TYPE_FLOAT: return GL_FLOAT;
+        default: {
+            break;
+        }
+    }
+    return GL_NONE;
+}
+
+void GLTFModel::SetupAttribute(GLint location, int attrIndex) {
+    auto& accessor = gltf.accessors[attrIndex];
+    auto& bufferView = gltf.bufferViews[accessor.bufferView];
+    auto& bufferObj = bufferObjs[bufferView.buffer];
+    auto stride = accessor.ByteStride(gltf.bufferViews[accessor.bufferView]);
+    auto offset = bufferView.byteOffset + accessor.byteOffset;
+
+    GLuint componentType = GetGLComponentType(accessor.componentType);
+    GLuint numComponents = GetNumComponentsInType(accessor.type);
+
+    VRB_GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, bufferObj));
+    VRB_GL_CHECK(glEnableVertexAttribArray((GLuint) location));
+    VRB_GL_CHECK(glVertexAttribPointer((GLuint) location, numComponents, componentType,
+                                       GL_FALSE, stride, (void*) offset));
+}
+
+void GLTFModel::InitializeGL() {
+    bufferObjs.resize(gltf.buffers.size(), 0);
+
+    // Lazily upload the KTX texture to the GPU
+    if (ktxTex && !tex) {
+        GLenum glError;
+        auto result = ktxTexture_GLUpload(ktxTex, &tex, &texTarget, &glError);
+        if (result != KTX_SUCCESS) {
+            VRB_LOG("XR_FB_keyboard_tracking: Error uploading KTX texture: (%u) %s", result,
+                    ktxErrorString(result));
+            assert(tex == 0);
+            return;
+        }
+        VRB_LOG("XR_FB_keyboard_tracking: KTX texture loaded successfully");
+    }
+
+    UploadAttributeBuffer(GL_ELEMENT_ARRAY_BUFFER, indicesAttrIndex);
+    UploadAttributeBuffer(GL_ARRAY_BUFFER, positionAttrIndex);
+    UploadAttributeBuffer(GL_ARRAY_BUFFER, normalAttrIndex);
+    UploadAttributeBuffer(GL_ARRAY_BUFFER, texcoordAttrIndex);
+
+    glFlush();
+}
+
+void GLTFModel::Draw(GLint positionAttrLocation, GLint normalAttrLocation, GLint texcoordAttrLocation) {
+    if (bufferObjs.size() == 0)
+        InitializeGL();
+
+    if (tex > 0) {
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(texTarget, tex);
+    }
+
+    SetupAttribute(positionAttrLocation, positionAttrIndex);
+    SetupAttribute(normalAttrLocation, normalAttrIndex);
+    SetupAttribute(texcoordAttrLocation, texcoordAttrIndex);
+
+    auto& accessor = gltf.accessors[indicesAttrIndex];
+    auto& bufferView = gltf.bufferViews[accessor.bufferView];
+    auto& bufferObj = bufferObjs[bufferView.buffer];
+    auto offset = bufferView.byteOffset + accessor.byteOffset;
+    VRB_GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bufferObj));
+    VRB_GL_CHECK(glDrawElements(GL_TRIANGLES, accessor.count, GL_UNSIGNED_SHORT, (void*) offset));
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+
+struct TrackedKeyboardRenderer::State {
+    bool visible { false };
+    vrb::Matrix transform { vrb::Matrix::Identity() };
+
+    GLuint vertexShader { 0 };
+    GLuint fragmentShader { 0 };
+    GLuint program { 0 };
+    GLint aPosition { -1 };
+    GLint aNormal { -1 };
+    GLint aTexcoord { -1 };
+    GLint uPerspective { -1 };
+    GLint uView { -1 };
+    GLint uModel { -1 };
+    GLint uSampler { -1 };
+
+    std::unique_ptr<GLTFModel> model { nullptr };
+};
+
+TrackedKeyboardRenderer::TrackedKeyboardRenderer(State& aState, vrb::CreationContextPtr& aContext)
+    : m(aState) {
+}
+
+TrackedKeyboardRendererPtr TrackedKeyboardRenderer::Create(vrb::CreationContextPtr& aContext) {
+    return std::make_unique<vrb::ConcreteClass<TrackedKeyboardRenderer, TrackedKeyboardRenderer::State> >(aContext);
+}
+
+TrackedKeyboardRenderer::~TrackedKeyboardRenderer() {
+    if (m.model != nullptr)
+        m.model.reset();
+
+    if (m.program)
+        VRB_GL_CHECK(glDeleteProgram(m.program));
+    if (m.vertexShader)
+        VRB_GL_CHECK(glDeleteShader(m.vertexShader));
+    if (m.vertexShader)
+        VRB_GL_CHECK(glDeleteShader(m.fragmentShader));
+}
+
+void TrackedKeyboardRenderer::SetTransform(const vrb::Matrix& transform) {
+    m.transform = transform;
+}
+
+bool TrackedKeyboardRenderer::ImageLoaderCallback(tinygltf::Image*, const int, std::string*, std::string*,
+                                                  int, int, const unsigned char* data, int dataSize,
+                                                  void* user_pointer)
+{
+    ktxTexture** ktxTex = (ktxTexture**) user_pointer;
+
+    assert(*ktxTex == nullptr);
+
+    auto result = ktxTexture_CreateFromMemory(data, dataSize, KTX_TEXTURE_CREATE_NO_FLAGS,
+                                              ktxTex);
+    if (result != KTX_SUCCESS) {
+        VRB_LOG("XR_FB_keyboard_tracking: Error creating KTX texture: (%u) %s", result,
+                ktxErrorString(result));
+        return false;
+    }
+
+    if (ktxTexture_NeedsTranscoding(*ktxTex)) {
+        result = ktxTexture2_TranscodeBasis((ktxTexture2*)*ktxTex, KTX_TTF_ETC, 0);
+        if (result != KTX_SUCCESS) {
+            VRB_LOG("XR_FB_keyboard_tracking: Error transcoding KTX texture: (%u) %s", result,
+                    ktxErrorString(result));
+            ktxTexture_Destroy(*ktxTex);
+            *ktxTex = nullptr;
+            return false;
+        }
+    }
+
+    VRB_LOG("XR_FB_keyboard_tracking: KTX texture created successfully");
+
+    return true;
+}
+
+bool TrackedKeyboardRenderer::LoadKeyboardMesh(const std::vector<uint8_t>& modelBuffer) {
+    // Destroy any previous model
+    if (m.model != nullptr) {
+        m.model.reset();
+        m.model = nullptr;
+    }
+
+    GLTFModel gltfModel;
+    tinygltf::TinyGLTF modelLoader;
+    auto& model = gltfModel.gltf;
+    std::string err;
+    std::string warn;
+    ktxTexture* ktxTex = nullptr;
+
+    modelLoader.SetImageLoader(&TrackedKeyboardRenderer::ImageLoaderCallback, &ktxTex);
+
+    if (!modelLoader.LoadBinaryFromMemory(&model, &err, &warn, modelBuffer.data(), modelBuffer.size())) {
+        VRB_ERROR("XR_FB_keyboard_tracking: Error loading keyboard model: %s", err.c_str());
+        return false;
+    }
+
+    if (!warn.empty())
+        VRB_WARN("%s", warn.c_str());
+
+    if (model.meshes.size() == 0)
+        return false;
+    // Assume the first mesh
+    auto& mesh = model.meshes[0];
+
+    if (mesh.primitives.size() == 0)
+        return false;
+    // Assume the first primitive of the mesh
+    auto& primitive = mesh.primitives[0];
+
+    // Load indices
+    if (primitive.indices < 0 || primitive.indices >= model.accessors.size())
+        return false;
+    gltfModel.indicesAttrIndex = primitive.indices;
+
+    // Load vertex attributes
+    for (auto& attr: primitive.attributes) {
+        if (attr.second >= model.accessors.size())
+            return false;
+
+        if (attr.first == "POSITION") {
+            gltfModel.positionAttrIndex = attr.second;
+        } else if (attr.first == "NORMAL") {
+            gltfModel.normalAttrIndex = attr.second;
+        } else if (attr.first == "TEXCOORD_0") {
+            gltfModel.texcoordAttrIndex = attr.second;
+        }
+    }
+
+    if (gltfModel.positionAttrIndex == -1 || gltfModel.normalAttrIndex == -1 || gltfModel.texcoordAttrIndex == -1)
+        return false;
+
+    m.model = std::make_unique<GLTFModel>(gltfModel);
+    m.model->ktxTex = ktxTex;
+
+    VRB_LOG("XR_FB_keyboard_tracking: Keyboard model loaded successfully");
+
+    return true;
+}
+
+void TrackedKeyboardRenderer::SetVisible(const bool aVisible) {
+    m.visible = aVisible;
+}
+
+bool TrackedKeyboardRenderer::InitializeGL() {
+    m.vertexShader = vrb::LoadShader(GL_VERTEX_SHADER, sVertexShader);
+    m.fragmentShader = vrb::LoadShader(GL_FRAGMENT_SHADER, sFragmentShader);
+    assert(m.vertexShader && m.fragmentShader);
+    m.program = vrb::CreateProgram(m.vertexShader, m.fragmentShader);
+    if (!m.program) {
+        VRB_ERROR("XR_FB_keyboard_tracking: Error creating GL program");
+        return false;
+    }
+
+    m.aPosition = vrb::GetAttributeLocation(m.program, "a_position");
+    m.aNormal = vrb::GetAttributeLocation(m.program, "a_normal");
+    m.aTexcoord = vrb::GetAttributeLocation(m.program, "a_texcoord");
+
+    m.uPerspective = vrb::GetUniformLocation(m.program, "u_perspective");
+    m.uView = vrb::GetUniformLocation(m.program, "u_view");
+    m.uModel = vrb::GetUniformLocation(m.program, "u_model");
+    m.uSampler = vrb::GetUniformLocation(m.program, "u_sampler");
+    VRB_GL_CHECK(glUniform1i(m.uSampler, 0));
+
+    glFlush();
+
+    return true;
+}
+
+void TrackedKeyboardRenderer::Draw(const vrb::Camera& aCamera) {
+    if (!m.visible || m.model == nullptr)
+        return;
+
+    if (!m.program) {
+        if (!InitializeGL())
+            return;
+    }
+
+    VRB_GL_CHECK(glUseProgram(m.program));
+
+    const auto depthTestEnabled = glIsEnabled(GL_DEPTH_TEST);
+    if (!depthTestEnabled)
+        VRB_GL_CHECK(glEnable(GL_DEPTH_TEST));
+
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_BLEND);
+
+    VRB_GL_CHECK(glUniformMatrix4fv(m.uPerspective, 1, GL_FALSE, aCamera.GetPerspective().Data()));
+    VRB_GL_CHECK(glUniformMatrix4fv(m.uView, 1, GL_FALSE, aCamera.GetView().Data()));
+    VRB_GL_CHECK(glUniformMatrix4fv(m.uModel, 1, GL_FALSE, m.transform.Data()));
+
+    m.model->Draw(m.aPosition, m.aNormal, m.aTexcoord);
+
+    if (!depthTestEnabled)
+        VRB_GL_CHECK(glDisable(GL_DEPTH_TEST));
+}
+
+};

--- a/app/src/main/cpp/TrackedKeyboardRenderer.h
+++ b/app/src/main/cpp/TrackedKeyboardRenderer.h
@@ -1,0 +1,37 @@
+/* -*- Mode: C++; tab-width: 20; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include "vrb/CreationContext.h"
+#include "vrb/Vector.h"
+#include "vrb/gl.h"
+#include <vector>
+#include "tiny_gltf.h"
+
+namespace crow {
+
+class TrackedKeyboardRenderer;
+typedef std::unique_ptr<TrackedKeyboardRenderer> TrackedKeyboardRendererPtr;
+
+class TrackedKeyboardRenderer {
+protected:
+    struct State;
+    State& m;
+    TrackedKeyboardRenderer(State&, vrb::CreationContextPtr&);
+public:
+    static TrackedKeyboardRendererPtr Create(vrb::CreationContextPtr&);
+    bool LoadKeyboardMesh(const std::vector<uint8_t>& modelBuffer);
+    void SetTransform(const vrb::Matrix&);
+    void SetVisible(const bool);
+    void Draw(const vrb::Camera& aCamera);
+    ~TrackedKeyboardRenderer();
+private:
+    bool InitializeGL();
+    static bool ImageLoaderCallback(tinygltf::Image*, const int, std::string*, std::string*, int, int,
+                                    const unsigned char* data, int dataSize, void* user_pointer);
+};
+
+};

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1599,6 +1599,10 @@ void DeviceDelegateOpenXR::SetHitDistance(const float distance) {
   m.furthestHitDistance = std::max(distance, m.furthestHitDistance);
 }
 
+bool DeviceDelegateOpenXR::PopulateTrackedKeyboardInfo(DeviceDelegate::TrackedKeyboardInfo& keyboardInfo) {
+  return m.input->PopulateTrackedKeyboardInfo(keyboardInfo);
+}
+
 void
 DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
   // Reset reorientation after Enter VR

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -68,6 +68,7 @@ public:
   void SetHitDistance(const float) override;
   void SetPointerMode(const PointerMode mode) override;
   bool IsPassthroughEnabled() const override;
+  bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -228,7 +228,8 @@ void OpenXRInput::UpdateTrackedKeyboard(const XrFrameState& frameState, XrSpace 
       keyboardTrackingFB->space = XR_NULL_HANDLE;
     }
     bzero(&keyboardTrackingFB->description, sizeof(keyboardTrackingFB->description));
-    keyboardTrackingFB->modelBuffer.resize(0);
+    keyboardTrackingFB->modelBuffer.clear();
+    keyboardTrackingFB->modelBufferChanged = false;
   }
 
   // Bail-out if no keyboard exists
@@ -270,6 +271,35 @@ void OpenXRInput::SetKeyboardTrackingEnabled(bool enabled) {
     keyboardTrackingFB.reset();
     keyboardTrackingFB = nullptr;
   }
+}
+
+bool OpenXRInput::PopulateTrackedKeyboardInfo(DeviceDelegate::TrackedKeyboardInfo& keyboardInfo) {
+  if (keyboardTrackingFB == nullptr)
+    return false;
+
+  if (keyboardTrackingFB->description.trackedKeyboardId == 0 || keyboardTrackingFB->space == nullptr ||
+      keyboardTrackingFB->modelBuffer.size() == 0) {
+    return false;
+  }
+
+  // Only report keyboard as active (be shown to the user) if it is connected and actively tracked.
+  keyboardInfo.isActive =
+    (keyboardTrackingFB->description.flags & XR_KEYBOARD_TRACKING_CONNECTED_BIT_FB) != 0 &&
+    (keyboardTrackingFB->location.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT) != 0 &&
+    (keyboardTrackingFB->location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT) != 0;
+
+  // Copy the model buffer over only if it has changed
+  if (keyboardTrackingFB->modelBufferChanged) {
+    keyboardInfo.modelBuffer = keyboardTrackingFB->modelBuffer;
+    keyboardTrackingFB->modelBufferChanged = false;
+  } else {
+    keyboardInfo.modelBuffer.resize(0);
+  }
+
+  keyboardInfo.transform = XrPoseToMatrix(keyboardTrackingFB->location.pose);
+  keyboardInfo.transform.TranslateInPlace(kAverageHeight);
+
+  return true;
 }
 
 OpenXRInput::~OpenXRInput() {

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -2,6 +2,7 @@
 
 #include "vrb/Forward.h"
 #include "OpenXRHelpers.h"
+#include "DeviceDelegate.h"
 #include "ControllerDelegate.h"
 #include "OneEuroFilter.h"
 #include "DeviceDelegate.h"
@@ -67,6 +68,7 @@ public:
   void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
   HandMeshBufferPtr GetNextHandMeshBuffer(const int32_t aControllerIndex);
   void SetKeyboardTrackingEnabled(bool enabled);
+  bool PopulateTrackedKeyboardInfo(DeviceDelegate::TrackedKeyboardInfo& keyboardInfo);
   ~OpenXRInput();
   void InitializeEyeGaze(ControllerDelegate&);
   void InitializeEyeGazeSpaces();


### PR DESCRIPTION
This patch integrates Wolvic's BrowserWorld with the keyboard tracking functionality already present in OpenXR backend.

A build-time dependency on KTX-Software suite is added, to use libktx library which allows us to decode KTX2 textures (Oculus's OpenXR runtime is currently giving textures in KTX2 format via the render model extension).
    
A new class TrackedKeyboardRenderer is added to load the keyboard model using tinygltf and libktx; and draw the keyboard in the scene using a OpenGL(ES) directly. I tried to encapsulate the glTF model loading and rendering as much as possible, thinking in possibly making it a stand-alone, generic model class in the future; that can be added to `vrb` and used to replace all our other models. But that would require a significantly larger effort.

There is one issue which I spent quite some time debugging but didn't manage to solve: While in Wolvic, if the keyboard is turned on or off using its physical button, Wolvic closes. At first I thought it was a crash, but there is no sign of a crash in the traces (logcat), nor I found any error in the lifetime cycle of the objects that would point to a bug. So my conclusion is that the Oculus system is shutting down Wolvic whenever the keyboard connects/disconnects from the system. 