### PR TITLE
Fix all tests in EnvironmentsTest

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ if (getGradle().getStartParameter().getTaskRequests().toString() =~ /(h|H)vr/) {
     apply plugin: 'com.huawei.agconnect'
 }
 
-deps.telemetry.glean_unittests = "org.mozilla.telemetry:glean-native-forUnitTests:$project.ext.glean_version"
+deps.telemetry.glean_unittests = "org.mozilla.telemetry:glean-native-forUnitTests:$versions.mozilla_glean"
 
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()

--- a/app/src/test/java/com/igalia/wolvic/EnvironmentsTest.kt
+++ b/app/src/test/java/com/igalia/wolvic/EnvironmentsTest.kt
@@ -15,7 +15,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
 
-// TODO: Fix all these tests or just remove all of them
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = TestApplication::class)
 class EnvironmentsTest {
@@ -47,7 +46,7 @@ class EnvironmentsTest {
     @Test
     fun `Environments for a target version`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/targetVersionEnvs.json"))
-        val env = EnvironmentUtils.getExternalEnvironments(context, "11")
+        val env = EnvironmentUtils.getExternalEnvironments(context, "1")
         assertNotNull(env)
         assertEquals(env.size, 2)
     }
@@ -55,7 +54,7 @@ class EnvironmentsTest {
     @Test
     fun `Environments do not exist for a target version, we fallback to the most recent ones`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/previousVersionEnvs.json"))
-        val env = EnvironmentUtils.getExternalEnvironments(context, "12")
+        val env = EnvironmentUtils.getExternalEnvironments(context, "2")
         assertNotNull(env)
         assertEquals(env.size, 2)
     }
@@ -63,85 +62,87 @@ class EnvironmentsTest {
     @Test
     fun `Environment exist for the target version`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/targetVersionEnvs.json"))
-        val env = EnvironmentUtils.getExternalEnvironmentById(context, "space", "11")
+        val env = EnvironmentUtils.getExternalEnvironmentById(context, "wolvic", "1")
         assertNotNull(env)
-        assertEquals(env?.value, "space")
-        assertEquals(env?.title, "Space")
-        assertEquals(env?.thumbnail, "https://mixedreality.mozilla.org/FirefoxReality/envs/space/thumbnail.jpg")
-        assertEquals(env?.payload, "https://mixedreality.mozilla.org/FirefoxReality/envs/space/space.zip")
+        assertEquals(env?.value, "wolvic")
+        assertEquals(env?.title, "Wolvic")
+        assertEquals(env?.thumbnail, "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/thumbnail.jpg")
+        assertEquals(env?.payload, "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/space.zip")
     }
 
     @Test
     fun `Environment does not exist for the target version, we fallback to the most recent one`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/previousVersionEnvs.json"))
-        val env = EnvironmentUtils.getExternalEnvironmentById(context, "space", "12")
+        val env = EnvironmentUtils.getExternalEnvironmentById(context, "wolvic", "2")
         assertNotNull(env)
-        assertEquals(env?.value, "space")
-        assertEquals(env?.title, "Space")
-        assertEquals(env?.thumbnail, "https://mixedreality.mozilla.org/FirefoxReality/envs/space/thumbnail.jpg")
-        assertEquals(env?.payload, "https://mixedreality.mozilla.org/FirefoxReality/envs/space/space.zip")
+        assertEquals(env?.value, "wolvic")
+        assertEquals(env?.title, "Wolvic")
+        assertEquals(env?.thumbnail, "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/thumbnail.jpg")
+        assertEquals(env?.payload, "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/space.zip")
     }
 
     @Test
     fun `Environment does not exist for any version`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/testNoEnvs.json"))
-        val env = EnvironmentUtils.getExternalEnvironmentById(context, "test", "12")
+        val env = EnvironmentUtils.getExternalEnvironmentById(context, "test", "2")
         assertNull(env)
     }
 
     @Test
     fun `Environment by payload url`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/targetVersionEnvs.json"))
