### PR TITLE
Remove READ_PHONE_STATE permission for Meta Store packages

### DIFF
--- a/app/src/oculusvrChromiumMetaStore/AndroidManifest.xml
+++ b/app/src/oculusvrChromiumMetaStore/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:installLocation="auto">
+
+    <!-- Not allowed by Meta Store -->
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
+
+</manifest>


### PR DESCRIPTION
That permission comes from Chromium. We need to remove it as it is indeed not allowed by Meta store.