### PR TITLE
[OpenXr] Update layers with reorient information

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1175,15 +1175,17 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
       return;
   }
 
+  XrPosef reorientPose = MatrixToXrPose(GetReorientTransform());
+
   // Add skybox or passthrough layer
   if (mIsPassthroughEnabled) {
       if (m.passthroughLayer && m.passthroughLayer->IsDrawRequested() && m.IsPassthroughLayerReady()) {
-          m.passthroughLayer->Update(m.localSpace, predictedPose, XR_NULL_HANDLE);
+          m.passthroughLayer->Update(m.localSpace, reorientPose, XR_NULL_HANDLE);
           layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&m.passthroughLayer->xrCompositionLayer));
           m.passthroughLayer->ClearRequestDraw();
       }
   } else if (m.cubeLayer && m.cubeLayer->IsLoaded() && m.cubeLayer->IsDrawRequested()) {
-    m.cubeLayer->Update(m.localSpace, predictedPose, XR_NULL_HANDLE);
+    m.cubeLayer->Update(m.localSpace, reorientPose, XR_NULL_HANDLE);
     for (uint32_t i = 0; i < m.cubeLayer->HeaderCount(); ++i) {
       layers.push_back(m.cubeLayer->Header(i));
     }
@@ -1192,7 +1194,7 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
 
   // Add VR video layer
   if (m.equirectLayer && m.equirectLayer->IsDrawRequested()) {
-    m.equirectLayer->Update(m.localSpace, predictedPose, XR_NULL_HANDLE);
+    m.equirectLayer->Update(m.localSpace, reorientPose, XR_NULL_HANDLE);
     for (uint32_t i = 0; i < m.equirectLayer->HeaderCount(); ++i) {
       layers.push_back(m.equirectLayer->Header(i));
     }
@@ -1207,7 +1209,7 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
   // Add back UI layers
   for (const OpenXRLayerPtr& layer: m.uiLayers) {
     if (!layer->GetDrawInFront() && layer->IsDrawRequested() && canAddLayers()) {
-      layer->Update(m.layersSpace, predictedPose, XR_NULL_HANDLE);
+      layer->Update(m.layersSpace, reorientPose, XR_NULL_HANDLE);
       for (uint32_t i = 0; i < layer->HeaderCount() && canAddLayers(); ++i) {
         layers.push_back(layer->Header(i));
       }
@@ -1242,7 +1244,7 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
   // Add front UI layers
   for (const OpenXRLayerPtr& layer: m.uiLayers) {
     if (layer->GetDrawInFront() && layer->IsDrawRequested() && canAddLayers()) {
-      layer->Update(m.layersSpace, predictedPose, XR_NULL_HANDLE);
+      layer->Update(m.layersSpace, reorientPose, XR_NULL_HANDLE);
       for (uint32_t i = 0; i < layer->HeaderCount() && canAddLayers(); ++i) {
         layers.push_back(layer->Header(i));
       }

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -33,8 +33,8 @@ OpenXRLayerQuad::Init(JNIEnv * aEnv, XrSession session, vrb::RenderContextPtr& a
 }
 
 void
-OpenXRLayerQuad::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain)  {
-  OpenXRLayerSurface<VRLayerQuadPtr, XrCompositionLayerQuad>::Update(aSpace, aPose, aClearSwapChain);
+OpenXRLayerQuad::Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain)  {
+  OpenXRLayerSurface<VRLayerQuadPtr, XrCompositionLayerQuad>::Update(aSpace, aReorientPose, aClearSwapChain);
 
   const uint numXRLayers = GetNumXRLayers();
   for (int i = 0; i < numXRLayers; ++i) {
@@ -75,8 +75,8 @@ OpenXRLayerCylinder::Init(JNIEnv * aEnv, XrSession session, vrb::RenderContextPt
 }
 
 void
-OpenXRLayerCylinder::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain)  {
-  OpenXRLayerSurface<VRLayerCylinderPtr, XrCompositionLayerCylinderKHR>::Update(aSpace, aPose, aClearSwapChain);
+OpenXRLayerCylinder::Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain)  {
+  OpenXRLayerSurface<VRLayerCylinderPtr, XrCompositionLayerCylinderKHR>::Update(aSpace, aReorientPose, aClearSwapChain);
 
   const uint numXRLayers = GetNumXRLayers();
   for (int i = 0; i < numXRLayers; ++i) {
@@ -155,8 +155,8 @@ OpenXRLayerCube::IsLoaded() const {
 }
 
 void
-OpenXRLayerCube::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain)  {
-  OpenXRLayerBase<VRLayerCubePtr, XrCompositionLayerCubeKHR>::Update(aSpace, aPose, aClearSwapChain);
+OpenXRLayerCube::Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain)  {
+  OpenXRLayerBase<VRLayerCubePtr, XrCompositionLayerCubeKHR>::Update(aSpace, aReorientPose, aClearSwapChain);
 
   const uint numXRLayers = GetNumXRLayers();
   for (uint i = 0; i < numXRLayers; ++i) {
@@ -205,17 +205,17 @@ OpenXRLayerEquirect::IsDrawRequested() const {
 }
 
 void
-OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) {
+OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) {
   OpenXRLayerPtr source = sourceLayer.lock();
   if (source) {
     swapchain = source->GetSwapChain();
   }
-  OpenXRLayerBase<VRLayerEquirectPtr, XrCompositionLayerEquirectKHR>::Update(aSpace, aPose, aClearSwapChain);
+  OpenXRLayerBase<VRLayerEquirectPtr, XrCompositionLayerEquirectKHR>::Update(aSpace, aReorientPose, aClearSwapChain);
 
   const uint numXRLayers = GetNumXRLayers();
   for (int i = 0; i < numXRLayers; ++i) {
     device::Eye eye = i == 0 ? device::Eye::Left : device::Eye::Right;
-    xrLayers[i].pose =  XrPoseIdentity();
+    xrLayers[i].pose = aReorientPose;
     xrLayers[i].eyeVisibility = GetEyeVisibility(i);
     // Map surface and rect
     device::EyeRect rect = layer->GetTextureRect(eye);
@@ -265,7 +265,7 @@ OpenXRLayerPassthrough::Init(JNIEnv *aEnv, XrSession session, vrb::RenderContext
 }
 
 void
-OpenXRLayerPassthrough::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) {
+OpenXRLayerPassthrough::Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) {
   xrCompositionLayer = {
           .type = XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB,
           .next = XR_NULL_HANDLE,
@@ -273,7 +273,7 @@ OpenXRLayerPassthrough::Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain
           .space = XR_NULL_HANDLE,
           .layerHandle = mPassthroughLayerHandle,
   };
-  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Update(aSpace, aPose, aClearSwapChain);
+  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Update(aSpace, aReorientPose, aClearSwapChain);
 }
 
 void

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -37,7 +37,7 @@ typedef std::weak_ptr<SurfaceChangedTarget> SurfaceChangedTargetWeakPtr;
 class OpenXRLayer {
 public:
   virtual void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) = 0;
-  virtual void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) = 0;
+  virtual void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) = 0;
   virtual OpenXRSwapChainPtr GetSwapChain() const = 0;
   virtual uint32_t HeaderCount() const = 0;
   virtual const XrCompositionLayerBaseHeader* Header(uint32_t aIndex) const = 0;
@@ -81,7 +81,7 @@ public:
   }
 
   virtual void
-  Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override {
+  Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override {
     const uint numXRLayers = GetNumXRLayers();
     if (mCompositionLayerColorScaleBias != XR_NULL_HANDLE) {
         vrb::Color tintColor = layer->GetTintColor();
@@ -271,8 +271,8 @@ public:
   }
 
   virtual void
-  Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override {
-    OpenXRLayerBase<T , U>::Update(aSpace, aPose, aClearSwapChain);
+  Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override {
+    OpenXRLayerBase<T , U>::Update(aSpace, aReorientPose, aClearSwapChain);
 #ifdef OCULUSVR
     if (this->mLayerImageLayout != XR_NULL_HANDLE) {
       const uint numXRLayers = this->GetNumXRLayers();
@@ -365,7 +365,7 @@ public:
   static OpenXRLayerQuadPtr
   Create(JNIEnv *aEnv, const VRLayerQuadPtr &aLayer, const OpenXRLayerPtr &aSource = nullptr);
   void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
-  void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
+  void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override;
 };
 
 
@@ -378,7 +378,7 @@ public:
   static OpenXRLayerCylinderPtr
   Create(JNIEnv *aEnv, const VRLayerCylinderPtr &aLayer, const OpenXRLayerPtr &aSource = nullptr);
   void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
-  void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
+  void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override;
 };
 
 
@@ -390,7 +390,7 @@ class OpenXRLayerCube : public OpenXRLayerBase<VRLayerCubePtr, XrCompositionLaye
 public:
   static OpenXRLayerCubePtr Create(const VRLayerCubePtr &aLayer, GLint aInternalFormat);
   void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
-  void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
+  void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override;
   void Destroy() override;
   bool IsLoaded() const;
 
@@ -409,7 +409,7 @@ public:
   static OpenXRLayerEquirectPtr
   Create(const VRLayerEquirectPtr &aLayer, const OpenXRLayerPtr &aSourceLayer);
   void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
-  void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
+  void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override;
   void Destroy() override;
   bool IsDrawRequested() const override;
 };
@@ -425,7 +425,7 @@ class OpenXRLayerPassthrough : public OpenXRLayerBase<VRLayerPassthroughPtr, XrC
     static OpenXRLayerPassthroughPtr
     Create(const VRLayerPassthroughPtr& aLayer, XrPassthroughFB);
     void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
-    void Update(XrSpace aSpace, const XrPosef &aPose, XrSwapchain aClearSwapChain) override;
+    void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override;
     void Destroy() override;
     bool IsDrawRequested() const override { return layer->IsDrawRequested(); };
     bool IsValid() const { return mPassthroughLayerHandle != XR_NULL_HANDLE; }


### PR DESCRIPTION
This PR is a slight modification of the method `OpenXRLayer::Update` to specify that the `XrPosef` parameter indicates the position and orientation of the layer in the current space (i.e. "reorient").

This "reorient" pose information is used to change the orientation of immersive videos through the `XrCompositionLayerEquirectKHR` layer where these videos are drawn.

In the future, we may use this information to reorient other types of layers around the user.