### PR TITLE
Use Khronos' OpenXR loader from Maven when supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,12 @@ wolvic$ git clone git@github.com:Igalia/wolvic-third-parties.git third_party
 
 This repo is only available to Igalia members. If you have access to the relevant SDK but not this repo, you can manually place them here:
 
- - `third_party/ovr_mobile/` for Oculus (should contain a `VrApi` folder)
- - ~`third_party/OVRPlatformSDK/` for Oculus (should contain a `Android` and `include` folders)~ (deprecated)
- - `third_party/ovr_openxr_mobile_sdk/` for Oculus (should contain an `OpenXR` folder)
+ - `third_party/OVRPlatformSDK/` for Oculus (should contain a `Android` and `Include` folders)
  - `third_party/hvr/` for Huawei (should contain  `arm64-v8a`, `armeabi-v7a` and `include` folders)
  - `third_party/wavesdk/` for Vive (should contain a `build` folder, among other things)
- - `third_party/picoxr` [Pico OpenXR Mobile SDK](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11) (should contain `include` and `libs` folders, among other things that are not necessary for Wolvic)
- - `third_party/lynx` [for Lynx](https://portal.lynx-r.com)(should contain a `loader-release.aar` file)
+ - `third_party/picoxr` [Pico OpenXR Mobile SDK](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11) (should contain `libs` folders, among other things that are not necessary for Wolvic)
  - `third_party/spaces` [for Snapdragon Spaces](https://spaces.qualcomm.com/)(should contain `libopenxr_loader.aar`)
- - `third_party/OpenXR-SDK/` [OpenXR-SDK](https://github.com/KhronosGroup/OpenXR-SDK) (should contain an `include` folder)
+ - `third_party/OpenXR-SDK/` [OpenXR-SDK](https://github.com/KhronosGroup/OpenXR-SDK) (should contain an `include` folder). This is used by HVR and PicoXR flavours. The other flavours using OpenXR use the include files provided by the Khronos OpenXR loader AAR from Maven.
  - `third_party/aliceimu/` for [Huawei Vision Glass](https://consumer.huawei.com/cn/wearables/vision-glass/) (should contain an `.aar` file with the IMU library for the glasses)
 
 The [repo in `third_party`](https://github.com/Igalia/wolvic-third-parties) can be updated like so:

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ Restart Wolvic XR and close and re-open the WebIDE page.
 
 - When using the native debugger you can ignore the first SIGSEGV: address access protected stop in GV thread. It's not a crash; you can click *Resume* to continue debugging.
 - On some platforms such as Oculus Go the native debugger stops on each input event. You can set this LLDB post-attach command in Android Studio to fix the problem: `pro hand -p true -s false SIGILL`
-- You can use `adb shell am start -a android.intent.action.VIEW -d "https://aframe.io" com.igalia.wolvic/com.igalia.wolvic.VRBrowserActivity` to load a URL from the command line
-- You can use `adb shell am start -a android.intent.action.VIEW  -n com.igalia.wolvic/com.igalia.wolvic.VRBrowserActivity -e homepage "https://example.com"` to override the homepage
+- You can use `adb shell am start -a android.intent.action.VIEW -d "https://aframe.io" com.igalia.wolvic/com.igalia.wolvic.VersionCheckActivity` to load a URL from the command line
+- You can use `adb shell am start -a android.intent.action.VIEW  -n com.igalia.wolvic/com.igalia.wolvic.VersionCheckActivity -e homepage "https://example.com"` to override the homepage
 - You can use `adb shell setprop debug.oculus.enableVideoCapture 1` to record a video on the Oculus Go. Remember to run `adb shell setprop debug.oculus.enableVideoCapture 0` to stop recording the video.
     - You can also record videos on the Oculus Go by exiting to the system library, and from the Oculus tray menu (toggle with the Oculus button on the controller): **`Sharing > Record Video`**
 - You can set `disableCrashRestart=true` in the gradle `user.properties` to disable app relaunch on crash.

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -89,41 +89,30 @@ target_sources(
 
 include(AndroidNdkModules)
 android_ndk_import_module_native_app_glue()
-target_link_libraries(native-lib native_app_glue)
+target_link_libraries(native-lib PRIVATE native_app_glue)
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
 endif()
 
-
 if(OPENXR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DXR_USE_PLATFORM_ANDROID -DXR_USE_GRAPHICS_API_OPENGL_ES")
-    include_directories(
-            ${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK/include
-            ${CMAKE_SOURCE_DIR}/../app/src/openxr/cpp
-    )
-    if (OCULUSVR)
-        include_directories(
-            ${CMAKE_SOURCE_DIR}/../third_party/OVRPlatformSDK/Include
-        )
-        add_custom_command(TARGET native-lib POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_SOURCE_DIR}/../third_party/ovr_openxr_mobile_sdk/OpenXR/Libs/Android/${ANDROID_ABI}/Release/libopenxr_loader.so
-                ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopenxr_loader.so
-                )
-    elseif (HVR)
+    find_package(OpenXR REQUIRED CONFIG)
+    include_directories(${CMAKE_SOURCE_DIR}/../app/src/openxr/cpp)
+    if (HVR)
+        include_directories(${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK/include)
         add_custom_command(TARGET native-lib POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy
                 ${CMAKE_SOURCE_DIR}/../third_party/hvr/${ANDROID_ABI}/libxr_loader.so
                 ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libxr_loader.so
                 )
     elseif (PICOXR)
-        include_directories(
-            ${CMAKE_SOURCE_DIR}/../third_party/picoxr/include
-        )
+        include_directories(${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK/include)
         add_custom_command(TARGET native-lib POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_SOURCE_DIR}/../third_party/picoxr/libs/android.${ANDROID_ABI}/libopenxr_loader.so
             ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopenxr_loader.so
         )
+    else ()
+        target_link_libraries(native-lib PRIVATE OpenXR::openxr_loader)
     endif ()
     target_sources(
             native-lib
@@ -141,6 +130,7 @@ if(OPENXR)
 endif()
 
 if(OCULUSVR)
+include_directories(${CMAKE_SOURCE_DIR}/../third_party/OVRPlatformSDK/Include)
 add_custom_command(TARGET native-lib POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_SOURCE_DIR}/../third_party/OVRPlatformSDK/Android/libs/${ANDROID_ABI}/libovrplatformloader.so
@@ -162,10 +152,6 @@ find_library( # Sets the name of the path variable.
               android-lib
               android )
 
-add_library(oculusvr-lib SHARED IMPORTED)
-set_target_properties(oculusvr-lib PROPERTIES IMPORTED_LOCATION
-                      ${CMAKE_SOURCE_DIR}/../third_party/ovr_openxr_mobile_sdk/OpenXR/Libs/Android/${ANDROID_ABI}/Release/libopenxr_loader.so )
-
 add_library(ovrplatform-lib SHARED IMPORTED)
 set_target_properties(ovrplatform-lib PROPERTIES IMPORTED_LOCATION
                       ${CMAKE_SOURCE_DIR}/../third_party/OVRPlatformSDK/Android/libs/${ANDROID_ABI}/libovrplatformloader.so )
@@ -182,22 +168,10 @@ add_library(picoxr-lib SHARED IMPORTED)
 set_target_properties(picoxr-lib PROPERTIES IMPORTED_LOCATION
         ${CMAKE_SOURCE_DIR}/../third_party/picoxr/libs/android.${ANDROID_ABI}/libopenxr_loader.so)
 
-if (LYNX OR SPACES)
+if(SPACES)
     find_package(loader REQUIRED CONFIG)
-    target_link_libraries(native-lib loader::openxr_loader)
-endif()
-
-if (AOSP)
-    # Each module in an Android project can link to only one CMake or ndk-build script file. Given
-    # that we already have the native-lib, we need to add other the OpenXR loaded CMake project
-    #to the top level CMakeLists.txt file, i.e., this one.
-    set(lib_src_DIR ${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK)
-    set(lib_build_DIR ${CMAKE_SOURCE_DIR}/../third_party/OpenXR-SDK/build)
-    file(MAKE_DIRECTORY ${lib_build_DIR})
-
-    add_subdirectory(${lib_src_DIR} ${lib_build_DIR})
-    target_link_libraries(native-lib openxr_loader)
-endif()
+    target_link_libraries(native-lib PRIVATE loader::openxr_loader)
+endif ()
 
 # Add dependency on tinygltf library, which is used to load hand models
 # from .glb assets. Since it is only a single C++ source and header,
@@ -210,7 +184,7 @@ include_directories(
 
 # Add dependency on KTX-Software
 add_subdirectory(${CMAKE_SOURCE_DIR}/src/main/cpp/KTX-Software)
-target_link_libraries(native-lib ktx_read)
+target_link_libraries(native-lib PRIVATE ktx_read)
 target_include_directories(native-lib PRIVATE ${CMAKE_SOURCE_DIR}/src/main/cpp/KTX-Software/include)
 
 # Specifies libraries CMake should link to your target library. You
@@ -218,7 +192,7 @@ target_include_directories(native-lib PRIVATE ${CMAKE_SOURCE_DIR}/src/main/cpp/K
 # build script, prebuilt third-party libraries, or system libraries.
 
 target_link_libraries( # Specifies the target library.
-                       native-lib
+                       native-lib PRIVATE
                        vrb
 
                        # Link VR_SDK_LIB exported from gradle flavors

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -213,7 +213,7 @@ android {
             externalNativeBuild {
                 cmake {
                     cppFlags "-DOCULUSVR -DOPENXR"
-                    arguments "-DVR_SDK_LIB=oculusvr-lib", "-DVR_SDK_EXTRA_LIB=ovrplatform-lib", "-DOCULUSVR=ON", "-DOPENXR=ON"
+                    arguments "-DVR_SDK_EXTRA_LIB=ovrplatform-lib", "-DOCULUSVR=ON", "-DOPENXR=ON"
                 }
             }
             manifestPlaceholders = [ headtrackingRequired:"false", permissionToRemove:"android.permission.RECEIVE_BOOT_COMPLETED" ]
@@ -693,6 +693,8 @@ dependencies {
     implementation deps.work.runtime
     implementation deps.work.runtime_ktx
 
+    // OpenXR standard loader
+    implementation 'org.khronos.openxr:openxr_loader_for_android:1.0.34'
 
     // Testing
     androidTestImplementation deps.atsl.runner
@@ -722,9 +724,6 @@ dependencies {
     hvrImplementation 'com.huawei.hms:ml-computer-voice-asr:3.1.0.300'
     hvrImplementation 'com.huawei.hms:location:6.2.0.300'
     hvrImplementation 'com.huawei.hms:push:6.5.0.300'
-
-    // Lynx
-    lynxImplementation fileTree(dir: "${project.rootDir}/third_party/lynx", include: ['*.aar'])
 
     // Snapdragon Spaces
     spacesImplementation fileTree(dir: "${project.rootDir}/third_party/spaces", include: ['*.aar'])

--- a/app/src/aosp/AndroidManifest.xml
+++ b/app/src/aosp/AndroidManifest.xml
@@ -15,12 +15,10 @@
         <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker"/>
     </queries>
     <application>
-        <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
+        <activity android:name=".VRBrowserActivity">
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
             </intent-filter>
         </activity>

--- a/app/src/common/shared/com/igalia/wolvic/VersionCheckActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VersionCheckActivity.java
@@ -1,0 +1,91 @@
+package com.igalia.wolvic;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.igalia.wolvic.utils.SystemUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+public class VersionCheckActivity extends Activity {
+    private static final String META_OS_VERSION = "ro.vros.build.version";
+    private static final int MIN_META_OS_VERSION_WITH_KHR_LOADER = 62;
+    static final String LOGTAG = SystemUtils.createLogtag(VersionCheckActivity.class);
+    private int minSupportedVersion = 0;
+    private boolean browserActivityStarted = false;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (isOSVersionCompatible()) {
+            Intent receivedIntent = getIntent();
+            Bundle extras = receivedIntent.getExtras();
+
+            // Start VRBrowserActivity if OS version is compatible
+            Intent intent = new Intent(this, VRBrowserActivity.class);
+            if (extras != null)
+                intent.putExtras(extras);
+
+            startActivity(intent);
+            browserActivityStarted = true;
+            finish();
+        } else {
+            // Show dialog if OS version is incompatible
+            showIncompatibleOSDialog();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (!browserActivityStarted)
+            System.exit(0);
+    }
+
+    private static String getSystemProperty(String key) {
+        String value = null;
+        try {
+            Process process = Runtime.getRuntime().exec("getprop " + key);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            value = reader.readLine();
+            reader.close();
+            process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+        return value;
+    }
+
+    private boolean isOSVersionCompatible() {
+        if (BuildConfig.FLAVOR_platform.equals("oculusvr")) {
+            minSupportedVersion = MIN_META_OS_VERSION_WITH_KHR_LOADER;
+            String osVersion = getSystemProperty(META_OS_VERSION);
+            Log.i(LOGTAG, "Checking that OS version is at least " + minSupportedVersion + " (found " + osVersion + ")");
+            try {
+                if (osVersion == null || Integer.parseInt(osVersion) < MIN_META_OS_VERSION_WITH_KHR_LOADER)
+                    return false;
+            } catch (NumberFormatException e) {
+                Log.e(LOGTAG, "Failed to parse OS version: " + osVersion);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void showIncompatibleOSDialog() {
+        new AlertDialog.Builder(this)
+            .setTitle(R.string.incompatible_os_version_title)
+            .setMessage(getString(R.string.incompatible_os_version_message, minSupportedVersion))
+            .setOnDismissListener((dialog) -> finish())
+            .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
+            .setIcon(android.R.drawable.ic_dialog_alert)
+            .show();
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <application android:name=".VRBrowserApplication">
         <activity android:name=".VRBrowserActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER"/>
                 <category android:name="android.intent.category.APP_BROWSER" />

--- a/app/src/hvr/AndroidManifest.xml
+++ b/app/src/hvr/AndroidManifest.xml
@@ -35,11 +35,9 @@
         </meta-data>
         <activity
             android:name=".VRBrowserActivity"
-            android:label="@string/app_name"
-            android:screenOrientation="landscape">
+            android:label="@string/app_name">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 

--- a/app/src/lynx/AndroidManifest.xml
+++ b/app/src/lynx/AndroidManifest.xml
@@ -17,11 +17,10 @@
         <package android:name="com.ultraleap.openxr.api_layer" />
     </queries>
     <application>
-        <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
+        <activity android:name=".VRBrowserActivity">
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,14 +31,23 @@
         android:supportsRtl="true"
         android:theme="@style/FxR.Dark">
         <activity
+            android:name=".VersionCheckActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="com.oculus.intent.category.2D" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="com.igalia.wolvic.VRBrowserActivity"
             android:launchMode="singleInstance"
-            android:exported="true"
+            android:exported="false"
             android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
             android:windowSoftInputMode="stateAlwaysHidden">
             <!-- Declares Wolvic as a browser app -->
             <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
 
@@ -47,7 +56,6 @@
             </intent-filter>
             <!-- Used for the special wolvic:// links -->
             <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2565,4 +2565,8 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="eye_tracking_permission_title">Eye Tracking Permissions</string>
     <string name="eye_tracking_permission_message">Enabling eye tracking for browsing the web poses significant privacy risks. This technology captures where and how long a user looks at specific parts of a webpage, revealing intimate details about their interests and emotional reactions. Advertisers and third parties can exploit this data for intrusive marketing and profiling. Moreover, eye movement patterns could infer sensitive information such as medical conditions, cognitive states, or personal habits. Therefore, it is crucial to consider the privacy implications before granting access to eye tracking information to webpages.</string>
 
+    <!-- Shown when starting the application if the OS version is not compatible -->
+    <string name="incompatible_os_version_title">Incompatible OS Version</string>
+    <string name="incompatible_os_version_message">Your OS version is not supported. This version of Wolvic requires at least version %1$d</string>
+
 </resources>

--- a/app/src/noapi/AndroidManifest.xml
+++ b/app/src/noapi/AndroidManifest.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <activity android:name=".VRBrowserActivity"
+        <activity
+            android:name=".VRBrowserActivity"
             android:screenOrientation="landscape">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -55,7 +55,6 @@ public class PlatformActivity extends NativeActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Log.e(LOGTAG,"in onCreate");
         super.onCreate(savedInstanceState);
         //getWindow().takeInputQueue(null);
         // Keep the screen on

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -51,12 +51,10 @@
             android:windowSoftInputMode="stateAlwaysHidden"
             android:resizeableActivity="false"
             android:supportsPictureInPicture="false"
-            tools:replace="android:launchMode, android:configChanges"
-            android:exported="true">
+            tools:replace="android:launchMode, android:configChanges">
             <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.INFO" />
                 <category android:name="com.oculus.intent.category.VR" android:value="vr_only"/>
             </intent-filter>

--- a/app/src/picoxr/AndroidManifest.xml
+++ b/app/src/picoxr/AndroidManifest.xml
@@ -8,12 +8,8 @@
     <uses-permission android:name="com.picovr.permission.EYE_TRACKING"/>
 
     <application android:requestLegacyExternalStorage="true">
-        <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
+        <activity android:name=".VRBrowserActivity">
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <meta-data android:name="pvr.app.type" android:value="vr" />
         <meta-data android:name="handtracking" android:value="1" />

--- a/app/src/spaces/AndroidManifest.xml
+++ b/app/src/spaces/AndroidManifest.xml
@@ -39,16 +39,12 @@
 
     <application>
         <activity
-            android:name=".VRBrowserActivity"
-            android:screenOrientation="landscape">
+            android:name=".VRBrowserActivity">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="native-lib" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="snapdragon.intent.category.SPACES" />
             </intent-filter>
         </activity>

--- a/app/src/visionglass/AndroidManifest.xml
+++ b/app/src/visionglass/AndroidManifest.xml
@@ -6,12 +6,9 @@
         android:required="false" />
 
     <application>
-        <activity
-            android:name=".VRBrowserActivity"
-            android:screenOrientation="portrait"
-            android:exported="true">
+        <activity android:name=".VRBrowserActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
Most of the platforms used to distribute their own implementations/builds of the OpenXR loader. It was traditionally part of the propietary SDKs distributed by vendors. As they were under an EULA we had to keep them in a private repository only available to core devs (obviously any other external dev could download them on their own).

More recently, and driven by the AOSP flavor effort, we started to build the Khronos OpenXR loader from sources. Fortunatelly we got a well documented report explaining how to use the loader directly from the central Maven repository. This greatly simplifies the build process and also improves the open-source feel of the project by reducing our deps with the third-party repo.

So far this option is now available for the following flavors:
* Meta Quest2, Quest3, QuestPro (requires firmware v62+)
* Lynx R1
* Magic Leap 2

It does not work for neither HVR, nor SnapdragonSpaces based devices nor Pico. For these ones we still need to rely on the loader from the SDK.

Fixes #1394