### PR TITLE
[Vision Glass] Lower target SDK to 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -321,6 +321,7 @@ android {
             dimension "platform"
             applicationIdSuffix ".visionglass"
             resValue "string", "app_name", "Wolvic Vision Glass"
+            targetSdkVersion build_versions.target_sdk_visionglass
             externalNativeBuild {
                 cmake {
                     cppFlags " -DVISIONGLASS"

--- a/versions.gradle
+++ b/versions.gradle
@@ -190,6 +190,7 @@ build_versions.target_sdk_oculusvr = 32
 build_versions.target_sdk_wave = 31
 build_versions.target_sdk_aosp = 29
 build_versions.target_sdk_spaces = 29
+build_versions.target_sdk_visionglass = 33
 build_versions.compile_sdk = 34
 build_versions.build_tools = "34.0.0"
 ext.build_versions = build_versions


### PR DESCRIPTION
This is needed to avoid a crash in the VisionGlass library because Wehn registering a broadcast receiver.

See: https://github.com/open-ecosystem-development/OpenXR-SDK/issues/56