### PR TITLE
Add unit tests for UrlUtils class

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -35,6 +35,8 @@ public class UrlUtils {
 
     public static String UNKNOWN_MIME_TYPE = "application/octet-stream";
     public static String EXTENSION_MIME_TYPE = "application/x-xpinstall";
+    public static boolean isUnderTest = false;
+    public static String TEST_SEARCH_URL = "http://testsearchengine.com/search?q=";
 
     public static String stripCommonSubdomains(@Nullable String host) {
         if (host == null) {
@@ -260,7 +262,7 @@ public class UrlUtils {
         } else if (text.startsWith("about:") || text.startsWith("resource://") || UrlUtils.isFileUri(text)) {
             url = text;
         } else {
-            url = SearchEngineWrapper.get(context).getSearchURL(text);
+            url = !isUnderTest ? SearchEngineWrapper.get(context).getSearchURL(text) : TEST_SEARCH_URL + url;
 
             // Doing search in the URL bar, so sending "aIsURL: false" to telemetry.
             TelemetryService.urlBarEvent(false);

--- a/app/src/test/java/com/igalia/wolvic/UrlUtilsTest.java
+++ b/app/src/test/java/com/igalia/wolvic/UrlUtilsTest.java
@@ -1,0 +1,60 @@
+package com.igalia.wolvic;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mockito;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+
+import com.igalia.wolvic.utils.UrlUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class UrlUtilsTest {
+    private static Context mContext;
+    @Parameter(value = 0)
+    public String text;
+    @Parameter(value = 1)
+    public String expected;
+
+    @BeforeClass
+    public static void init() {
+        mContext = Mockito.mock(Context.class);
+        UrlUtils.isUnderTest = true;
+    }
+
+    @Parameters(name = "{0} => {1}")
+    public static Collection data() {
+        return Arrays.asList(new Object[][]{
+                {"test", UrlUtils.TEST_SEARCH_URL + "test"},
+                {"test spaces", UrlUtils.TEST_SEARCH_URL + "test spaces"},
+                {"http://example", UrlUtils.TEST_SEARCH_URL + "http://example"},
+                {"http://exam ple", UrlUtils.TEST_SEARCH_URL + "http://exam ple"},
+                {"http://example.com", "http://example.com"},
+                {"example.com", "http://example.com"},
+                {"sublevel.example.uvwxyz", "http://sublevel.example.uvwxyz"},
+                {"http://121.25.63.2", "http://121.25.63.2"},
+                {"http://121 .25.63.2", UrlUtils.TEST_SEARCH_URL + "http://121 .25.63.2"},
+                {"http://1211.25.63.2", UrlUtils.TEST_SEARCH_URL + "http://1211.25.63.2"},
+                {"about://config", "about://config"},
+                {"resource://images", "resource://images"},
+                {"file:///tmp/data", "file:///tmp/data"}
+        });
+    }
+
+    @Test
+    public void testUrlForText() {
+        String result = UrlUtils.urlForText(mContext, text);
+        assertEquals(expected, result);
+    }
+}
+


### PR DESCRIPTION
We start by adding tests for urlForText() method that is the one that decides whether some text typed in the URL bar should be considered as a valid URL and thus visited, or as search terms in which case it returns the URL for the user selected search engine.