### PR TITLE
[VisionGlass] Restart phone IMU when calibrating

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -180,6 +180,10 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         }
     }
 
+    private void registerPhoneIMUListener() {
+        mSensorManager.registerListener(this, mSensorManager.getDefaultSensor(Sensor.TYPE_GAME_ROTATION_VECTOR), SensorManager.SENSOR_DELAY_NORMAL);
+    }
+
     private void initVisionGlassPhoneUI() {
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
@@ -196,6 +200,8 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         mBinding.voiceSearchButton.setEnabled(false);
 
         mBinding.realignButton.setOnClickListener(v -> {
+            mSensorManager.unregisterListener(this);
+            registerPhoneIMUListener();
             queueRunnable(this::calibrateController);
         });
 
@@ -338,7 +344,7 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
         Log.d(LOGTAG, "PlatformActivity onResume");
         super.onResume();
 
-        mSensorManager.registerListener(this, mSensorManager.getDefaultSensor(Sensor.TYPE_GAME_ROTATION_VECTOR), SensorManager.SENSOR_DELAY_NORMAL);
+        registerPhoneIMUListener();
 
         // Sometimes no display event is emitted so we need to call updateDisplays() from here.
         if (VisionGlass.getInstance().isConnected() && VisionGlass.getInstance().hasUsbPermission() && mSwitchedTo3DMode && mActivePresentation == null) {


### PR DESCRIPTION
Restarting the IMU listener on calibration provides much better results. This is specially important with extreme calibrations (like the glasses and phone IMUs being rotated 90 degs).

The following is a good test case:
1. put the phone over a surface with a 90º rotation relative to the glasses, i.e. pointing towards your right or left
2. start wolvic
3. observe that the ray is pointing to the front despite the phone position
4. take the phone and point it to the wolvic window and then click on calibrate

Without this patch the behaviour of the pointer after calibration is pretty bad. With this patch it works normally