### PR TITLE
[Chromium] Prevent a crash when downloading files

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -406,6 +406,8 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
 
     @Override
     public void newDownload(String url) {
+        if (mContentDelegate == null)
+            return;
         // Since we only have the URL, we have to use default values for the rest of the web
         // response data.
         mContentDelegate.onExternalResponse(this, new WWebResponse() {


### PR DESCRIPTION
It might happen that by the time a new download is triggered the session does no longer have a content delegate. In those cases we should just bail out to avoid a null pointer dereference.

It's really hard to reproduce as it depends on specific timing, but I triggered it by clicking on a search result in Google that was pointing to a PDF archive.