### PR TITLE
Workaround to avoid the crash in the CrashReporter

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/crashreporting/CrashReporterService.java
+++ b/app/src/common/shared/com/igalia/wolvic/crashreporting/CrashReporterService.java
@@ -59,9 +59,13 @@ public class CrashReporterService extends JobIntentService {
         }
         return files;
     }
-
+    
     @Override
     protected void onHandleWork(@NonNull Intent intent) {
+        if (!EngineProvider.INSTANCE.isRuntimeCreated()) {
+            Log.e(LOGTAG, "Application crashed during startup, before the engine's runtime had been created.");
+            return;
+        }
         String action = intent.getAction();
         WRuntime.CrashReportIntent crash = EngineProvider.INSTANCE.getOrCreateRuntime(getBaseContext()).getCrashReportIntent();
         if (crash.action_crashed.equals(action)) {


### PR DESCRIPTION
The runtime must be created in the UI process but the CrashReporterService is not allowed to run on it, as it's explained in commit [63f474a](https://github.com/Igalia/wolvic/commit/63f474a56f35d1f12afc019e5bcfc19cc5495127). 

This PR provides a workaround by creating a dummy CrashReportIntent if the runtime instance has not been created.

It's important to consider that this change discovers an underlying issue we already had, due to the way Gecko starts the CrashReportService: ```context.startForegroundService(intent);```It seems that if the Service doesn't call to ```startForegound()``` in a short period of time, android raises a ```ForegroundServiceDidNotStartInTimeException:```

