### PR TITLE
Fixes related to URL schemes

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -28,7 +28,9 @@ import org.chromium.wolvic.UserDialogManagerBridge;
 
 import java.io.InputStream;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
@@ -51,6 +53,7 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     private WebContents mWebContents;
     private TabImpl mTab;
     private ReadyCallback mReadyCallback = new ReadyCallback();
+    private UrlUtilsVisitor mUrlUtilsVisitor;
 
     private class ReadyCallback implements RuntimeImpl.Callback {
         @Override
@@ -471,5 +474,20 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
 
     public WResult<Boolean> checkLoginIfAlreadySaved(PasswordForm form) {
        return mRuntime.getUpLoginPersistence().checkLoginIfAlreadySaved(form);
+    }
+
+    @NonNull
+    @Override
+    public UrlUtilsVisitor getUrlUtilsVisitor() {
+        if (mUrlUtilsVisitor == null) {
+            mUrlUtilsVisitor = new UrlUtilsVisitor() {
+                private final List<String> ENGINE_SUPPORTED_SCHEMES = Arrays.asList("about", "data", "file", "ftp", "http", "https", "view-source", "ws", "wss", "blob", "chrome");
+                @Override
+                public boolean isSupportedScheme(@NonNull String scheme) {
+                    return ENGINE_SUPPORTED_SCHEMES.contains(scheme);
+                }
+            };
+        }
+        return mUrlUtilsVisitor;
     }
 }

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -19,6 +19,8 @@ import com.igalia.wolvic.browser.api.WTextInput;
 import org.mozilla.geckoview.GeckoSession;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 public class SessionImpl implements WSession {
     private @NonNull GeckoSession mSession;
@@ -36,6 +38,7 @@ public class SessionImpl implements WSession {
     private TextInputImpl mTextInput;
     private PanZoomControllerImpl mPanZoomController;
     private Method mGeckoLocationMethod;
+    private UrlUtilsVisitor mUrlUtilsVisitor;
 
     // The difference between "Mobile" and "VR" matches GeckoViewSettings.jsm
     private static final String WOLVIC_USER_AGENT_MOBILE = GeckoSession.getDefaultUserAgent() + " Wolvic/" + BuildConfig.VERSION_NAME;
@@ -408,5 +411,19 @@ public class SessionImpl implements WSession {
             result |= GeckoSession.LOAD_FLAGS_BYPASS_CLASSIFIER;
         }
         return result;
+    }
+
+    @Override
+    public UrlUtilsVisitor getUrlUtilsVisitor() {
+        if (mUrlUtilsVisitor == null) {
+            mUrlUtilsVisitor = new UrlUtilsVisitor() {
+                private final List<String> ENGINE_SUPPORTED_SCHEMES = Arrays.asList("about", "data", "file", "ftp", "http", "https", "moz-extension", "moz-safe-about", "resource", "view-source", "ws", "wss", "blob");
+                @Override
+                public boolean isSupportedScheme(@NonNull String scheme) {
+                    return ENGINE_SUPPORTED_SCHEMES.contains(scheme);
+                }
+            };
+        }
+        return mUrlUtilsVisitor;
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -2733,7 +2733,19 @@ public interface WSession {
     @UiThread
     void getClientToScreenMatrix(@NonNull final Matrix matrix);
 
+    interface UrlUtilsVisitor {
+        @AnyThread
+        boolean isSupportedScheme(@NonNull String scheme);
+    }
 
+    /**
+     * Get the URL utils visitor for this session.
+     *
+     * @return UrlUtilsVisitor instance.
+     */
+    @AnyThread
+    @NonNull
+    UrlUtilsVisitor getUrlUtilsVisitor();
 
     /**
      * Get a matrix for transforming from page coordinates to screen coordinates. The page coordinates

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
@@ -380,9 +380,8 @@ public class NavigationURLBar extends FrameLayout {
     }
 
     public  void handleURLEdit(String text) {
-        String url = UrlUtils.urlForText(getContext(), text.trim());
-
         if (!mDelegate.onHandleExternalRequest(text)) {
+            String url = UrlUtils.urlForText(getContext(), text.trim());
             mViewModel.setUrl(url);
             mSession.loadUri(url);
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
@@ -381,7 +381,7 @@ public class NavigationURLBar extends FrameLayout {
 
     public  void handleURLEdit(String text) {
         if (!mDelegate.onHandleExternalRequest(text)) {
-            String url = UrlUtils.urlForText(getContext(), text.trim());
+            String url = UrlUtils.urlForText(getContext(), text.trim(), mSession.getWSession().getUrlUtilsVisitor());
             mViewModel.setUrl(url);
             mSession.loadUri(url);
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -2231,13 +2231,15 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public boolean onHandleExternalRequest(@NonNull String url) {
+        URI uri;
         try {
-            if (UrlUtils.parseUri(url).getScheme() == null)
+            uri = UrlUtils.parseUri(url);
+            if (uri.getScheme() == null)
                 return false;
         } catch (URISyntaxException e) {
             return false;
         }
-        if (UrlUtils.isEngineSupportedScheme(url, mSession.getWSession().getUrlUtilsVisitor())) {
+        if (UrlUtils.isEngineSupportedScheme(uri, mSession.getWSession().getUrlUtilsVisitor())) {
             return false;
         } else {
             Intent intent;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -74,6 +74,8 @@ import com.igalia.wolvic.utils.ViewUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2229,9 +2231,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public boolean onHandleExternalRequest(@NonNull String url) {
+        try {
+            if (UrlUtils.parseUri(url).getScheme() == null)
+                return false;
+        } catch (URISyntaxException e) {
+            return false;
+        }
         if (UrlUtils.isEngineSupportedScheme(url)) {
             return false;
-
         } else {
             Intent intent;
             try {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -2237,7 +2237,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         } catch (URISyntaxException e) {
             return false;
         }
-        if (UrlUtils.isEngineSupportedScheme(url)) {
+        if (UrlUtils.isEngineSupportedScheme(url, mSession.getWSession().getUrlUtilsVisitor())) {
             return false;
         } else {
             Intent intent;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/SelectionActionWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/SelectionActionWidget.java
@@ -20,6 +20,7 @@ import com.igalia.wolvic.ui.views.UITextButton;
 import com.igalia.wolvic.ui.widgets.UIWidget;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
+import com.igalia.wolvic.ui.widgets.WindowWidget;
 import com.igalia.wolvic.utils.UrlUtils;
 import com.igalia.wolvic.utils.ViewUtils;
 
@@ -219,9 +220,10 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
     private void handleAction(View sender) {
         String action = (String)sender.getTag();
         if (action.equals(ACTION_WEB_SEARCH) && mSelectionText != null) {
+            WindowWidget focusedWindow = mWidgetManager.getWindows().getFocusedWindow();
             mWidgetManager.getWindows().addTab(
-                    mWidgetManager.getWindows().getFocusedWindow(),
-                    UrlUtils.urlForText(getContext(), mSelectionText));
+                    focusedWindow,
+                    UrlUtils.urlForText(getContext(), mSelectionText, focusedWindow.getSession().getWSession().getUrlUtilsVisitor()));
         }
 
         if (mDelegate != null) {

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -16,6 +16,7 @@ import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
+import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.search.SearchEngineWrapper;
 import com.igalia.wolvic.telemetry.TelemetryService;
 
@@ -30,8 +31,6 @@ import java.util.regex.Pattern;
 
 // This class refers from mozilla-mobile/focus-android
 public class UrlUtils {
-
-    private static List<String> ENGINE_SUPPORTED_SCHEMES = Arrays.asList(null, "about", "data", "file", "ftp", "http", "https", "moz-extension", "moz-safe-about", "resource", "view-source", "ws", "wss", "blob");
 
     public static String UNKNOWN_MIME_TYPE = "application/octet-stream";
     public static String EXTENSION_MIME_TYPE = "application/x-xpinstall";
@@ -254,7 +253,7 @@ public class UrlUtils {
         }
     }
 
-    public static String urlForText(@NonNull Context context, @NonNull String text) {
+    public static String urlForText(@NonNull Context context, @NonNull String text, @NonNull WSession.UrlUtilsVisitor visitor) {
         String url = text.trim();
         if ((UrlUtils.isDomain(text) || UrlUtils.isIPUri(text)) && !text.contains(" ")) {
             url = text;
@@ -278,7 +277,8 @@ public class UrlUtils {
     }
 
     // TODO Ideally we should use something like org.mozilla.fenix.components.AppLinksInterceptor for this
-    public static boolean isEngineSupportedScheme(@NonNull String url) {
-        return ENGINE_SUPPORTED_SCHEMES.contains(Uri.parse(url).getScheme());
+    public static boolean isEngineSupportedScheme(@NonNull String url, @NonNull WSession.UrlUtilsVisitor visitor) {
+        String scheme = Uri.parse(url).getScheme();
+        return scheme != null && visitor.isSupportedScheme(scheme);
     }
 }

--- a/app/src/test/java/com/igalia/wolvic/UrlUtilsTest.java
+++ b/app/src/test/java/com/igalia/wolvic/UrlUtilsTest.java
@@ -13,14 +13,17 @@ import org.mockito.Mockito;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
+import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.utils.UrlUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 @RunWith(Parameterized.class)
 public class UrlUtilsTest {
     private static Context mContext;
+    private static WSession.UrlUtilsVisitor mVisitor;
     @Parameter(value = 0)
     public String text;
     @Parameter(value = 1)
@@ -29,6 +32,14 @@ public class UrlUtilsTest {
     @BeforeClass
     public static void init() {
         mContext = Mockito.mock(Context.class);
+        mVisitor = new WSession.UrlUtilsVisitor() {
+            // Any web engine should support at least these schemes
+            private final List<String> ENGINE_SUPPORTED_SCHEMES = Arrays.asList("about", "data", "file", "ftp", "http", "https", "ws", "wss", "blob");
+            @Override
+            public boolean isSupportedScheme(@NonNull String scheme) {
+                return ENGINE_SUPPORTED_SCHEMES.contains(scheme);
+            }
+        };
         UrlUtils.isUnderTest = true;
     }
 
@@ -36,24 +47,34 @@ public class UrlUtilsTest {
     public static Collection data() {
         return Arrays.asList(new Object[][]{
                 {"test", UrlUtils.TEST_SEARCH_URL + "test"},
-                {"test spaces", UrlUtils.TEST_SEARCH_URL + "test spaces"},
-                {"http://example", UrlUtils.TEST_SEARCH_URL + "http://example"},
+                {" test spaces ", UrlUtils.TEST_SEARCH_URL + "test spaces"},
+                {"http://example", "http://example"},
                 {"http://exam ple", UrlUtils.TEST_SEARCH_URL + "http://exam ple"},
                 {"http://example.com", "http://example.com"},
+                {"https://example.com", "https://example.com"},
                 {"example.com", "http://example.com"},
                 {"sublevel.example.uvwxyz", "http://sublevel.example.uvwxyz"},
+                {"121.25.63.2", "http://121.25.63.2"},
                 {"http://121.25.63.2", "http://121.25.63.2"},
                 {"http://121 .25.63.2", UrlUtils.TEST_SEARCH_URL + "http://121 .25.63.2"},
+                {"1211.25.63.2", UrlUtils.TEST_SEARCH_URL + "1211.25.63.2"},
                 {"http://1211.25.63.2", UrlUtils.TEST_SEARCH_URL + "http://1211.25.63.2"},
+                {"http://11.222.333.4", UrlUtils.TEST_SEARCH_URL + "http://11.222.333.4"},
                 {"about://config", "about://config"},
-                {"resource://images", "resource://images"},
-                {"file:///tmp/data", "file:///tmp/data"}
+                {"file:///tmp/data", "file:///tmp/data"},
+                {"ftp://example.com", "ftp://example.com"},
+                {"ws://example.com", "ws://example.com"},
+                {"wss://example.com", "wss://example.com"},
+                {"data://images", "data://images"},
+                {"data:,Hello%2C%20World%21", "data:,Hello%2C%20World%21"},
+                {"data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==", "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="},
+                {"blob:example.com/123456-7890-abcdef-ghijk-lmnopqrstuvwx", "blob:example.com/123456-7890-abcdef-ghijk-lmnopqrstuvwx"}
         });
     }
 
     @Test
     public void testUrlForText() {
-        String result = UrlUtils.urlForText(mContext, text);
+        String result = UrlUtils.urlForText(mContext, text, mVisitor);
         assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
We didn't have support for `chrome://` pages because it was not recognized as a scheme handled by the engine. That's correct for Gecko but not for Chromium. So we had to refactor some UrlUtils to cope with engine differences. This also fixes a hidden bug handling the launch of externally managed URLs via intents.

Fixes #1391