### PR TITLE
Add missing proguard rules for Huawei SDK libraries

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -85,6 +85,9 @@
 -keep class com.huawei.agconnect.**{*;}
 -keep class com.huawei.hms.analytics.**{*;}
 -keep class com.huawei.hms.push.**{*;}
+-keep class com.huawei.usblib.**{*;}
+-keep class com.huawei.hvr.**{*;}
+-keep class com.huawei.hmf.**{*;}
 
 -dontwarn **
 -target 1.7


### PR DESCRIPTION
Vision Glass release builds don't work correctly because they need exceptions in `proguard-rules.pro` for a few additional libraries from the Huawei SDK.