### PR TITLE
Load controller 3D models even with multiple interaction profiles

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -977,6 +977,7 @@ BrowserWorld::InitializeJava(JNIEnv* aEnv, jobject& aActivity, jobject& aAssetMa
 
   if (!m.modelsLoaded) {
     m.device->OnControllersReady([this](){
+      bool loadStarted = false;
       const int32_t modelCount = m.device->GetControllerModelCount();
       for (int32_t index = 0; index < modelCount; index++) {
         vrb::LoadTask task = m.device->GetControllerModelTask(index);
@@ -986,15 +987,18 @@ BrowserWorld::InitializeJava(JNIEnv* aEnv, jobject& aActivity, jobject& aAssetMa
           // we need to do the model load right when the controller becomes available)
           m.controllers->SetControllerModelTask(index, task);
           m.controllers->LoadControllerModel(index);
+          loadStarted = true;
         } else {
           const std::string fileName = m.device->GetControllerModelName(index);
           if (!fileName.empty()) {
             m.controllers->LoadControllerModel(index, m.loader, fileName);
+            loadStarted = true;
           }
         }
       }
       if (m.device->IsControllerLightEnabled())
         m.rootController->AddLight(m.light);
+      return loadStarted;
     });
 
     VRBrowser::CheckTogglePassthrough();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -100,7 +100,8 @@ public:
   virtual bool IsControllerLightEnabled() const { return true; }
   virtual vrb::LoadTask GetControllerModelTask(int32_t index) { return nullptr; } ;
   virtual void OnControllersCreated(std::function<void()> callback) { callback(); }
-  virtual void OnControllersReady(const std::function<void()>& callback) {
+  typedef std::function<bool()> ControllersReadyCallback;
+  virtual void OnControllersReady(const ControllersReadyCallback& callback) {
     callback();
   }
   class ReorientClient {

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -43,7 +43,7 @@ public:
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
   bool IsPositionTrackingSupported() const override;
   void OnControllersCreated(std::function<void()> callback) override;
-  void OnControllersReady(const std::function<void()>& callback) override;
+  void OnControllersReady(const ControllersReadyCallback& callback) override;
   void SetCPULevel(const device::CPULevel aLevel) override;
   void ProcessEvents() override;
   bool SupportsFramePrediction(FramePrediction aPrediction) const override;


### PR DESCRIPTION
Now that hand interaction profile is available for some devices it might happen that the user uses it at start time. That profile, as it's meant to be used for hand tracking, does not require any 3D model (the hand 3D model uses hand tracking joints that are not related to the hand interaction profile). This means that the callback of OnControllersReady() in BrowserWorld will not load any 3D model, and then DeviceDelegateOpenXR will uninstall the callback. Then if the user ever grabs a physical controller, the interaction profile will be updated (as we get notified by the runtime), but no 3D models would be ever loaded for those controllers as the callback is now null.

In order to fix that, the callback for OnControllersReady now returns a boolean representing whether or not the 3D models where loaded. If it's true then we can uninstall the callback after completion. If it's false then we leave the callback ready for eventual interaction profile changes.

Note that this do not support having multiple physical controllers for a single device, but that scenario is unlikely to happen.

We have also moved the callback signature to a typedef, that is not really required but it's better for robustness and maintenance as it allows us to modify it in a single place.

Fixes #1445