### PR TITLE
[OpenXR] Remove simple khronos interaction profile

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -969,6 +969,12 @@ BrowserWorld::InitializeJava(JNIEnv* aEnv, jobject& aActivity, jobject& aAssetMa
 
   tinygltf::asset_manager = AAssetManager_fromJava(m.env, aAssetManager);
 
+  m.device->OnControllersCreated([this](){
+    m.controllers->InitializeBeam();
+    m.controllers->SetPointerColor(vrb::Color(VRBrowser::GetPointerColor()));
+    m.rootController->AddNode(m.controllers->GetRoot());
+  });
+
   if (!m.modelsLoaded) {
     m.device->OnControllersReady([this](){
       const int32_t modelCount = m.device->GetControllerModelCount();
@@ -987,12 +993,8 @@ BrowserWorld::InitializeJava(JNIEnv* aEnv, jobject& aActivity, jobject& aAssetMa
           }
         }
       }
-      m.controllers->InitializeBeam();
-      m.controllers->SetPointerColor(vrb::Color(VRBrowser::GetPointerColor()));
-      m.rootController->AddNode(m.controllers->GetRoot());
-      if (m.device->IsControllerLightEnabled()) {
+      if (m.device->IsControllerLightEnabled())
         m.rootController->AddLight(m.light);
-      }
     });
 
     VRBrowser::CheckTogglePassthrough();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -99,6 +99,7 @@ public:
   virtual void DeleteLayer(const VRLayerPtr& aLayer) {};
   virtual bool IsControllerLightEnabled() const { return true; }
   virtual vrb::LoadTask GetControllerModelTask(int32_t index) { return nullptr; } ;
+  virtual void OnControllersCreated(std::function<void()> callback) { callback(); }
   virtual void OnControllersReady(const std::function<void()>& callback) {
     callback();
   }

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -587,33 +587,11 @@ struct DeviceDelegateOpenXR::State {
     return nullptr;
   }
 
-  const char* GetDefaultInteractionProfilePath() {
-#if OCULUSVR
-      return OculusTouch.path;
-#elif PICOXR
-      return Pico4x.path;
-#else
-      if (deviceType == device::MagicLeap2)
-          return MagicLeap2.path;
-      return KHRSimple.path;
-#endif
-  }
-
   void BeginXRSession() {
       XrSessionBeginInfo sessionBeginInfo{XR_TYPE_SESSION_BEGIN_INFO};
       sessionBeginInfo.primaryViewConfigurationType = viewConfigType;
       CHECK_XRCMD(xrBeginSession(session, &sessionBeginInfo));
       vrReady = true;
-
-      // If hand tracking is supported, we want to emulate a default interaction
-      // profile, so that if Wolvic is launched without controllers active, we can
-      // still use hand tracking for emulating the controllers.
-      // This is a temporary situation while we don't implement WebXR hand tracking
-      // APIs.
-      if (mHandTrackingSupported) {
-          if (const char* defaultProfilePath = GetDefaultInteractionProfilePath())
-              UpdateInteractionProfile(defaultProfilePath);
-      }
   }
 
   void HandleSessionEvent(const XrEventDataSessionStateChanged& event) {
@@ -782,11 +760,11 @@ struct DeviceDelegateOpenXR::State {
     controllersReadyCallback = nullptr;
   }
 
-  void UpdateInteractionProfile(const char* emulateProfile = nullptr) {
+  void UpdateInteractionProfile() {
       if (!input || !controller)
           return;
 
-      input->UpdateInteractionProfile(*controller, emulateProfile);
+      input->UpdateInteractionProfile(*controller);
       MaybeNotifyControllersReady();
   }
 

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -42,6 +42,7 @@ public:
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
   bool IsPositionTrackingSupported() const override;
+  void OnControllersCreated(std::function<void()> callback) override;
   void OnControllersReady(const std::function<void()>& callback) override;
   void SetCPULevel(const device::CPULevel aLevel) override;
   void ProcessEvents() override;

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -112,10 +112,10 @@ std::string OpenXRInput::GetControllerModelName(const int32_t aModelIndex) const
   return mInputSources.at(aModelIndex)->ControllerModelName();
 }
 
-void OpenXRInput::UpdateInteractionProfile(ControllerDelegate& delegate, const char* emulateProfile)
+void OpenXRInput::UpdateInteractionProfile(ControllerDelegate& delegate)
 {
   for (auto& input : mInputSources) {
-    input->UpdateInteractionProfile(delegate, emulateProfile);
+    input->UpdateInteractionProfile(delegate);
   }
 }
 

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -56,7 +56,7 @@ public:
   XrResult Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, ControllerDelegate& delegate);
   int32_t GetControllerModelCount() const;
   std::string GetControllerModelName(const int32_t aModelIndex) const;
