### PR TITLE
Draw dialogs on a flat surface

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/UIDialog.java
@@ -29,6 +29,9 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
 
     private void initialize() {
         mWidgetManager.addWorldClickListener(this);
+
+        // For visibility, dialogs are not shown on the cylinder by default.
+        mWidgetPlacement.cylinder = false;
     }
 
     @Override


### PR DESCRIPTION
Dialogs are not drawn on a cylinder by default. This improves their visibility when they are attached to a window to the side of the user, specially as the window distance increases.