### PR TITLE
[Vision Glass] Beam extends all the way to the pointer

### DIFF
--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -235,6 +235,14 @@ DeviceDelegateVisionGlass::GetControllerModelName(const int32_t) const {
 }
 
 void
+DeviceDelegateVisionGlass::SetHitDistance(const float distance) {
+  // Scale the beam so it reaches all the way to the pointer.
+  auto beamTransform = vrb::Matrix::Identity();
+  beamTransform.ScaleInPlace(vrb::Vector(1.0, 1.0, distance));
+  m.controller->SetBeamTransform(kControllerIndex, beamTransform);
+}
+
+void
 DeviceDelegateVisionGlass::ProcessEvents() {}
 
 vrb::Quaternion

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
@@ -42,6 +42,7 @@ public:
   void BindEye(const device::Eye) override;
   void EndFrame(const FrameEndMode aMode) override;
   bool IsControllerLightEnabled() const override;
+  void SetHitDistance(const float) override;
   // DeviceDelegateVisionGlass interface
   void InitializeJava(JNIEnv* aEnv, jobject aActivity);
   void ShutdownJava();


### PR DESCRIPTION
It is easy to get lost while using the Vision Glass because the controllers are not drawn in the 3D world and the narrow field of view means that the beam is not always visible to the user.

This change extends the beam so it reaches all the way to the pointer, making the UI easier and more understandable.