### PR TITLE
Add null checks before calling PlatformPlugin methods

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -462,7 +462,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         // Create the platform plugin after widgets are created to be extra safe.
         mPlatformPlugin = createPlatformPlugin(this);
-        mPlatformPlugin.registerListener(this);
+        if (mPlatformPlugin != null)
+            mPlatformPlugin.registerListener(this);
 
         mWindows.restoreSessions();
     }
@@ -685,7 +686,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         // Unregister the crash service broadcast receiver
         unregisterReceiver(mCrashReceiver);
         mSearchEngineWrapper.unregisterForUpdates();
-        mPlatformPlugin.unregisterListener(this);
+        if (mPlatformPlugin != null)
+            mPlatformPlugin.unregisterListener(this);
 
         mFragmentController.dispatchDestroy();
 


### PR DESCRIPTION
In 6958a465 we added a listener interface to the platform plugins so that the VRBrowserActivity could get events from them. The only flavour implementing the platform plugin right now is the VisionGlass one. That's why we still need to have null checks before any plugin method call. The aforementioned commit was adding a couple of unchecked calls and thus it was causing crashes for all non VisionGlass flavours.