### PR TITLE
[VisionGlass] Add scroll gesture to the phone touchpad

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
+++ b/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
@@ -1,6 +1,25 @@
 package com.igalia.wolvic;
 
-public interface PlatformActivityPlugin {
-    void onKeyboardVisibilityChange(boolean isVisible);
-    void onVideoAvailabilityChange();
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class PlatformActivityPlugin {
+    public interface PlatformActivityPluginListener {
+        void onPlatformScrollEvent(float distanceX, float distanceY);
+    }
+    abstract void onKeyboardVisibilityChange(boolean isVisible);
+    abstract void onVideoAvailabilityChange();
+    void registerListener(PlatformActivityPluginListener listener) {
+        if (mListeners == null)
+            mListeners = new ArrayList<>();
+        mListeners.add(listener);
+    }
+    void unregisterListener(PlatformActivityPluginListener listener) {
+        mListeners.remove(listener);
+    }
+    void notifyOnScrollEvent(float distanceX, float distanceY) {
+        for (PlatformActivityPluginListener listener : mListeners)
+            listener.onPlatformScrollEvent(distanceX, distanceY);
+    }
+    private List<PlatformActivityPluginListener> mListeners;
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2544,5 +2544,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="tray_wifi_unavailable_ssid">SSID unavailable</string>
     <!-- Tooltip for the battery level when using a tethered device instead of a headset -->
     <string name="tray_status_phone">Phone: %1$s</string>
+    <string name="vision_glass_touchpad_instructions">Tap to click. Swipe to scroll</string>
 
 </resources>

--- a/app/src/visionglass/res/layout/visionglass_layout.xml
+++ b/app/src/visionglass/res/layout/visionglass_layout.xml
@@ -111,18 +111,31 @@
                 app:layout_constraintStart_toEndOf="@id/realign_button"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <View
-                android:id="@+id/touchpad"
+            <FrameLayout
+                android:id="@+id/touchpad_container"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:background="@drawable/touchpad_ripple_bg"
                 android:clickable="true"
                 android:focusable="true"
                 app:layout_constraintBottom_toTopOf="@id/media_controls"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/headlock_toggle_button" />
-
+                app:layout_constraintTop_toBottomOf="@id/headlock_toggle_button">
+                <View
+                    android:id="@+id/touchpad"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@drawable/touchpad_ripple_bg"
+                    android:clickable="true"
+                    android:focusable="true"/>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:clickable="false"
+                    android:focusable="false"
+                    android:text="@string/vision_glass_touchpad_instructions"/>
+            </FrameLayout>
             <LinearLayout
                 android:id="@+id/media_controls"
                 android:layout_width="match_parent"
@@ -133,7 +146,7 @@
                 android:orientation="vertical"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/touchpad"
+                app:layout_constraintTop_toBottomOf="@id/touchpad_container"
                 app:visibleGone="@{viewModel.isPlayingMedia}">
 
                 <SeekBar


### PR DESCRIPTION
From now on users can scroll web pages by scrolling on the touchpad of the phone UI. This involved a set of changes:

1. Migrate from onTouchEvent() to GestureManager.onTouchEvent(). Instead of handling the low level UP/DOWN events the code will deal with onScroll, onSingleTap events recognized by the GestureManager. Due to this change scrolling via tap and tilt the controller (phone) is no longer possible.
2. Convert PlatformActivityPlugin into an abstract class. This was done to allow some method implementations. We added a new interface implemented by VRBrowserActivity to get scroll notifications from the platform plugins.
3. Use the current event generation machinery to deliver a scroll event to the Web widget. Note that WindowWidget was modified to prevent scroll events to reach the widget if it isn't hovered.