### PR TITLE
Updated ICP license numbers

### DIFF
--- a/app/src/hvr/res/values/non_L10n.xml
+++ b/app/src/hvr/res/values/non_L10n.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="rCN_icp_license_number" translatable="false">ICP备案号：京ICP备2022006476号-10A</string>
+</resources>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -231,8 +231,9 @@
     <!-- Shared preferences key to store the list of installed Web apps (JSON string) -->
     <string name="settings_key_web_apps_data" translatable="false">settings_key_web_apps_data</string>
 
-    <!-- China license number -->
-    <string name="rCN_license_number" translatable="false">ICP备案号：京ICP备2022006476号-10A</string>
+    <!-- China ICP license number; the actual value is set in each specific build. -->
+    <string name="rCN_icp_license_number" translatable="false" />
+    <string name="rCN_license_number" translatable="false">@string/rCN_icp_license_number</string>
     <string name="rCN_license_link" translatable="false">https://beian.miit.gov.cn/</string>
 
 </resources>

--- a/app/src/visionglass/res/values/non_L10n.xml
+++ b/app/src/visionglass/res/values/non_L10n.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="rCN_icp_license_number" translatable="false">ICP备案号：京ICP备2022006476号-14A</string>
+</resources>


### PR DESCRIPTION
The ICP license number must be displayed in the app in China.

This PR adapts our existing solution to take into account that we have different values for the HVR and Vision Glass builds of Wolvic.