### PR TITLE
[OpenXR] Add support for hand interaction profile

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -204,6 +204,9 @@ struct DeviceDelegateOpenXR::State {
     if (OpenXRExtensions::IsExtensionSupported(XR_ML_FRAME_END_INFO_EXTENSION_NAME))
         extensions.push_back(XR_ML_FRAME_END_INFO_EXTENSION_NAME);
 
+    if (OpenXRExtensions::IsExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME))
+        extensions.push_back(XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
+
     java = {XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR};
     java.applicationVM = javaContext->vm;
     java.applicationActivity = javaContext->activity;

--- a/app/src/openxr/cpp/OpenXRActionSet.cpp
+++ b/app/src/openxr/cpp/OpenXRActionSet.cpp
@@ -102,6 +102,9 @@ XrResult OpenXRActionSet::GetOrCreateButtonActions(OpenXRButtonType type, OpenXR
   if (flags  & OpenXRButtonFlags::Value) {
     RETURN_IF_XR_FAILED(CreateAction(XR_ACTION_TYPE_FLOAT_INPUT, key + "_value", hand, actions.value));
   }
+  if (flags  & OpenXRButtonFlags::Ready) {
+    RETURN_IF_XR_FAILED(CreateAction(XR_ACTION_TYPE_BOOLEAN_INPUT, key + "_ready_ext", hand, actions.ready));
+  }
 
   mButtonActions.emplace(key, actions);
 

--- a/app/src/openxr/cpp/OpenXRActionSet.h
+++ b/app/src/openxr/cpp/OpenXRActionSet.h
@@ -18,6 +18,7 @@ namespace crow {
       XrAction click { XR_NULL_HANDLE };
       XrAction touch { XR_NULL_HANDLE };
       XrAction value { XR_NULL_HANDLE };
+      XrAction ready { XR_NULL_HANDLE };
     };
   private:
     OpenXRActionSet(XrInstance, XrSession);

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -46,6 +46,9 @@ void OpenXRExtensions::Initialize() {
 #elif PICOXR
     // Pico incorrectly advertises this extension as supported but it makes Wolvic not work.
     sSupportedExtensions.erase(XR_EXTX_OVERLAY_EXTENSION_NAME);
+#elif SPACES
+    // Spaces incorrectly advertises this extension as supported but it does not really work.
+    sSupportedExtensions.erase(XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
 #endif
 
     // Adding this check here is ugly but required to have a working build for VRX. With the current

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -39,9 +39,13 @@ namespace crow {
     constexpr const char* kPathButtonB { "input/b" };
     constexpr const char* kPathButtonX { "input/x" };
     constexpr const char* kPathButtonY { "input/y" };
+    constexpr const char* kPinchPose { "input/pinch_ext/pose" };
+    constexpr const char* kPokePose { "input/poke_ext/pose" };
     constexpr const char* kPathActionClick { "click" };
     constexpr const char* kPathActionTouch { "touch" };
     constexpr const char* kPathActionValue { "value" };
+    constexpr const char* kPathActionReady { "ready_ext" };
+    constexpr const char* kInteractionProfileHandInteraction { "/interaction_profiles/ext/hand_interaction_ext" };
 
     // OpenXR Button List
     enum class OpenXRButtonType {
@@ -73,9 +77,11 @@ namespace crow {
         Click = (1u << 0),
         Touch = (1u << 1),
         Value  = (1u << 2),
+        Ready = (1u << 3),
         ValueTouch = Touch | Value,
         ClickTouch = Click | Touch,
         ClickValue = Click | Value,
+        ReadyValue = Ready | Value,
         All  = Click | Touch | Value,
     };
 
@@ -391,6 +397,21 @@ namespace crow {
             },
     };
 
+    const OpenXRInputMapping HandInteraction {
+        kInteractionProfileHandInteraction,
+        IS_6DOF,
+        "",
+        "",
+        device::UnknownType,
+        std::vector<OpenXRInputProfile> { "generic-hand-select-grasp", "generic-hand-select", "generic-hand" },
+        std::vector<OpenXRButton> {
+                { OpenXRButtonType::Trigger, "input/pinch_ext", OpenXRButtonFlags::ReadyValue, OpenXRHandFlags::Both },
+                /* Not adding aim_activate_ext nor grasp_ext as we don't need them yet */
+        },
+        {},
+        {}
+    };
+
     // Default fallback: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-button.json
     const OpenXRInputMapping KHRSimple {
             "/interaction_profiles/khr/simple_controller",
@@ -408,8 +429,8 @@ namespace crow {
             },
     };
 
-    const std::array<OpenXRInputMapping, 11> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4x, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, KHRSimple
+    const std::array<OpenXRInputMapping, 12> OpenXRInputMappings {
+        OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4x, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, HandInteraction, KHRSimple
     };
 
 } // namespace crow


### PR DESCRIPTION
OpenXR defines the XR_EXT_hand_interaction extension that allows users of the API to handle the input from hands as if they were physical controllers.

The hand tracking extensions we have been using so far, were completely disconnected to the OpenXR input model based on actions and input profiles. Hand gestures did not trigger events that can be handled using the OpenXR input model. That's why we had to use vendor specific extensions to compute aim or detect pinches or special system actions. For those systems not providing those we were inferring them from the position of the hand joints.

However with the hand interaction extension we can use the same input model based on actions and suggest bindings for certain paths provided by that extension. Those paths include poses (aim, grip, poke...) and also actions (pinch, grip...).

Apart from adding the input profiles we had to slightly modify the current code so that it does not assume that all the events coming from actions are from physical controllers. Likewise we should also retrieve hand joint information not only if there is no physical controller, but also if the system is using the hand interaction profile.