### PR TITLE
Regression: hand interaction profile is not available

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -77,10 +77,14 @@ XrResult OpenXRInputSource::Initialize()
         systemDoF = DoF::IS_6DOF;
     }
     for (auto& mapping: OpenXRInputMappings) {
-      if (mDeviceType != mapping.controllerType)
-        continue;
-
-      if (systemDoF != mapping.systemDoF)
+      // Always populate default/fall-back profiles
+      if (mapping.controllerType == device::UnknownType) {
+          mMappings.push_back(mapping);
+          // Use the system's deviceType instead to ensure we get a valid VRController on WebXR sessions
+          mMappings.back().controllerType = mDeviceType;
+          continue;
+      }
+      if ((mDeviceType != mapping.controllerType) || (systemDoF != mapping.systemDoF))
           continue;
       mMappings.push_back(mapping);
     }


### PR DESCRIPTION
When we removed the KHR simple profile in c3b539a96 we also did delete the code that was handling profiles with no specific device. That was a mistake because that's precisely the case of generic profiles like hand interaction.

Restored the code adding those profiles to the list of available mappings.