### PR TITLE
[Vision Glass] China app name and id

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -319,8 +319,9 @@ android {
 
         visionglass {
             dimension "platform"
+            applicationId "com.igalia.wolvic"
             applicationIdSuffix ".visionglass"
-            resValue "string", "app_name", "Wolvic Vision Glass"
+            resValue "string", "app_name", "Wolvic Vision"
             targetSdkVersion build_versions.target_sdk_visionglass
             externalNativeBuild {
                 cmake {


### PR DESCRIPTION
Set the app name of the Vision Glass variant to "Wolvic Vision" and the application id for China to "com.igalia.wolvic.visionglass".