### PR TITLE
Preserve autocompleted URL

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NavigationURLBar.java
@@ -158,8 +158,9 @@ public class NavigationURLBar extends FrameLayout {
         mBinding.urlEditText.setOnEditorActionListener((aTextView, actionId, event) -> {
             if (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_SEARCH
                     || actionId == EditorInfo.IME_ACTION_GO || actionId == EditorInfo.IME_ACTION_SEND) {
+                String textContent = aTextView.getText().toString();
                 ((Activity)getContext()).runOnUiThread(() -> {
-                    handleURLEdit(aTextView.getText().toString());
+                    handleURLEdit(textContent);
                 });
                 return true;
             }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1008,14 +1008,17 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         }
         final InputConnection connection = mInputConnection;
         final int action = mEditorInfo.imeOptions & EditorInfo.IME_MASK_ACTION;
-        postInputCommand(() -> postDisplayCommand(() -> connection.performEditorAction(action)));
+        postInputCommand(() -> postDisplayCommand(() -> {
+            // Handle the action before clearing the focus, otherwise URL autocomplete will be lost.
+            connection.performEditorAction(action);
 
-        boolean hide = (action == EditorInfo.IME_ACTION_DONE) || (action == EditorInfo.IME_ACTION_GO) ||
+            boolean hide = (action == EditorInfo.IME_ACTION_DONE) || (action == EditorInfo.IME_ACTION_GO) ||
                 (action == EditorInfo.IME_ACTION_SEARCH) || (action == EditorInfo.IME_ACTION_SEND);
 
-        if (hide && mFocusedView != null) {
-            mFocusedView.clearFocus();
-        }
+            if (hide && mFocusedView != null) {
+                mFocusedView.clearFocus();
+            }
+        }));
     }
 
     private void handleShowKeyboard(Keyboard aKeyboard) {


### PR DESCRIPTION
Ensure that the editor action listener in the URL bar gets called before the focus is cleared, otherwise the autocompleted text will have been lost by the time we try to use it to navigate.

Fixes #1267 