### PR TITLE
[Vision Glass] Back button when VR is not active

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
+++ b/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
@@ -9,6 +9,7 @@ public abstract class PlatformActivityPlugin {
     }
     abstract void onKeyboardVisibilityChange(boolean isVisible);
     abstract void onVideoAvailabilityChange();
+    abstract boolean onBackPressed();
     void registerListener(PlatformActivityPluginListener listener) {
         if (mListeners == null)
             mListeners = new ArrayList<>();

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -997,6 +997,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     @Deprecated
     public void onBackPressed() {
+        if (mPlatformPlugin != null && mPlatformPlugin.onBackPressed()) {
+            return;
+        }
         if (mIsPresentingImmersive) {
             queueRunnable(this::exitImmersiveNative);
             return;

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -675,6 +675,16 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                 return mGestureDetector.onTouchEvent(event);
             });
         }
+
+        @Override
+        boolean onBackPressed() {
+            // User pressed Back on the phone and VR is not active, so we use the default behaviour.
+            if (mViewModel.getConnectionState().getValue() != PhoneUIViewModel.ConnectionState.ACTIVE) {
+                PlatformActivity.super.onBackPressed();
+                return true;
+            }
+            return false;
+        }
     }
 
     private final DisplayManager.DisplayListener mDisplayListener =


### PR DESCRIPTION
Fix the issue that the Back button on the phone is not responsive before we have entered VR mode.

The fix is to add a method onBackPressed() to PlatformActivityPlugin which returns true if the platform activity has handled the Back press.

In the Vision Glass implementation, we use the default Back behaviour if the user presses that button before we have started VR mode.