### PR TITLE
Do not launch the crash handler dialog

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -375,7 +375,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         initializeSpeechRecognizer();
 
         mPoorPerformanceAllowList = new HashSet<>();
-        checkForCrash();
+
+        // FIXME: We don't have any crash report analysis tool, so we need to disable this for the time being.
+        if (false)
+            checkForCrash();
 
         setHeadLockEnabled(mSettings.isHeadLockEnabled());
 


### PR DESCRIPTION
We don't have a service to collect and analyze the coredumps generated after crashes, so it's better to avoid launching the dialog to ask the user about sending it.