### PR TITLE
[VisionGlass] Multiple fixes for WebXR and controller orientations

### DIFF
--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -209,7 +209,7 @@ DeviceDelegateVisionGlass::SetControllerDelegate(ControllerDelegatePtr& aControl
   m.controller->SetControllerType(kControllerIndex, device::VisionGlass);
   m.controller->SetMode(kControllerIndex, ControllerMode::Device);
   m.controller->SetAimEnabled(kControllerIndex, true);
-  m.controller->SetCapabilityFlags(kControllerIndex, device::Orientation | device::PositionEmulated | device::GripSpacePosition);
+  m.controller->SetCapabilityFlags(kControllerIndex, device::Orientation | device::PositionEmulated);
 
   m.controller->SetButtonCount(kControllerIndex, 1);
   m.controller->SetButtonState(kControllerIndex, ControllerDelegate::BUTTON_TRIGGER, device::kImmersiveButtonTrigger, false, false);

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -255,7 +255,6 @@ DeviceDelegateVisionGlass::StartFrame(const FramePrediction aPrediction) {
   m.cameras[1]->SetHeadTransform(headTransform);
   m.immersiveDisplay->SetEyeTransform(device::Eye::Left, m.cameras[0]->GetEyeTransform());
   m.immersiveDisplay->SetEyeTransform(device::Eye::Right, m.cameras[1]->GetEyeTransform());
-  m.immersiveDisplay->SetSittingToStandingTransform(vrb::Matrix::Translation(kAverageHeight));
 
   // Update controller
   if (!m.controller)

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -70,7 +70,7 @@ struct DeviceDelegateVisionGlass::State {
   }
 
   void SetupOrientationFilter() {
-      orientationFilter = std::make_unique<OneEuroFilterQuaternion>(0.1, 0.5, 1.0);
+      orientationFilter = std::make_unique<OneEuroFilterQuaternion>(0.25, 2, 1.0);
   }
 
   void Initialize() {

--- a/app/src/visionglass/res/values/dimen.xml
+++ b/app/src/visionglass/res/values/dimen.xml
@@ -6,4 +6,5 @@
     <dimen name="media_controls_world_z" format="float" type="dimen">1.5</dimen>
     <item name="tray_world_z" format="float" type="dimen">-4.0</item>
     <item name="keyboard_z" format="float" type="dimen">-4.0</item>
+    <item name="webxr_interstitial_world_y" format="float" type="dimen">1.5</item>
 </resources>


### PR DESCRIPTION
This PR finally addresses the problem with the phone as a controller, the unreliable and inaccurate orientation of the pointer as soon as the head was turn around. We're suffering the well known issue in 3D world of gimbal lock. But the PR has much more to offer :), summarizing:
1. Make the transformations in orientation sensor code self-explanatory
2. Remove invalid capabilities from the controller
3. Remove sitting to standing transform (view position too high)
4. Fix controller's gimbal lock
5. Make 1€ filter more responsive on high speed movements
6. Make the interstitial visible by moving the text up to the eye level