### PR TITLE
Add a new UA override for Museo del Prado

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/UriOverride.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/UriOverride.java
@@ -90,7 +90,7 @@ public class UriOverride {
                 Log.d(LOGTAG, "Failed to hash domain: " + domain);
                 return null;
             }
-            Log.d(LOGTAG, "hash: " + domainHash);
+            Log.d(LOGTAG, "hash: " + domainHash + " for domain: " + domain);
             override = mOverrideMap.get(domainHash);
             if (override != null) {
                 Log.d(LOGTAG, "found override from hash: " + override);

--- a/app/src/gecko/assets/userAgentOverride.json
+++ b/app/src/gecko/assets/userAgentOverride.json
@@ -19,6 +19,7 @@
   "ed510f9b2add002ee2b14418c5c4a64f376beb63668953c5a2e43989010aa22afc11b9eadc7fd3969f02eae8125e2c2ae1c1e9eaf2e6e35c3c653ab55a942aab": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
   "44908fbb56b0dd5ed7769e601ed3067b38c3ef01638acc8d1e2c4b6d3a5ca3004643a0dc2115a30b193023a034d555ea081082c5dc30ad44181b4af61fe7a38c": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
   "b1788b8e6dd78d0d5b91b66f8f9be9f9eae5024a38e426aaa2f0f7859d96b56fd693941f8a3ef071c4f21367f26cd14ff6ef4303c1fbec7e33ff1ca44137431f": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
-  "c0f87f0034d49b825116cdb8a9387e9b3715dd78f6affb05cd3141c3e56c780ffde29f68347278a2b8fa5fc20e09a693f61bd4189d42c109ae29105ba89b5bbb": "Mozilla/5.0 (X11; LinuxX86_64; rv:121.0) Gecko/20100101 Firefox/121.0"
+  "c0f87f0034d49b825116cdb8a9387e9b3715dd78f6affb05cd3141c3e56c780ffde29f68347278a2b8fa5fc20e09a693f61bd4189d42c109ae29105ba89b5bbb": "Mozilla/5.0 (X11; LinuxX86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+  "41ff0a55eb311911674b0c8a68eda6f2078cba4f7a44d6af6290fe149330e6d4e34493b0b0f81fc69d1a2345dac539e1bee8ac7d9704f84a81271e0411da0536": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36"
 }
 


### PR DESCRIPTION
As usual we were getting a WebVR page instead of the WebXR version that is correctly served if we pretend to be Chromium.

Also added some more debug that will help when adding overrides.