### PR TITLE
[ML2] Increase beta params for 1€ filter

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -146,7 +146,11 @@ XrResult OpenXRInputSource::Initialize()
             mGestureManager = std::make_unique<OpenXRGestureManagerFBHandTrackingAim>();
         else {
             // TODO: fine tune params for different devices.
-            OpenXRGestureManagerHandJoints::OneEuroFilterParams params = { 0.25, 0.1, 1 };
+            OpenXRGestureManagerHandJoints::OneEuroFilterParams params;
+            if (deviceType == device::MagicLeap2)
+                params = {0.25, 2, 1};
+            else
+                params = { 0.25, 0.1, 1 };
             mGestureManager = std::make_unique<OpenXRGestureManagerHandJoints>(mHandJoints, &params);
         }
     }


### PR DESCRIPTION
Increasing beta makes the filter more reactive to changes in speed. That obviously reduces smoothness but that is not an issue in ML2 and it allows us to make the pointer feel more responsive.