### PR TITLE
[OpenXR] Discard unsolicited hand gestures with hand interaction profile

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -83,6 +83,7 @@ private:
     bool mSupportsHandJointsMotionRangeInfo { false };
     bool mUsingHandInteractionProfile { false };
     device::DeviceType mDeviceType { device::UnknownType };
+    float mLastHandActionTriggerValue { 0.0f };
 
     struct HandMeshMSFT {
         XrSpace space = XR_NULL_HANDLE;


### PR DESCRIPTION
We use the gesture of facing the hand palm plus a pinch to perform some actions. With the left hand that's mapped to a back action, while with the right hand that means exit the application.

When using the hand interaction profile (only in MagicLeap2 so far), we were sometimes getting those gestures just by moving the hands out of sight. That was triggering a lot of unsolicited actions that confuse users.

There were two main causes for that erroneous behaviour:
1. we were asuming that if aim was not valid then it was because the hand was facing the head. That's correct but the aim is also not valid if the hand is untracked (mostly when out of sight).
2. the OpenXR runtime has a bug, and sometimes returns 1.0 (or in general values close to 1.0) in the pinch_ext action (meaning that there is a pinch) when the hand is completely opened but moving from tracked to untracked state.

This PR fixes both issues making the code far more robust.