### PR TITLE
Use a more conservative setting for display density in AOSP

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -299,6 +299,7 @@ android {
                     arguments "-DAOSP=ON", "-DOPENXR=ON"
                 }
             }
+            buildConfigField "Float", "DEFAULT_DENSITY", "1.0f"
         }
 
         hvr {


### PR DESCRIPTION
Increasing the default density degraded the performance significantly in some use cases in AOSP devices like the MagicLeap2. Set it back to 1.0 by default.