### PR TITLE
[Chromium] Fix crash in media permissions

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/PermissionDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/PermissionDelegate.java
@@ -303,8 +303,8 @@ public class PermissionDelegate implements WSession.PermissionDelegate, WidgetMa
     public void onMediaPermissionRequest(@NonNull WSession aSession, @NonNull String aUri, MediaSource[] aVideo, MediaSource[] aAudio, @NonNull final MediaCallback aMediaCallback) {
         Log.d(LOGTAG, "onMediaPermissionRequest: " + aUri);
 
-        final MediaSource video = aVideo != null ? aVideo[0] : null;
-        final MediaSource audio = aAudio != null ? aAudio[0] : null;
+        final MediaSource video = aVideo != null && aVideo.length > 0 ? aVideo[0] : null;
+        final MediaSource audio = aAudio != null && aAudio.length > 0 ? aAudio[0] : null;
         PermissionWidget.PermissionType type;
         if (video != null && audio != null) {
             type = PermissionWidget.PermissionType.CameraAndMicrophone;


### PR DESCRIPTION
Requesting an empty list of either video or audio media sources is currently causing a crash because Wolvic expects aAudio or aVideo to be null in this case but Chromium provides an empty list instead. This patch makes the code more robust by supporting both an empty list and a null object.