### PR TITLE
[OpenXR] Enable XR_EXT_view_configuration_depth_range

### DIFF
--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -38,6 +38,7 @@ void OpenXRExtensions::Initialize() {
 
     for (auto& extension: extensions) {
         sSupportedExtensions.insert(extension.extensionName);
+        VRB_LOG("OpenXR: supported extension: %s", extension.extensionName)
     }
 #ifdef LYNX
     // Lynx incorrectly advertises these extensions as supported but in reality they don't work.


### PR DESCRIPTION
This extension, whenever supported, provides additional view configuration information. In particular it returns both the [near,far] recommended clipping range, but also the maximum values allowed by the system.

We'll use those values in systems supporting the extension like the MagicLeap2 or the Pico4.