-        val env = EnvironmentUtils.getExternalEnvironmentByPayload(context, "https://mixedreality.mozilla.org/FirefoxReality/envs/space/space.zip", "11")
+        val env = EnvironmentUtils.getExternalEnvironmentByPayload(context, "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/space.zip", "11")
         assertNotNull(env)
-        assertEquals(env?.value, "space")
-        assertEquals(env?.title, "Space")
-        assertEquals(env?.thumbnail, "https://mixedreality.mozilla.org/FirefoxReality/envs/space/thumbnail.jpg")
-        assertEquals(env?.payload, "https://mixedreality.mozilla.org/FirefoxReality/envs/space/space.zip")
+        assertEquals(env?.value, "wolvic")
+        assertEquals(env?.title, "Wolvic")
+        assertEquals(env?.thumbnail, "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/thumbnail.jpg")
+        assertEquals(env?.payload, "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/space.zip")
     }
 
     @Test
     fun `Environment is builtin`() {
         assertTrue(EnvironmentUtils.isBuiltinEnvironment(context, "void"))
-        assertTrue(EnvironmentUtils.isBuiltinEnvironment(context, "offworld"))
+        assertTrue(EnvironmentUtils.isBuiltinEnvironment(context, "wolvic"))
+        assertTrue(EnvironmentUtils.isBuiltinEnvironment(context, "cyberpunk"))
     }
 
     @Test
     fun `Environment is external`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/targetVersionEnvs.json"))
-        val isExternal = EnvironmentUtils.isExternalEnvironment(context, "space", "11")
+        val isExternal = EnvironmentUtils.isExternalEnvironment(context, "wolvic", "1")
         assertTrue(isExternal)
     }
 
     @Test
     fun `Environment is not external`() {
         settingStore.setRemoteProperties(TestFileUtils.readTextFile(javaClass.classLoader!!,"environments/testNoEnvs.json"))
-        val isExternal = EnvironmentUtils.isExternalEnvironment(context, "space", "11")
+        val isExternal = EnvironmentUtils.isExternalEnvironment(context, "wolvic", "1")
         assertFalse(isExternal)
     }
 
     @Test
     fun `External environment path`() {
-        var path = context.getExternalFilesDir(EnvironmentUtils.ENVS_FOLDER)
-        assertNotNull(path)
-        path = File(path, "space")
+        val cacheDir = context.cacheDir.absolutePath
+        assertNotNull(cacheDir)
+
+        val path = File(cacheDir, EnvironmentUtils.ENVS_FOLDER + "/wolvic")
         assertNotNull(path)
 
-        val actualPath = EnvironmentUtils.getExternalEnvPath(context, "space")
+        val actualPath = EnvironmentUtils.getExternalEnvPath(context, "wolvic")
         assertNotNull(actualPath)
 
-        assertEquals(actualPath, path.absolutePath)
+        assertEquals(path.absolutePath, actualPath)
     }
 
     @Test
     fun `External environment is not ready`() {
-        val isReady = EnvironmentUtils.isExternalEnvReady(context, "space")
+        val isReady = EnvironmentUtils.isExternalEnvReady(context, "wolvic")
         assertFalse(isReady)
     }
 
     @Test
     fun `External environment is ready`() {
-        val actualPath = EnvironmentUtils.getExternalEnvPath(context, "space")
+        val actualPath = EnvironmentUtils.getExternalEnvPath(context, "wolvic")
         assertNotNull(actualPath)
 
         // We just check that there are 6 files in the directory to determine that the env is ready
@@ -154,7 +155,7 @@ class EnvironmentsTest {
             assertTrue(file.createNewFile())
         }
 
-        val isReady = EnvironmentUtils.isExternalEnvReady(context, "space")
+        val isReady = EnvironmentUtils.isExternalEnvReady(context, "wolvic")
         assertTrue(isReady)
     }
 

