### PR TITLE
Additional color format checks

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -73,6 +73,10 @@ public:
   bool IsInVRMode() const;
   bool ExitApp();
   bool ShouldExitRenderLoop() const;
+
+private:
+  void checkSupportedColorFormats(GLint aInternalFormat);
+
 protected:
   struct State;
   DeviceDelegateOpenXR(State& aState);

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -393,7 +393,7 @@ public:
   void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override;
   void Destroy() override;
   bool IsLoaded() const;
-
+  GLint GetColorFormat() { return glFormat; }
 protected:
   GLint glFormat;
 };


### PR DESCRIPTION
We already have a function to ensure that the XrSwapchainCreateInfo structure provides a compatible color format. We were using this check when creating the swapchains for the views, as part of the GetSwapChainCreateInfo() logic,

However, when we create the OpenXRLayerCube instance we pass a color format Id that is later used in the XrSwapchainCreateInfo structure during the layer initialization. This PR provides a more descriptive error and avoids the failure on the OpenXR code.