### PR TITLE
[Vision Glass] Headlock button state on startup

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -42,6 +42,7 @@ import com.huawei.usblib.DisplayModeCallback;
 import com.huawei.usblib.OnConnectionListener;
 import com.huawei.usblib.VisionGlass;
 import com.igalia.wolvic.browser.Media;
+import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WMediaSession;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.databinding.VisionglassLayoutBinding;
@@ -494,6 +495,8 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
                 mDelegate.getWindows().getFocusedWindow().loadHome();
             });
 
+            mBinding.headlockToggleButton.setChecked(
+                    SettingsStore.getInstance(PlatformActivity.this).isHeadLockEnabled());
             mBinding.headlockToggleButton.setOnClickListener(v -> {
                 mDelegate.setHeadLockEnabled(mBinding.headlockToggleButton.isChecked());
             });


### PR DESCRIPTION
Set up the state of the headlock button on startup so that it will be checked if headlock has been enabled in the Settings.