--- a/app/src/test/resources/environments/previousVersionEnvs.json
+++ b/app/src/test/resources/environments/previousVersionEnvs.json
@@ -5,9 +5,18 @@
       {
         "value": "wolvic",
         "title": "Wolvic",
+        "thumbnail": "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/thumbnail.jpg",
+        "payload": "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/space.zip"
+      },
+      {
+        "value": "meadow",
+        "title": "Meadow",
         "thumbnail": "https://mixedreality.mozilla.org/FirefoxReality/envs/meadow/thumbnail.jpg",
         "payload": "https://mixedreality.mozilla.org/FirefoxReality/envs/meadow/space.zip"
       }
     ]
+  },
+  "2": {
+    "whatsNewUrl": "https://blog.mozvr.com/firefox-reality-11/"
   }
 }

--- a/app/src/test/resources/environments/targetVersionEnvs.json
+++ b/app/src/test/resources/environments/targetVersionEnvs.json
@@ -5,9 +5,18 @@
       {
         "value": "wolvic",
         "title": "Wolvic",
+        "thumbnail": "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/thumbnail.jpg",
+        "payload": "https://mixedreality.mozilla.org/FirefoxReality/envs/wolvic/space.zip"
+      },
+      {
+        "value": "meadow",
+        "title": "Meadow",
         "thumbnail": "https://mixedreality.mozilla.org/FirefoxReality/envs/meadow/thumbnail.jpg",
         "payload": "https://mixedreality.mozilla.org/FirefoxReality/envs/meadow/space.zip"
       }
     ]
+  },
+  "2": {
+    "whatsNewUrl": "https://blog.mozvr.com/firefox-reality-11/"
   }
 }

--- a/app/src/test/resources/environments/testNoEnvs.json
+++ b/app/src/test/resources/environments/testNoEnvs.json
@@ -1,5 +1,5 @@
 {
-    "11": {
+    "1": {
       "whatsNewUrl": "https://wolvic.com",
       "environments": [
       ]

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     apply from: 'versions.gradle'
     addRepos(repositories)
     dependencies {
-        classpath "org.mozilla.telemetry:glean-gradle-plugin:56.1.0"
+        classpath "org.mozilla.telemetry:glean-gradle-plugin:$versions.mozilla_glean"
         classpath "com.android.tools.build:gradle:$versions.android_gradle_plugin"
         classpath 'com.android.tools:r8:8.3.37'
         classpath "$deps.kotlin.plugin"

--- a/versions.gradle
+++ b/versions.gradle
@@ -28,6 +28,7 @@ versions.gecko_view_release = "121.0.20240108143603"
 versions.gecko_view_nightly = "121.0.20231120095246"
 versions.gecko_view_beta = "121.0.20231208091859"
 versions.android_components = "121.1.0"
+versions.mozilla_glean = "55.0.0"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.
 // The version number below tracks the application-services version


### PR DESCRIPTION
## Summary

The `glean-native-forUnitTests` and `glean-gradle-plugin` versions were updated to `55.0.0` to address an issue where running tests resulted in a `java.lang.UnsatisfiedLinkError: Error looking up function 'ffi_glean_uniffi_contract_version'` exception. Following this, I conducted adjustments to the JSON and unit tests through trial and error until they all passed successfully. 

I also went through the deleted changes in this commit https://github.com/Igalia/wolvic/commit/0a9ca17590db25da22283c618c50c3a1be0a125a which I think what made the tests fail to understand the expected behavior of the tests.

The choice of version 55.0.0 was based on its compatibility with Mozilla android components v121. For context: https://github.com/mozilla-mobile/firefox-android/blob/979fbe8d7fe04a9b09fe657bb787fda6f4d5ab42/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt#L46

![image](https://github.com/Igalia/wolvic/assets/21198231/79a9ea87-d225-467a-8186-e4fda015e6d7)
