### PR TITLE
Prevent crash when clearing the focus of the URL bar

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1008,16 +1008,17 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         }
         final InputConnection connection = mInputConnection;
         final int action = mEditorInfo.imeOptions & EditorInfo.IME_MASK_ACTION;
+        final boolean hide = (action == EditorInfo.IME_ACTION_DONE) || (action == EditorInfo.IME_ACTION_GO) ||
+                (action == EditorInfo.IME_ACTION_SEARCH) || (action == EditorInfo.IME_ACTION_SEND);
         postInputCommand(() -> postDisplayCommand(() -> {
             // Handle the action before clearing the focus, otherwise URL autocomplete will be lost.
             connection.performEditorAction(action);
 
-            boolean hide = (action == EditorInfo.IME_ACTION_DONE) || (action == EditorInfo.IME_ACTION_GO) ||
-                (action == EditorInfo.IME_ACTION_SEARCH) || (action == EditorInfo.IME_ACTION_SEND);
-
-            if (hide && mFocusedView != null) {
-                mFocusedView.clearFocus();
-            }
+            postUICommand(() -> {
+                if (hide && mFocusedView != null) {
+                    mFocusedView.clearFocus();
+                }
+            });
         }));
     }
 


### PR DESCRIPTION
This change prevents a crash when clearing the focus of the URL bar from the wrong thread.