### PR TITLE
[OpenXR] Do not use freed structs in ".next" pointers

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1201,8 +1201,8 @@ DeviceDelegateOpenXR::EndFrame(const FrameEndMode aEndMode) {
       frameEndInfo.layerCount = (uint32_t) layers.size();
       frameEndInfo.layers = layers.data();
 
+      XrFrameEndInfoML frameEndInfoML{XR_TYPE_FRAME_END_INFO_ML};
       if (OpenXRExtensions::IsExtensionSupported(XR_ML_FRAME_END_INFO_EXTENSION_NAME)) {
-            XrFrameEndInfoML frameEndInfoML{XR_TYPE_FRAME_END_INFO_ML};
             frameEndInfoML.next = nullptr;
             frameEndInfoML.focusDistance = distance;
             frameEndInfo.next = &frameEndInfoML;

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1546,12 +1546,12 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
   createInfo.next = reinterpret_cast<const XrBaseInStructure*>(&m.graphicsBinding);
   createInfo.systemId = m.system;
 
-  if (OpenXRExtensions::IsExtensionSupported(XR_EXTX_OVERLAY_EXTENSION_NAME)) {
-    XrSessionCreateInfoOverlayEXTX overlayInfo {
+  XrSessionCreateInfoOverlayEXTX overlayInfo {
       .type = XR_TYPE_SESSION_CREATE_INFO_OVERLAY_EXTX,
       .createFlags = 0,
       .sessionLayersPlacement = 0
-    };
+  };
+  if (OpenXRExtensions::IsExtensionSupported(XR_EXTX_OVERLAY_EXTENSION_NAME)) {
     auto oldNext = createInfo.next;
     createInfo.next = &overlayInfo;
     overlayInfo.next = oldNext;


### PR DESCRIPTION
A couple of crash fixes with the same root cause, a variable that goes out of scope but is referenced in a struct that is used by the OpenXR runtime.