### PR TITLE
Fix position/orientation computations of flat widgets with curved parents

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -399,7 +399,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         aPlacement.worldWidth = WidgetPlacement.floatDimension(context, R.dimen.keyboard_world_width);
         aPlacement.visible = false;
         // FIXME: keyboard is misplaced when rendered in a cylinder layer.
-        aPlacement.cylinder = !((VRBrowserActivity) getContext()).areLayersEnabled();
+        aPlacement.cylinder = false;
         aPlacement.layerPriority = 1;
         updatePlacementTranslationZ();
     }

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -670,8 +670,16 @@ void Widget::LayoutQuadWithCylinderParent(const WidgetPtr& aParent) {
     // The widget is flat and the parent is a cylinder.
     // Adjust the widget rotation based on the parent cylinder
     // e.g. rotate the tray based on the parent cylindrical window.
-    const float radius = cylinder->GetTransformNode()->GetTransform().GetScale().x();
-    m.AdjustCylinderRotation(radius);
+    auto x = m.transform->GetTransform().GetTranslation().x();
+    if (x != 0.0) {
+      auto radius = m.placement->cylinderMapRadius;
+      auto angle = M_PI_2 - atan(x/radius);
+      vrb::Matrix transform = vrb::Matrix::Rotation(vrb::Vector(-cosf(angle), 0.0f, sinf(angle)));
+      transform.PostMultiplyInPlace(vrb::Matrix::Translation(vrb::Vector(-x, 0.0f, 0.0f)));
+      m.transformContainer->SetTransform(transform);
+    } else {
+      m.transformContainer->SetTransform(vrb::Matrix::Identity());
+    }
   } else {
     // The widget is flat and the parent is flat. Copy the parent transformContainer matrix (used for cylinder rotations)
     // because the parent widget can still be recursively rotated based on a parent cylinder.


### PR DESCRIPTION
Some widgets are always rendered flat even in curved mode, like the tray bar. What we do in multiwindow environments is basically rotate it following the rotation of their parent windows. However that was not working well when not using
OpenXR layers and non-default window distances.

Replaced the code by a different computation that provides much better and natural results as the widgets now face the user and it's much easier to type in the keyboard for example. Speaking of which, we had to force the keyboard not to be in curved mode. We were doing that for the layers case but we do it now as well for the non-layers case as we started to suffer from the same issues.