### PR TITLE
UI recentering issues

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -765,7 +765,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             if (key.equals(getString(R.string.settings_key_voice_search_service))) {
                 initializeSpeechRecognizer();
             } else if (key.equals(getString(R.string.settings_key_head_lock))) {
-                setHeadLockEnabled(SettingsStore.getInstance(this).isHeadLockEnabled());
+                boolean isHeadLockEnabled = SettingsStore.getInstance(this).isHeadLockEnabled();
+                setHeadLockEnabled(isHeadLockEnabled);
+                if (!isHeadLockEnabled)
+                    recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL);
             }
     }
 
@@ -2010,12 +2013,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public void setHeadLockEnabled(boolean isHeadLockEnabled) {
-        queueRunnable(() -> {
-            setHeadLockEnabledNative(isHeadLockEnabled);
-            if (!isHeadLockEnabled) {
-                recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL);
-            }
-        });
+        queueRunnable(() -> setHeadLockEnabledNative(isHeadLockEnabled));
     }
 
     @Override

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1923,6 +1923,7 @@ BrowserWorld::TickSplashAnimation() {
     DrawSplashAnimation(aEye);
   };
   if (animationFinished) {
+    RecenterUIYaw(YawTarget::ALL);
     m.frameEndHandler = [=]() {
       if (m.splashAnimation && m.splashAnimation->GetLayer()) {
         m.device->DeleteLayer(m.splashAnimation->GetLayer());

--- a/app/src/main/cpp/SplashAnimation.cpp
+++ b/app/src/main/cpp/SplashAnimation.cpp
@@ -126,8 +126,8 @@ SplashAnimation::Update(const vrb::Matrix& aHeadTransform) {
   }
   vrb::Vector position = aHeadTransform.GetTranslation();
   if (m.firstDraw && position.Magnitude() > 0.1f) {
-    static const vrb::Vector offset(0.0f, -0.2f, -1.5f);
-    m.logo->GetTransformNode()->SetTransform(vrb::Matrix::Position(position + offset));
+    static const vrb::Vector offset(0.0f, -0.1f, -1.5f);
+    m.logo->GetTransformNode()->SetTransform(aHeadTransform.PostMultiply(vrb::Matrix::Position(offset)));
     m.firstDraw = false;
   }
   m.UpdateTime();


### PR DESCRIPTION
This PR tackles 3 different issues:
1. View is recentered when setting headlock mode setting on startup
2. View is not recentered when the head is moved while splash is shown
3. Splash screen logo do not follow head orientation if the head moves before splash is shown