### PR TITLE
Head lock must be disabled by default

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -350,7 +350,7 @@ public class SettingsStore {
 
     public boolean isHeadLockEnabled() {
         return mPrefs.getBoolean(
-                mContext.getString(R.string.settings_key_head_lock), shouldStartWithPassthrougEnabled());
+                mContext.getString(R.string.settings_key_head_lock), HEAD_LOCK_DEFAULT);
     }
 
     public void setHeadLockEnabled(boolean isEnabled) {


### PR DESCRIPTION
The previous code was enabling it for see through devices by default. We don't really want that, head lock is not the default behaviour of Wolvic and should be enabled by the user.

Fixes #1364