### PR TITLE
[VisionGlass] Make seek backward/forward work with non-fullscreen media

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/Media.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/Media.java
@@ -100,6 +100,18 @@ public class Media implements WMediaSession.Delegate {
        }
     }
 
+    public void seekForward() {
+        if (mMediaSession != null) {
+            mMediaSession.seekForward();
+        }
+    }
+
+    public void seekBackward() {
+        if (mMediaSession != null) {
+            mMediaSession.seekBackward();
+        }
+    }
+
     public void play() {
         if (mMediaSession != null) {
             mMediaSession.play();

--- a/app/src/main/res/drawable/ic_icon_media_seek_backward.xml
+++ b/app/src/main/res/drawable/ic_icon_media_seek_backward.xml
@@ -1,0 +1,10 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M100 18.41a84.67 84.67 0 0 0-34.2 7.2l-7.24-10.49A6.58 6.58 0 0 0 47.2 16L29.82 52.61A6.58 6.58 0 0 0 36.29 62l40.37-3.24a6.58 6.58 0 0 0 4.89-10.29l-6.47-9.38a68.66 68.66 0 1 1-43.74 64 8 8 0 0 0-16 0A84.66 84.66 0 1 0 100 18.41z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_icon_media_seek_forward.xml
+++ b/app/src/main/res/drawable/ic_icon_media_seek_forward.xml
@@ -1,0 +1,10 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M100 18.41a84.67 84.67 0 0 1 34.2 7.2l7.24-10.49a6.58 6.58 0 0 1 11.36.88l17.38 36.58a6.58 6.58 0 0 1-6.47 9.42l-40.37-3.24a6.58 6.58 0 0 1-4.89-10.29l6.47-9.38a68.66 68.66 0 1 0 43.74 64 8 8 0 0 1 16 0A84.66 84.66 0 1 1 100 18.41z"/>
+</vector>

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -516,14 +516,14 @@ public class PlatformActivity extends ComponentActivity implements SensorEventLi
                 Media media = getActiveMedia();
                 if (media == null)
                     return;
-                media.seek(media.getCurrentTime() - 10);
+                media.seekBackward();
             });
 
             mBinding.seekForwardButton.setOnClickListener(v -> {
                 Media media = getActiveMedia();
                 if (media == null)
                     return;
-                media.seek(media.getCurrentTime() + 30);
+                media.seekForward();
             });
 
             mBinding.voiceSearchButton.setOnClickListener(v -> {

--- a/app/src/visionglass/res/layout/visionglass_layout.xml
+++ b/app/src/visionglass/res/layout/visionglass_layout.xml
@@ -165,7 +165,7 @@
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        app:icon="@drawable/ic_icon_media_seek_backward_10"
+                        app:icon="@drawable/ic_icon_media_seek_backward"
                         app:iconGravity="textStart"
                         app:iconPadding="0dp"
                         app:iconTint="@color/white" />
@@ -187,7 +187,7 @@
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        app:icon="@drawable/ic_icon_media_seek_forward_30"
+                        app:icon="@drawable/ic_icon_media_seek_forward"
                         app:iconGravity="textStart"
                         app:iconPadding="0dp"
                         app:iconTint="@color/white" />


### PR DESCRIPTION
The previous implementation was relying on the Media's seekTo() method and, specifically for this case, on the getCurrentTime(). The problem of the latter is that it depends on receiving position changed events from the Web engine. In the case of Gecko, for whatever reason, those events are only emitted when in fullscreen.

By switching to using seekForward()/seekBackward() we can keep the functionality. The only significat change is that we cannot control the amount of time skipped, which will be now 5s instead of the previous 10s for backwards and 30s for forwards.