### PR TITLE
[VisionGlass] Finetune FOV and widget distances

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -340,8 +340,8 @@ android {
                     arguments "-DVISIONGLASS=ON"
                 }
             }
-            buildConfigField "Float", "DEFAULT_DENSITY", "1.0f"
-            buildConfigField "Float", "DEFAULT_WINDOW_DISTANCE", "0.5f"
+            buildConfigField "Float", "DEFAULT_DENSITY", "1.5f"
+            buildConfigField "Float", "DEFAULT_WINDOW_DISTANCE", "1.0f"
         }
 
         // Supported ABIs

--- a/app/src/visionglass/res/values/dimen.xml
+++ b/app/src/visionglass/res/values/dimen.xml
@@ -1,9 +1,9 @@
 <resources>
-    <item name="settings_world_z" format="float" type="dimen">-3.8</item>
+    <item name="settings_world_z" format="float" type="dimen">-3.5</item>
     <item name="browser_children_z_distance" format="float" type="dimen">0.3</item>
-    <item name="window_world_z_min" format="float" type="dimen">-4.2</item>
-    <item name="window_world_z_max" format="float" type="dimen">-6.2</item>
-    <dimen name="media_controls_world_z" format="float" type="dimen">2.5</dimen>
-    <item name="tray_world_z" format="float" type="dimen">-3.0</item>
-    <item name="keyboard_z" format="float" type="dimen">-3.0</item>
+    <item name="window_world_z_min" format="float" type="dimen">-5.2</item>
+    <item name="window_world_z_max" format="float" type="dimen">-7.2</item>
+    <dimen name="media_controls_world_z" format="float" type="dimen">1.5</dimen>
+    <item name="tray_world_z" format="float" type="dimen">-4.0</item>
+    <item name="keyboard_z" format="float" type="dimen">-4.0</item>
 </resources>


### PR DESCRIPTION
The Vision Glass is a see through device with high resolution displays but small FOV (41º diagonal FOV). This means that we should position the widgets a bit farther away in order not to crop visual content. Apart from that the FOV computation was wrong because we were assuming 41 deg horizontal FOV when in reality 41 deg is the diagonal FOV.