-  void UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);
+  void UpdateInteractionProfile(ControllerDelegate&);
   bool AreControllersReady() const;
   void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
   HandMeshBufferPtr GetNextHandMeshBuffer(const int32_t aControllerIndex);

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -31,7 +31,6 @@ namespace crow {
     constexpr const char* kPathThumbstick { "input/thumbstick" };
     constexpr const char* kPathThumbrest { "input/thumbrest" };
     constexpr const char* kPathTrackpad { "input/trackpad" };
-    constexpr const char* kPathSelect { "input/select" };
     constexpr const char* kPathMenu { "input/menu" };
     constexpr const char* kPathBack { "input/back" };
     constexpr const char* kPathHaptic { "output/haptic" };
@@ -412,25 +411,8 @@ namespace crow {
         {}
     };
 
-    // Default fallback: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-button.json
-    const OpenXRInputMapping KHRSimple {
-            "/interaction_profiles/khr/simple_controller",
-            IS_3DOF,
-            "vr_controller_oculusgo.obj",
-            "vr_controller_oculusgo.obj",
-            device::UnknownType,
-            std::vector<OpenXRInputProfile> { "generic-button" },
-            std::vector<OpenXRButton> {
-                    { OpenXRButtonType::Trigger, kPathSelect, OpenXRButtonFlags::Click, OpenXRHandFlags::Both },
-            },
-            {},
-            std::vector<OpenXRHaptic> {
-                    { kPathHaptic, OpenXRHandFlags::Both },
-            },
-    };
-
-    const std::array<OpenXRInputMapping, 12> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4x, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, HandInteraction, KHRSimple
+    const std::array<OpenXRInputMapping, 11> OpenXRInputMappings {
+        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4x, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, HandInteraction
     };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -668,7 +668,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
     delegate.SetMode(mIndex, ControllerMode::Hand);
     delegate.SetEnabled(mIndex, true);
-    delegate.SetControllerType(mIndex, mDeviceType);
+    delegate.SetButtonCount(mIndex, 1);
 
     // Select action
     bool indexPinching = false;
@@ -744,12 +744,9 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
 
 void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, ControllerDelegate& delegate)
 {
-    if (!mActiveMapping) {
-      delegate.SetEnabled(mIndex, false);
-      return;
-    }
-
-    if ((mHandeness == OpenXRHandFlags::Left && !mActiveMapping->leftControllerModel) || (mHandeness == OpenXRHandFlags::Right && !mActiveMapping->rightControllerModel)) {
+    if (mActiveMapping &&
+        ((mHandeness == OpenXRHandFlags::Left && !mActiveMapping->leftControllerModel) ||
+         (mHandeness == OpenXRHandFlags::Right && !mActiveMapping->rightControllerModel))) {
       delegate.SetEnabled(mIndex, false);
       return;
     }
@@ -810,6 +807,11 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
             }
             delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
         }
+    }
+
+    if (!mActiveMapping) {
+        delegate.SetEnabled(mIndex, false);
+        return;
     }
 
     bool hasAim = isPoseActive && (poseLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT);
@@ -1022,15 +1024,13 @@ XrResult OpenXRInputSource::UpdateInteractionProfile(ControllerDelegate& delegat
         }
     }
 
+    uint32_t numHaptics = 0;
     if (mActiveMapping != nullptr) {
         // Add haptic devices to controller, if any
-        uint32_t numHaptics = 0;
         for (auto& haptic: mActiveMapping->haptics) {
             if (haptic.hand == OpenXRHandFlags::Both || haptic.hand == mHandeness)
                 numHaptics++;
         }
-        delegate.SetHapticCount(mIndex, numHaptics);
-
         // On emulated profiles we need to set the button count here because it
         // may never be set during Update() (e.g, when hand tracking is active).
         if (emulateProfile) {
@@ -1044,6 +1044,7 @@ XrResult OpenXRInputSource::UpdateInteractionProfile(ControllerDelegate& delegat
             delegate.SetButtonCount(mIndex, buttonCount);
         }
     }
+    delegate.SetHapticCount(mIndex, numHaptics);
 
     return XR_SUCCESS;
 }

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -77,15 +77,8 @@ XrResult OpenXRInputSource::Initialize()
         systemDoF = DoF::IS_6DOF;
     }
     for (auto& mapping: OpenXRInputMappings) {
-      // Always populate default/fall-back profiles
-      if (mapping.controllerType == device::UnknownType) {
-          mMappings.push_back(mapping);
-          // Use the system's deviceType instead to ensure we get a valid VRController on WebXR sessions
-          mMappings.back().controllerType = mDeviceType;
+      if (mDeviceType != mapping.controllerType)
         continue;
-      } else if (mDeviceType != mapping.controllerType) {
-        continue;
-      }
 
       if (systemDoF != mapping.systemDoF)
           continue;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -82,6 +82,7 @@ private:
     OpenXRGesturePtr mGestureManager;
     bool mSupportsHandJointsMotionRangeInfo { false };
     bool mUsingHandInteractionProfile { false };
+    device::DeviceType mDeviceType { device::UnknownType };
 
     struct HandMeshMSFT {
         XrSpace space = XR_NULL_HANDLE;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -109,7 +109,7 @@ public:
 
     XrResult SuggestBindings(SuggestedBindings&) const;
     void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, ControllerDelegate& delegate);
-    XrResult UpdateInteractionProfile(ControllerDelegate&, const char* emulateProfile = nullptr);
+    XrResult UpdateInteractionProfile(ControllerDelegate&);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }
     void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);


### PR DESCRIPTION
This PR fixes #1430 by removing the simple khronos interaction profile which is causing unexpected behaviours and interactions with other interaction profiles and hand tracking. In particular when enabled in Meta devices this profile
causes all the hand tracking data to become zero, effectively disabling it.

Removing it is not as simple as it might look like. The current code heavily depend on having an active OpenXR interaction profile (also called input mapping in the code) which does make sense for devices with physical controllers. However devices with no controllers should not need any. That's why in order to remove that profile we had first to remove that constraint which required several previous steps, namely:
1. Do not use input mappings to set the device type (as there might not be interaction profiles)
2. Do not make the beam creation depend on interaction profiles (as there might be none)
3. Allow Wolvic to run without active interaction profiles (like in hand tracking devices)
4. Get rid of the emulated profile we had to ensure there was always an interaction profile

The nice thing about this sequence of patches is that the fix comes in the last patch but none of the previous ones break hand-tracking only devices as the Lynx R1 or the Lenovo A3
 