### PR TITLE
[ML2] Use XR_ML_frame_end_info extension

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -508,6 +508,10 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
       }
     }
 
+    // Used by some runtimes to perform visual optimizations
+    if (hitDistance < farClip)
+        device->SetHitDistance(hitDistance);
+
     if (controller.focused && (!hitWidget || !hitWidget->IsResizing()) && resizingWidget) {
       resizingWidget->HoverExitResize();
       resizingWidget.reset();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -115,6 +115,7 @@ public:
   virtual void UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
                               const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) {};
   virtual void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) {};
+  virtual void SetHitDistance(const float) {};
 
 protected:
   DeviceDelegate() {}

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -64,6 +64,7 @@ public:
   void UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,
                       const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) override;
   void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) override;
+  void SetHitDistance(const float) override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);


### PR DESCRIPTION
Among other things this extension allows us to specify a focus distance that would be used by the compositor to provide better visual results.