### PR TITLE
[VisionGlass] WebXR fixes

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WebXRInterstitialWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WebXRInterstitialWidget.java
@@ -122,6 +122,8 @@ public class WebXRInterstitialWidget extends UIWidget implements WidgetManagerDe
         } else if (deviceType == DeviceType.LenovoVRX) {
             addController(DeviceType.LenovoVRX, WebXRInterstitialController.HAND_LEFT);
             addController(DeviceType.LenovoVRX, WebXRInterstitialController.HAND_RIGHT);
+        } else if (deviceType == DeviceType.VisionGlass) {
+            addController(DeviceType.VisionGlass, WebXRInterstitialController.HAND_NONE);
         }
         for (UIWidget controller: mControllers) {
             controller.getPlacement().parentHandle = getHandle();

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -231,6 +231,7 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
           break;
     case device::HVR3DoF:
     case device::HVR6DoF:
+    case device::VisionGlass:
     case device::ViveFocus:
       result = mozilla::gfx::VRControllerType::HTCViveFocus;
       break;
@@ -261,9 +262,6 @@ mozilla::gfx::VRControllerType GetVRControllerTypeByDevice(device::DeviceType aT
     case device::LynxR1:
       // FIXME: Gecko does not support LynxR1 device yet, so let's use a similar one for WebXR.
       result = mozilla::gfx::VRControllerType::OculusTouch3;
-      break;
-    case device::VisionGlass:
-      result = mozilla::gfx::VRControllerType::_empty;
       break;
     case device::UnknownType:
     default:

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -205,14 +205,14 @@ DeviceDelegateVisionGlass::SetControllerDelegate(ControllerDelegatePtr& aControl
   m.controller = aController;
   m.controller->CreateController(kControllerIndex, kControllerIndex, "Vision Glass Controller");
   m.controller->SetEnabled(kControllerIndex, true);
-  m.controller->SetCapabilityFlags(kControllerIndex, device::Orientation);
   m.controller->SetTargetRayMode(kControllerIndex, device::TargetRayMode::TrackedPointer);
   m.controller->SetControllerType(kControllerIndex, device::VisionGlass);
   m.controller->SetMode(kControllerIndex, ControllerMode::Device);
   m.controller->SetAimEnabled(kControllerIndex, true);
-  m.controller->SetCapabilityFlags(kControllerIndex, device::Orientation);
+  m.controller->SetCapabilityFlags(kControllerIndex, device::Orientation | device::PositionEmulated | device::GripSpacePosition);
 
-  m.controller->SetButtonCount(kControllerIndex, 5);
+  m.controller->SetButtonCount(kControllerIndex, 1);
+  m.controller->SetButtonState(kControllerIndex, ControllerDelegate::BUTTON_TRIGGER, device::kImmersiveButtonTrigger, false, false);
 }
 
 void

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -111,8 +111,8 @@ struct DeviceDelegateVisionGlass::State {
     cameras[0]->SetPerspective(fov);
     cameras[1]->SetPerspective(fov);
     immersiveDisplay->SetEyeResolution((int32_t)(glWidth / 2), glHeight);
-    immersiveDisplay->SetFieldOfView(device::Eye::Left, -halfHorizontalFOV, halfHorizontalFOV, halfVerticalFOV, -halfVerticalFOV);
-    immersiveDisplay->SetFieldOfView(device::Eye::Right, -halfHorizontalFOV, halfHorizontalFOV, halfVerticalFOV, -halfVerticalFOV);
+    immersiveDisplay->SetFieldOfView(device::Eye::Left, halfHorizontalFOV, halfHorizontalFOV, halfVerticalFOV, halfVerticalFOV);
+    immersiveDisplay->SetFieldOfView(device::Eye::Right, halfHorizontalFOV, halfHorizontalFOV, halfVerticalFOV, halfVerticalFOV);
 
     immersiveDisplay->SetCapabilityFlags(device::PositionEmulated | device::Orientation | device::Present | device::InlineSession | device::ImmersiveVRSession);
   }


### PR DESCRIPTION
This PR reenables WebXR rendering in VisionGlass port. It also brings some interesting fixes like:
* controller has now a valid position in WebXR
* a 3D model of the controller is shown (from the WebXR registry) if none is rendered by the experience
* removed the sitting to standing transform which was moving the head position way too high