### PR TITLE
Initial implementation of tabs bar

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -69,6 +69,12 @@ public class SettingsStore {
     public static final int INTERNAL = 0;
     public static final int EXTERNAL = 1;
 
+    @IntDef(value = { TABS_LOCATION_TRAY, TABS_LOCATION_HORIZONTAL, TABS_LOCATION_VERTICAL})
+    public @interface TabsLocation {}
+    public static final int TABS_LOCATION_TRAY = 0;
+    public static final int TABS_LOCATION_HORIZONTAL = 1;
+    public static final int TABS_LOCATION_VERTICAL = 2;
+
     private Context mContext;
     private SharedPreferences mPrefs;
     private SettingsViewModel mSettingsViewModel;
@@ -143,6 +149,7 @@ public class SettingsStore {
     public final static boolean AUDIO_ENABLED = BuildConfig.FLAVOR_backend == "chromium";
     public final static boolean LATIN_AUTO_COMPLETE_ENABLED = false;
     public final static boolean WINDOW_MOVEMENT_DEFAULT = false;
+    public final static @TabsLocation int TABS_LOCATION_DEFAULT = TABS_LOCATION_TRAY;
     public final static float CYLINDER_DENSITY_ENABLED_DEFAULT = 4680.0f;
     public final static float HAPTIC_PULSE_DURATION_DEFAULT = 10.0f;
     public final static float HAPTIC_PULSE_INTENSITY_DEFAULT = 1.0f;
@@ -389,6 +396,18 @@ public class SettingsStore {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putBoolean(mContext.getString(R.string.settings_key_head_lock), isEnabled);
         editor.apply();
+    }
+
+    @TabsLocation
+    public int getTabsLocation() {
+        return mPrefs.getInt(
+                mContext.getString(R.string.settings_key_tabs_location), TABS_LOCATION_DEFAULT);
+    }
+
+    public void setTabsLocation(@TabsLocation int tabsLocation) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putInt(mContext.getString(R.string.settings_key_tabs_location), tabsLocation);
+        editor.commit();
     }
 
     public boolean isEnvironmentOverrideEnabled() {

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -212,6 +212,9 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         if (mState.mSession != null) {
             setActive(false);
             suspend();
+        } else {
+            // Notify listeners manually.
+            mSessionChangeListeners.forEach(listener -> listener.onSessionRemoved(mState.mId));
         }
 
         if (mState.mParentId != null) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/TabsBarAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/TabsBarAdapter.java
@@ -1,0 +1,90 @@
+package com.igalia.wolvic.ui.adapters;
+
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.engine.Session;
+import com.igalia.wolvic.ui.views.TabsBarItem;
+import com.igalia.wolvic.ui.widgets.TabDelegate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TabsBarAdapter extends RecyclerView.Adapter<TabsBarAdapter.ViewHolder> {
+
+    public enum Orientation {HORIZONTAL, VERTICAL}
+
+    private final TabDelegate mTabDelegate;
+    private final Orientation mOrientation;
+    private final List<Session> mTabs = new ArrayList<>();
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        TabsBarItem mTabBarItem;
+
+        ViewHolder(TabsBarItem v) {
+            super(v);
+            mTabBarItem = v;
+        }
+    }
+
+    public TabsBarAdapter(@NonNull TabDelegate tabDelegate, Orientation orientation) {
+        mTabDelegate = tabDelegate;
+        mOrientation = orientation;
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return (position == 0) ? 0 : mTabs.get(position - 1).getId().hashCode();
+    }
+
+    public void updateTabs(List<Session> aTabs) {
+        mTabs.clear();
+        mTabs.addAll(aTabs);
+
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        @LayoutRes int layout;
+        if (mOrientation == Orientation.HORIZONTAL) {
+            layout = R.layout.tabs_bar_item_horizontal;
+        } else {
+            layout = R.layout.tabs_bar_item_vertical;
+        }
+        TabsBarItem view = (TabsBarItem) LayoutInflater.from(parent.getContext()).inflate(layout, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        holder.mTabBarItem.setDelegate(mItemDelegate);
+
+        Session session = mTabs.get(position);
+        holder.mTabBarItem.attachToSession(session);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mTabs.size();
+    }
+
+    private final TabsBarItem.Delegate mItemDelegate = new TabsBarItem.Delegate() {
+        @Override
+        public void onClick(TabsBarItem item) {
+            mTabDelegate.onTabSelect(item.getSession());
+        }
+
+        @Override
+        public void onClose(TabsBarItem item) {
+            mTabDelegate.onTabsClose(Collections.singletonList(item.getSession()));
+        }
+    };
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/TrayViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/TrayViewModel.java
@@ -21,6 +21,7 @@ public class TrayViewModel extends AndroidViewModel {
     private MediatorLiveData<ObservableBoolean> isVisible;
     private MutableLiveData<String> time;
     private MutableLiveData<String> pm;
+    private MutableLiveData<ObservableBoolean> tabsButtonInTray;
     private MutableLiveData<ObservableBoolean> wifiConnected;
     private MutableLiveData<ObservableInt> headsetIcon;
     private MutableLiveData<ObservableInt> headsetBatteryLevel;
@@ -43,7 +44,7 @@ public class TrayViewModel extends AndroidViewModel {
         isVisible.setValue(new ObservableBoolean(false));
         time = new MutableLiveData<>();
         pm = new MutableLiveData<>();
-        pm = new MutableLiveData<>();
+        tabsButtonInTray = new MutableLiveData<>(new ObservableBoolean(true));
         wifiConnected = new MutableLiveData<>(new ObservableBoolean(true));
         headsetIcon = new MutableLiveData<>(new ObservableInt(R.drawable.ic_icon_statusbar_headset_normal));
         headsetBatteryLevel = new MutableLiveData<>(new ObservableInt(R.drawable.ic_icon_statusbar_indicator));
@@ -69,6 +70,7 @@ public class TrayViewModel extends AndroidViewModel {
         isKeyboardVisible.setValue(isKeyboardVisible.getValue());
         time.postValue(time.getValue());
         pm.postValue(pm.getValue());
+        tabsButtonInTray.postValue(tabsButtonInTray.getValue());
         wifiConnected.postValue(wifiConnected.getValue());
         headsetIcon.setValue(headsetIcon.getValue());
         headsetBatteryLevel.setValue(headsetBatteryLevel.getValue());
@@ -125,6 +127,14 @@ public class TrayViewModel extends AndroidViewModel {
 
     public MutableLiveData<String> getPm() {
         return pm;
+    }
+
+    public void setTabsButtonInTray(boolean tabsButtonInTray) {
+        this.tabsButtonInTray.setValue(new ObservableBoolean(tabsButtonInTray));
+    }
+
+    public MutableLiveData<ObservableBoolean> getTabsButtonInTray() {
+        return tabsButtonInTray;
     }
 
     public void setWifiConnected(boolean connected) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
@@ -46,6 +46,7 @@ public class WindowViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isKioskMode;
     private MutableLiveData<ObservableBoolean> isDesktopMode;
     private MediatorLiveData<ObservableBoolean> isTopBarVisible;
+    private MediatorLiveData<ObservableBoolean> isTabsBarVisible;
     private MutableLiveData<ObservableBoolean> isResizeMode;
     private MutableLiveData<ObservableBoolean> isPrivateSession;
     private MediatorLiveData<ObservableBoolean> showClearButton;
@@ -158,6 +159,14 @@ public class WindowViewModel extends AndroidViewModel {
         titleBarUrl.addSource(url, mTitleBarUrlObserver);
         titleBarUrl.setValue("");
 
+        isTabsBarVisible = new MediatorLiveData<>();
+        isTabsBarVisible.addSource(isActiveWindow, mIsTabsBarVisibleObserver);
+        isTabsBarVisible.addSource(isFullscreen, mIsTabsBarVisibleObserver);
+        isTabsBarVisible.addSource(isKioskMode, mIsTabsBarVisibleObserver);
+        isTabsBarVisible.addSource(isResizeMode, mIsTabsBarVisibleObserver);
+        isTabsBarVisible.addSource(isWindowVisible, mIsTabsBarVisibleObserver);
+        isTabsBarVisible.setValue(new ObservableBoolean(true));
+
         isInsecureVisible = new MediatorLiveData<>();
         isInsecureVisible.addSource(isInsecure, mIsInsecureVisibleObserver);
         isInsecureVisible.addSource(isPrivateSession, mIsInsecureVisibleObserver);
@@ -209,6 +218,18 @@ public class WindowViewModel extends AndroidViewModel {
                 } else {
                     isTopBarVisible.postValue(new ObservableBoolean(true));
                 }
+            }
+        }
+    };
+
+    private Observer<ObservableBoolean> mIsTabsBarVisibleObserver = new Observer<ObservableBoolean>() {
+        @Override
+        public void onChanged(ObservableBoolean o) {
+            if (!isActiveWindow.getValue().get() || isFullscreen.getValue().get() || isKioskMode.getValue().get() || isResizeMode.getValue().get() || !isWindowVisible.getValue().get()) {
+                isTabsBarVisible.postValue(new ObservableBoolean(false));
+
+            } else {
+                isTabsBarVisible.postValue(new ObservableBoolean(true));
             }
         }
     };
@@ -518,6 +539,11 @@ public class WindowViewModel extends AndroidViewModel {
 
     public void setIsTopBarVisible(boolean isTopBarVisible) {
         this.isTopBarVisible.postValue(new ObservableBoolean(isTopBarVisible));
+    }
+
+    @NonNull
+    public MediatorLiveData<ObservableBoolean> getIsTabsBarVisible() {
+        return isTabsBarVisible;
     }
 
     @NonNull

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/CustomFastScroller.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/CustomFastScroller.java
@@ -361,7 +361,7 @@ class CustomFastScroller extends RecyclerView.ItemDecoration implements Recycler
         int verticalContentLength = mRecyclerView.computeVerticalScrollRange();
         int verticalVisibleLength = mRecyclerViewHeight;
         mNeedVerticalScrollbar = verticalContentLength - verticalVisibleLength > 0
-                    && mRecyclerViewHeight >= mScrollbarMinimumRange || mNeedHorizontalScrollbar;
+                    && mRecyclerViewHeight >= mScrollbarMinimumRange || mNeedVerticalScrollbar;
 
         int horizontalContentLength = mRecyclerView.computeHorizontalScrollRange();
         int horizontalVisibleLength = mRecyclerViewWidth;

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
@@ -1,0 +1,174 @@
+package com.igalia.wolvic.ui.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModel;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.SessionChangeListener;
+import com.igalia.wolvic.browser.api.WSession;
+import com.igalia.wolvic.browser.engine.Session;
+import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+import com.igalia.wolvic.ui.widgets.WindowWidget;
+import com.igalia.wolvic.utils.UrlUtils;
+
+import java.util.Objects;
+
+import mozilla.components.browser.icons.IconRequest;
+
+public class TabsBarItem extends RelativeLayout implements WSession.ContentDelegate, WSession.NavigationDelegate,
+        SessionChangeListener {
+
+    protected ViewGroup mTabDetailsView;
+    protected ImageView mFavicon;
+    protected TextView mSubtitle;
+    protected TextView mTitle;
+    protected Button mCloseButton;
+    protected Delegate mDelegate;
+    protected Session mSession;
+    protected ViewModel mViewModel;
+
+    public interface Delegate {
+        void onClick(TabsBarItem aSender);
+
+        void onClose(TabsBarItem aSender);
+    }
+
+    public TabsBarItem(Context context) {
+        super(context);
+    }
+
+    public TabsBarItem(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public TabsBarItem(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        mTabDetailsView = findViewById(R.id.tab_details);
+
+        mCloseButton = findViewById(R.id.tab_close_button);
+        mCloseButton.setOnClickListener(v -> {
+            v.requestFocusFromTouch();
+            if (mDelegate != null) {
+                mDelegate.onClose(this);
+            }
+        });
+
+        mFavicon = findViewById(R.id.tab_favicon);
+        mTitle = findViewById(R.id.tab_title);
+        mSubtitle = findViewById(R.id.tab_subtitle);
+
+        this.setOnClickListener(mClickListener);
+    }
+
+    private final OnClickListener mClickListener = new OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            if (mDelegate != null) {
+                mDelegate.onClick(TabsBarItem.this);
+            }
+        }
+    };
+
+    public void attachToSession(@Nullable Session aSession) {
+        if (mSession != null) {
+            mSession.removeContentListener(this);
+            mSession.removeNavigationListener(this);
+            mSession.removeSessionChangeListener(this);
+        }
+
+        mSession = aSession;
+        if (mSession != null) {
+            mSession.addContentListener(this);
+            mSession.addNavigationListener(this);
+            mSession.addSessionChangeListener(this);
+
+            mTitle.setText(mSession.getCurrentTitle());
+            mSubtitle.setText(UrlUtils.stripProtocol(mSession.getCurrentUri()));
+            SessionStore.get().getBrowserIcons().loadIntoView(
+                    mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
+
+            if (getContext() instanceof WidgetManagerDelegate) {
+                WidgetManagerDelegate widgetManager = (WidgetManagerDelegate) getContext();
+                WindowWidget focusedWindow = widgetManager.getFocusedWindow();
+                if (focusedWindow != null && focusedWindow.getSession() != null) {
+                    setActive(mSession.isActive() && Objects.equals(mSession.getId(), focusedWindow.getSession().getId()));
+                }
+            } else {
+                setActive(mSession.isActive());
+            }
+        } else {
+            // Null session
+            mTitle.setText(null);
+            mSubtitle.setText(null);
+            mFavicon.setImageDrawable(null);
+        }
+    }
+
+    public Session getSession() {
+        return mSession;
+    }
+
+    public void setDelegate(Delegate aDelegate) {
+        mDelegate = aDelegate;
+    }
+
+    @Override
+    public void onTitleChange(@NonNull WSession session, @Nullable String title) {
+        if (mSession == null || mSession.getWSession() != session) {
+            return;
+        }
+        mTitle.setText(title);
+    }
+
+    @Override
+    public void onLocationChange(@NonNull WSession session, @Nullable String url) {
+        if (mSession == null || mSession.getWSession() != session) {
+            return;
+        }
+
+        if (url == null) {
+            mSubtitle.setText(null);
+            mFavicon.setImageDrawable(null);
+        } else {
+            mSubtitle.setText(UrlUtils.stripProtocol(mSession.getCurrentUri()));
+            SessionStore.get().getBrowserIcons().loadIntoView(
+                    mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
+        }
+    }
+
+    @Override
+    public void onSessionStateChanged(Session aSession, boolean aActive) {
+        // TODO this should only apply to the session in the focused window
+        if (Objects.equals(mSession, aSession)) {
+            setActive(aActive);
+        }
+    }
+
+    @Override
+    public void onCloseRequest(@NonNull WSession aSession) {
+        if (mSession.getWSession() == aSession) {
+            mDelegate.onClose(this);
+        }
+    }
+
+    public void setActive(boolean isActive) {
+        setSelected(isActive);
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/AbstractTabsBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/AbstractTabsBar.java
@@ -1,0 +1,146 @@
+package com.igalia.wolvic.ui.widgets;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.databinding.ObservableBoolean;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
+
+import com.igalia.wolvic.VRBrowserActivity;
+import com.igalia.wolvic.browser.SessionChangeListener;
+import com.igalia.wolvic.browser.api.WSession;
+import com.igalia.wolvic.browser.engine.Session;
+import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.ui.viewmodel.WindowViewModel;
+import com.igalia.wolvic.utils.SystemUtils;
+
+public abstract class AbstractTabsBar extends UIWidget implements SessionChangeListener, WidgetManagerDelegate.UpdateListener {
+
+    protected final String LOGTAG = SystemUtils.createLogtag(this.getClass());
+
+    protected boolean mPrivateMode;
+    protected WindowWidget mAttachedWindow;
+    protected WindowViewModel mWindowViewModel;
+
+    public AbstractTabsBar(Context aContext) {
+        super(aContext);
+
+        SessionStore.get().addSessionChangeListener(this);
+    }
+
+    public abstract void updateWidgetPlacement();
+
+    @Override
+    public void attachToWindow(@NonNull WindowWidget window) {
+        if (mAttachedWindow == window) {
+            return;
+        }
+        detachFromWindow();
+        mAttachedWindow = window;
+
+        mPrivateMode = mAttachedWindow.getSession() != null && mAttachedWindow.getSession().isPrivateMode();
+        mWidgetManager.addUpdateListener(this);
+        mWindowViewModel = new ViewModelProvider(
+                (VRBrowserActivity) getContext(),
+                ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
+                .get(String.valueOf(mAttachedWindow.hashCode()), WindowViewModel.class);
+        mWindowViewModel.getIsTabsBarVisible().observe((VRBrowserActivity) getContext(), mIsTabsBarVisibleObserver);
+
+        updateWidgetPlacement();
+        refreshTabs();
+    }
+
+    @Override
+    public void detachFromWindow() {
+        if (mWindowViewModel != null) {
+            mWindowViewModel.getIsTabsBarVisible().removeObserver(mIsTabsBarVisibleObserver);
+            mWindowViewModel = null;
+        }
+        mAttachedWindow = null;
+    }
+
+    Observer<? super ObservableBoolean> mIsTabsBarVisibleObserver = isTabsVisible -> {
+        if (isTabsVisible.get()) {
+            show(CLEAR_FOCUS);
+        } else {
+            hide(KEEP_WIDGET);
+        }
+    };
+
+    @Override
+    public void show(@ShowFlags int aShowFlags) {
+        updateWidgetPlacement();
+        mWidgetPlacement.visible = true;
+        mWidgetManager.updateWidget(this);
+    }
+
+    @Override
+    public void hide(@HideFlags int aHideFlag) {
+        mWidgetPlacement.visible = false;
+        mWidgetManager.updateWidget(this);
+    }
+
+    @Override
+    public void releaseWidget() {
+        if (mWidgetManager != null) {
+            mWidgetManager.removeUpdateListener(this);
+            mWindowViewModel.getIsTabsBarVisible().removeObserver(mIsTabsBarVisibleObserver);
+        }
+        SessionStore.get().removeSessionChangeListener(this);
+        super.releaseWidget();
+    }
+
+    // WidgetManagerDelegate.UpdateListener
+    @Override
+    public void onWidgetUpdate(Widget aWidget) {
+        if (aWidget == mAttachedWindow && !mAttachedWindow.isResizing()) {
+            updateWidgetPlacement();
+        }
+    }
+
+    // TODO Use more fine-grained updates.
+    public abstract void refreshTabs();
+
+    // SessionChangeListener
+
+    @Override
+    public void onSessionAdded(Session aSession) {
+        refreshTabs();
+    }
+
+    @Override
+    public void onSessionOpened(Session aSession) {
+        refreshTabs();
+    }
+
+    @Override
+    public void onSessionClosed(Session aSession) {
+        refreshTabs();
+    }
+
+    @Override
+    public void onSessionRemoved(String aId) {
+        refreshTabs();
+    }
+
+    @Override
+    public void onSessionStateChanged(Session aSession, boolean aActive) {
+        refreshTabs();
+    }
+
+    @Override
+    public void onCurrentSessionChange(WSession aOldSession, WSession aSession) {
+        refreshTabs();
+    }
+
+    @Override
+    public void onStackSession(Session aSession) {
+        refreshTabs();
+    }
+
+    @Override
+    public void onUnstackSession(Session aSession, Session aParent) {
+        refreshTabs();
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/HorizontalTabsBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/HorizontalTabsBar.java
@@ -1,0 +1,71 @@
+package com.igalia.wolvic.ui.widgets;
+
+import android.content.Context;
+import android.widget.Button;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.SettingsStore;
+import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.ui.adapters.TabsBarAdapter;
+
+public class HorizontalTabsBar extends AbstractTabsBar {
+
+    protected Button mAddTabButton;
+    protected RecyclerView mTabsList;
+    protected LinearLayoutManager mLayoutManager;
+    protected TabsBarAdapter mAdapter;
+    protected final TabDelegate mTabDelegate;
+
+    public HorizontalTabsBar(Context aContext, TabDelegate aDelegate) {
+        super(aContext);
+        mTabDelegate = aDelegate;
+        updateUI();
+    }
+
+    private void updateUI() {
+        removeAllViews();
+
+        inflate(getContext(), R.layout.tabs_bar_horizontal, this);
+
+        mAddTabButton = findViewById(R.id.add_tab);
+        mAddTabButton.setOnClickListener(v -> mTabDelegate.onTabAdd());
+
+        mTabsList = findViewById(R.id.tabsRecyclerView);
+        mLayoutManager = new LinearLayoutManager(getContext());
+        mLayoutManager.setOrientation(RecyclerView.HORIZONTAL);
+        mTabsList.setLayoutManager(mLayoutManager);
+        mAdapter = new TabsBarAdapter(mTabDelegate, TabsBarAdapter.Orientation.HORIZONTAL);
+        mTabsList.setAdapter(mAdapter);
+    }
+
+    @Override
+    protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
+        Context context = getContext();
+        aPlacement.width = SettingsStore.getInstance(getContext()).getWindowWidth();
+        aPlacement.height = WidgetPlacement.dpDimension(context, R.dimen.horizontal_tabs_bar_height);
+        aPlacement.worldWidth = aPlacement.width * WidgetPlacement.worldToDpRatio(context);
+        aPlacement.anchorX = 0.0f;
+        aPlacement.anchorY = 0.0f;
+        aPlacement.parentAnchorX = 0.0f;
+        aPlacement.parentAnchorY = 1.0f;
+        aPlacement.parentAnchorGravity = WidgetPlacement.GRAVITY_DEFAULT;
+    }
+
+    @Override
+    public void updateWidgetPlacement() {
+        if (mAttachedWindow == null) {
+            mWidgetPlacement.parentHandle = -1;
+        } else {
+            mWidgetPlacement.parentHandle = mAttachedWindow.getHandle();
+            mWidgetPlacement.width = mAttachedWindow.getPlacement().width;
+            mWidgetPlacement.worldWidth = mAttachedWindow.getPlacement().worldWidth;
+        }
+    }
+
+    public void refreshTabs() {
+        mAdapter.updateTabs(SessionStore.get().getSessions(mPrivateMode));
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabDelegate.java
@@ -1,0 +1,12 @@
+package com.igalia.wolvic.ui.widgets;
+
+import com.igalia.wolvic.browser.engine.Session;
+
+import java.util.List;
+
+public interface TabDelegate {
+    void onTabAdd();
+    void onTabSelect(Session aTab);
+    void onTabsClose(List<Session> aTabs);
+    void onTabsBookmark(List<Session> aTabs);
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
@@ -48,13 +48,6 @@ public class TabsWidget extends UIDialog {
     protected boolean mSelecting;
     protected ArrayList<Session> mSelectedTabs = new ArrayList<>();
 
-    public interface TabDelegate {
-        void onTabSelect(Session aTab);
-        void onTabAdd();
-        void onTabsClose(List<Session> aTabs);
-        void onTabsBookmark(List<Session> aTabs);
-    }
-
     public TabsWidget(Context aContext) {
         super(aContext);
         mBitmapCache = BitmapCache.getInstance(aContext);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -9,6 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
@@ -27,10 +28,12 @@ import android.view.MotionEvent;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 import androidx.databinding.ObservableBoolean;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.preference.PreferenceManager;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
@@ -59,8 +62,11 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
-public class TrayWidget extends UIWidget implements WidgetManagerDelegate.UpdateListener, DownloadsManager.DownloadsListener, ConnectivityReceiver.Delegate {
+public class TrayWidget extends UIWidget implements WidgetManagerDelegate.UpdateListener,
+        DownloadsManager.DownloadsListener, ConnectivityReceiver.Delegate,
+        SharedPreferences.OnSharedPreferenceChangeListener {
 
     private static final int ICON_ANIMATION_DURATION = 200;
 
@@ -117,9 +123,11 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
                 (VRBrowserActivity)getContext(),
                 ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
                 .get(TrayViewModel.class);
-        mTrayViewModel.getIsVisible().observe((VRBrowserActivity) getContext(), mIsVisibleObserver);
 
+        mTrayViewModel.getIsVisible().observe((VRBrowserActivity) getContext(), mIsVisibleObserver);
         mTrayViewModel.setHeadsetBatteryLevel(R.drawable.ic_icon_statusbar_indicator_10);
+        mTrayViewModel.setTabsButtonInTray(SettingsStore.getInstance(getContext()).getTabsLocation() == SettingsStore.TABS_LOCATION_TRAY);
+
         updateUI();
 
         mIsWindowAttached = false;
@@ -136,6 +144,8 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mConnectivityReceived = ((VRBrowserApplication)getContext().getApplicationContext()).getConnectivityReceiver();
         mConnectivityReceived.addListener(this);
+
+        PreferenceManager.getDefaultSharedPreferences(getContext()).registerOnSharedPreferenceChangeListener(this);
 
         mWifiSSID = getContext().getString(R.string.tray_wifi_no_connection);
 
@@ -918,5 +928,14 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
         java.text.DateFormat format = SimpleDateFormat.getDateInstance(
                 SimpleDateFormat.FULL, LocaleUtils.getDisplayLanguage(getContext()).getLocale());
         return format.format(new Date());
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, @Nullable String key) {
+        if (Objects.equals(key, getContext().getString(R.string.settings_key_tabs_location))) {
+            int value = sharedPreferences.getInt(key, SettingsStore.TABS_LOCATION_TRAY);
+            mTrayViewModel.setTabsButtonInTray(value == SettingsStore.TABS_LOCATION_TRAY);
+            updateUI();
+        }
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/VerticalTabsBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/VerticalTabsBar.java
@@ -1,0 +1,71 @@
+package com.igalia.wolvic.ui.widgets;
+
+import android.content.Context;
+import android.widget.Button;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.SettingsStore;
+import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.ui.adapters.TabsBarAdapter;
+
+public class VerticalTabsBar extends AbstractTabsBar {
+
+    protected Button mAddTabButton;
+    protected RecyclerView mTabsList;
+    protected LinearLayoutManager mLayoutManager;
+    protected TabsBarAdapter mAdapter;
+    protected final TabDelegate mTabDelegate;
+
+    public VerticalTabsBar(Context aContext, TabDelegate aDelegate) {
+        super(aContext);
+        mTabDelegate = aDelegate;
+        updateUI();
+    }
+
+    private void updateUI() {
+        removeAllViews();
+
+        inflate(getContext(), R.layout.tabs_bar_vertical, this);
+
+        mAddTabButton = findViewById(R.id.add_tab);
+        mAddTabButton.setOnClickListener(v -> mTabDelegate.onTabAdd());
+
+        mTabsList = findViewById(R.id.tabsRecyclerView);
+        mLayoutManager = new LinearLayoutManager(getContext());
+        mLayoutManager.setOrientation(RecyclerView.VERTICAL);
+        mTabsList.setLayoutManager(mLayoutManager);
+        mAdapter = new TabsBarAdapter(mTabDelegate, TabsBarAdapter.Orientation.VERTICAL);
+        mTabsList.setAdapter(mAdapter);
+    }
+
+    @Override
+    protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
+        Context context = getContext();
+        aPlacement.width = WidgetPlacement.dpDimension(context, R.dimen.vertical_tabs_bar_width);
+        aPlacement.height = SettingsStore.getInstance(getContext()).getWindowHeight();
+        aPlacement.worldWidth = aPlacement.width * WidgetPlacement.worldToDpRatio(context);
+        aPlacement.anchorX = 1.0f;
+        aPlacement.anchorY = 0.0f;
+        aPlacement.parentAnchorX = 0.0f;
+        aPlacement.parentAnchorY = 0.0f;
+        aPlacement.parentAnchorGravity = WidgetPlacement.GRAVITY_CENTER_Y;
+    }
+
+    @Override
+    public void updateWidgetPlacement() {
+        if (mAttachedWindow == null) {
+            mWidgetPlacement.parentHandle = -1;
+        } else {
+            mWidgetPlacement.parentHandle = mAttachedWindow.getHandle();
+            mWidgetPlacement.height = mAttachedWindow.getPlacement().height;
+        }
+    }
+
+    public void refreshTabs() {
+        mAdapter.updateTabs(SessionStore.get().getSessions(mPrivateMode));
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetPlacement.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetPlacement.java
@@ -16,7 +16,6 @@ import androidx.annotation.NonNull;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
-import com.igalia.wolvic.utils.DeviceType;
 
 public class WidgetPlacement {
     static final float WORLD_DPI_RATIO = 2.0f/720.0f;
@@ -83,6 +82,10 @@ public class WidgetPlacement {
      */
     public float cylinderMapRadius;
 
+    // Translation offset (in world dimensions), applied after anchors.
+    public float horizontalOffset;
+    public float verticalOffset;
+
     public WidgetPlacement clone() {
         WidgetPlacement w = new WidgetPlacement();
         w.copyFrom(this);
@@ -121,6 +124,8 @@ public class WidgetPlacement {
         this.name = w.name;
         this.clearColor = w.clearColor;
         this.cylinderMapRadius = w.cylinderMapRadius;
+        this.horizontalOffset = w.horizontalOffset;
+        this.verticalOffset = w.verticalOffset;
     }
 
     public void updateCylinderMapRadius() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1055,6 +1055,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mWidgetManager.updateVisibleWidgets();
     }
 
+    public void setOffset(float horizontalOffset, float verticalOffset) {
+        mWidgetPlacement.horizontalOffset = horizontalOffset;
+        mWidgetPlacement.verticalOffset = verticalOffset;
+        mWidgetManager.updateWidget(this);
+    }
+
     @Override
     public void releaseWidget() {
         cleanListeners(mSession);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -65,7 +65,7 @@ import mozilla.components.concept.sync.Profile;
 import mozilla.components.concept.sync.TabData;
 
 public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWidget.Delegate,
-        WindowWidget.WindowListener, TabsWidget.TabDelegate, Services.TabReceivedDelegate {
+        WindowWidget.WindowListener, TabDelegate, Services.TabReceivedDelegate {
 
     private static final String LOGTAG = SystemUtils.createLogtag(Windows.class);
 
@@ -348,9 +348,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         updateMaxWindowScales();
         mWidgetManager.addWidget(newWindow);
-        focusWindow(newWindow);
         updateCurvedMode(true);
         updateViews();
+        focusWindow(newWindow);
 
         // We are only interested in general windows opened.
         if (!isInPrivateMode()) {
@@ -445,6 +445,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         }
 
         updateViews();
+        adjustWindowOffsets();
         if (mDelegate != null) {
             mDelegate.onWindowClosed();
         }
@@ -935,6 +936,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 placement.parentAnchorX = 0.0f;
                 placement.parentAnchorY = 0.0f;
                 placement.parentAnchorGravity = centerWindow ? WidgetPlacement.GRAVITY_CENTER_Y : WidgetPlacement.GRAVITY_DEFAULT;
+                placement.horizontalOffset = - WidgetPlacement.dpDimension(mContext, R.dimen.vertical_tabs_bar_width) * WidgetPlacement.worldToDpRatio(mContext);
                 placement.rotationAxisX = 0;
                 placement.rotationAxisZ = 0;
                 if (curvedMode) {
@@ -954,6 +956,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 placement.parentAnchorX = 1.0f;
                 placement.parentAnchorY = 0.0f;
                 placement.parentAnchorGravity = centerWindow ? WidgetPlacement.GRAVITY_CENTER_Y : WidgetPlacement.GRAVITY_DEFAULT;
+                placement.horizontalOffset = WidgetPlacement.dpDimension(mContext, R.dimen.vertical_tabs_bar_width) * WidgetPlacement.worldToDpRatio(mContext);
                 placement.rotationAxisX = 0;
                 placement.rotationAxisZ = 0;
                 if (curvedMode) {
@@ -967,6 +970,27 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 placement.translationX = WidgetPlacement.dpDimension(mContext, R.dimen.multi_window_padding);
                 placement.translationY = 0.0f;
                 placement.translationZ = 0.0f;
+        }
+    }
+
+    public void adjustWindowOffsets() {
+        boolean verticalTabsBar = SettingsStore.getInstance(mContext).getTabsLocation() == SettingsStore.TABS_LOCATION_VERTICAL;
+        float tabsBarWidth = WidgetPlacement.dpDimension(mContext, R.dimen.vertical_tabs_bar_width) * WidgetPlacement.worldToDpRatio(mContext);
+
+        WindowWidget frontWindow = getFrontWindow();
+        WindowWidget leftWindow = getLeftWindow();
+        WindowWidget rightWindow = getRightWindow();
+
+        if (frontWindow != null) {
+            frontWindow.setOffset(0.0f, 0.0f);
+        }
+
+        if (leftWindow != null) {
+            leftWindow.setOffset((verticalTabsBar && frontWindow == mFocusedWindow) ? -tabsBarWidth : 0.0f, 0.0f);
+        }
+
+        if (rightWindow != null) {
+            rightWindow.setOffset((verticalTabsBar && rightWindow == mFocusedWindow) ? tabsBarWidth : 0.0f, 0.0f);
         }
     }
 
@@ -1425,6 +1449,7 @@ public void selectTab(@NonNull Session aTab) {
     public void onTabSelect(Session aTab) {
         if (mFocusedWindow.getSession() != aTab) {
             TelemetryService.Tabs.activatedEvent();
+            aTab.updateLastUse();
         }
 
         WindowWidget targetWindow = mFocusedWindow;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
@@ -101,7 +101,7 @@ public class ContextMenuWidget extends MenuWidget {
             // Open link in a new tab
             mItems.add(new MenuWidget.MenuItem(getContext().getString(R.string.context_menu_open_link_new_tab_1), 0, () -> {
                 if (!StringUtils.isEmpty(aContextElement.linkUri)) {
-                    widgetManager.openNewTab(aContextElement.linkUri);
+                    widgetManager.openNewTabForeground(aContextElement.linkUri);
                     TelemetryService.Tabs.openedCounter(TelemetryService.Tabs.TabSource.CONTEXT_MENU);
                 }
                 onDismiss();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -107,6 +107,10 @@ class DisplayOptionsView extends SettingsView {
         mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
         setHeadLock(SettingsStore.getInstance(getContext()).isHeadLockEnabled(), false);
 
+        @SettingsStore.TabsLocation int tabsLocation = SettingsStore.getInstance(getContext()).getTabsLocation();
+        mBinding.tabsLocationRadio.setOnCheckedChangeListener(mTabsLocationChangeListener);
+        setTabsLocation(mBinding.tabsLocationRadio.getIdForValue(tabsLocation), false);
+
         mDefaultHomepageUrl = getContext().getString(R.string.HOMEPAGE_URL);
 
         mBinding.homepageEdit.setHint1(getContext().getString(R.string.homepage_hint, getContext().getString(R.string.app_name)));
@@ -200,6 +204,10 @@ class DisplayOptionsView extends SettingsView {
         setHeadLock(value, true);
     };
 
+    private RadioGroupSetting.OnCheckedChangeListener mTabsLocationChangeListener = (radioGroup, checkedId, doApply) -> {
+        setTabsLocation(checkedId, true);
+    };
+
     private OnClickListener mHomepageListener = (view) -> {
         if (!mBinding.homepageEdit.getFirstText().isEmpty()) {
             setHomepage(mBinding.homepageEdit.getFirstText());
@@ -258,6 +266,9 @@ class DisplayOptionsView extends SettingsView {
         if (!prevMSAA.equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
             setMSAAMode(mBinding.msaaRadio.getIdForValue(SettingsStore.MSAA_DEFAULT_LEVEL), true);
             restart = true;
+        }
+        if (!mBinding.tabsLocationRadio.getValueForId(mBinding.tabsLocationRadio.getCheckedRadioButtonId()).equals(SettingsStore.TABS_LOCATION_DEFAULT)) {
+            setTabsLocation(mBinding.tabsLocationRadio.getIdForValue(SettingsStore.TABS_LOCATION_DEFAULT), true);
         }
 
         if (mBinding.windowsSize.getCheckedRadioButtonId() != SettingsStore.WINDOW_SIZE_PRESET_DEFAULT.ordinal()) {
@@ -362,6 +373,17 @@ class DisplayOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setAudioEnabled(value);
             AudioEngine.fromContext(getContext()).setEnabled(value);
+        }
+    }
+
+    private void setTabsLocation(int checkedId, boolean doApply) {
+        mBinding.tabsLocationRadio.setOnCheckedChangeListener(null);
+        mBinding.tabsLocationRadio.setChecked(checkedId, doApply);
+        mBinding.tabsLocationRadio.setOnCheckedChangeListener(mTabsLocationChangeListener);
+
+        if (doApply) {
+            int tabsLocationValue = (Integer) mBinding.tabsLocationRadio.getValueForId(checkedId);
+            SettingsStore.getInstance(getContext()).setTabsLocation(tabsLocationValue);
         }
     }
 

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1599,7 +1599,7 @@ BrowserWorld::LayoutWidget(int32_t aHandle) {
   // Widget anchor point
   translation -= vrb::Vector(anchorX, anchorY, 0.0f);
 
-  // Parent anchor point, taking the gravity into account.
+  // Parent anchor point, taking gravity and offset into account.
   if (parent) {
     float parentTranslationX, parentTranslationY;
     if (aPlacement->parentAnchorGravity & WidgetPlacement::kParentAnchorGravityCenterX) {
@@ -1607,12 +1607,16 @@ BrowserWorld::LayoutWidget(int32_t aHandle) {
     } else {
       parentTranslationX = parentWorldWith * aPlacement->parentAnchor.x() - parentWorldWith * 0.5f;
     }
+    parentTranslationX += (aPlacement->horizontalOffset);
+
     if (aPlacement->parentAnchorGravity & WidgetPlacement::kParentAnchorGravityCenterY) {
       parentTranslationY = (parentWorldHeight - worldHeight) / 2.0f - parentWorldHeight * 0.5f;
     } else {
       parentTranslationY =
               parentWorldHeight * aPlacement->parentAnchor.y() - parentWorldHeight * 0.5f;
     }
+    parentTranslationY += (aPlacement->verticalOffset);
+
     translation += vrb::Vector(parentTranslationX, parentTranslationY, 0.0f);
   }
 

--- a/app/src/main/cpp/WidgetPlacement.cpp
+++ b/app/src/main/cpp/WidgetPlacement.cpp
@@ -76,6 +76,8 @@ WidgetPlacement::FromJava(JNIEnv* aEnv, jobject& aObject) {
   GET_INT_FIELD(borderColor);
   GET_STRING_FIELD(name);
   GET_INT_FIELD(clearColor);
+  GET_FLOAT_FIELD(horizontalOffset, "horizontalOffset");
+  GET_FLOAT_FIELD(verticalOffset, "verticalOffset");
 
   return result;
 }

--- a/app/src/main/cpp/WidgetPlacement.h
+++ b/app/src/main/cpp/WidgetPlacement.h
@@ -48,6 +48,8 @@ struct WidgetPlacement {
   int borderColor;
   std::string name;
   int clearColor;
+  float horizontalOffset;
+  float verticalOffset;
 
   int32_t GetTextureWidth() const;
   int32_t GetTextureHeight() const;

--- a/app/src/main/res/drawable/tabs_bar_bg.xml
+++ b/app/src/main/res/drawable/tabs_bar_bg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:bottomLeftRadius="8dp"
+        android:bottomRightRadius="8dp"
+        android:topLeftRadius="8dp"
+        android:topRightRadius="8dp" />
+    <stroke
+        android:width="@dimen/blur_radius"
+        android:color="@color/asphalt_blur" />
+    <solid android:color="@color/asphalt" />
+</shape>

--- a/app/src/main/res/drawable/tabs_bar_item_bg.xml
+++ b/app/src/main/res/drawable/tabs_bar_item_bg.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true" android:state_selected="true">
+        <shape>
+            <stroke android:width="2dp" android:color="@color/azure" />
+            <solid android:color="#2FFFFFFF" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_hovered="true" android:state_selected="true">
+        <shape>
+            <stroke android:width="2dp" android:color="@color/azure" />
+            <solid android:color="#28FFFFFF" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape>
+            <stroke android:width="2dp" android:color="@color/azure" />
+            <solid android:color="#22FFFFFF" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="#2F000000" />
+        </shape>
+    </item>
+    <item android:state_hovered="true">
+        <shape>
+            <solid android:color="#22000000" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="#00000000" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -149,6 +149,14 @@
                     android:layout_height="wrap_content"
                     app:description="@string/display_options_head_lock" />
 
+                <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
+                    android:id="@+id/tabs_location_radio"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/display_options_tabs_location"
+                    app:options="@array/display_options_tabs_location"
+                    app:values="@array/display_options_tabs_location_values" />
+
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 

--- a/app/src/main/res/layout/tabs_bar_horizontal.xml
+++ b/app/src/main/res/layout/tabs_bar_horizontal.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:layout_height="@dimen/horizontal_tabs_bar_height"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/tabs_bar_bg"
+    android:orientation="horizontal">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/add_tab"
+        android:layout_width="64dp"
+        android:layout_height="match_parent"
+        android:layout_margin="4dp"
+        android:background="@drawable/tab_add_background"
+        android:scaleType="fitCenter"
+        app:backgroundTint="@null"
+        app:icon="@drawable/ic_icon_newtab"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
+        app:iconSize="24dp"
+        app:iconTint="@color/fog" />
+
+    <com.igalia.wolvic.ui.views.CustomRecyclerView
+        android:id="@+id/tabsRecyclerView"
+        style="@style/customRecyclerViewStyle"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_margin="2dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:overScrollMode="never"
+        android:scrollbars="horizontal"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/tabs_bar_item_horizontal" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/tabs_bar_item_horizontal.xml
+++ b/app/src/main/res/layout/tabs_bar_item_horizontal.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.igalia.wolvic.ui.views.TabsBarItem xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="@dimen/horizontal_tabs_bar_item_width"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:layout_height="match_parent"
+    android:padding="1dp">
+
+    <RelativeLayout
+        android:id="@+id/tab_details"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:background="@drawable/tabs_bar_item_bg"
+        android:duplicateParentState="true">
+
+        <ImageView
+            android:id="@+id/tab_favicon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerInParent="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_icon_globe" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toStartOf="@id/tab_close_button"
+            android:layout_toEndOf="@id/tab_favicon"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tab_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="start"
+                android:lines="1"
+                android:shadowColor="#00000000"
+                android:textColor="#ffffff"
+                android:textSize="12sp"
+                android:textStyle="normal"
+                tools:text="Title of the page" />
+
+            <TextView
+                android:id="@+id/tab_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tab_close_button"
+            style="@style/Widget.Material3.Button.TextButton.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:minWidth="32dp"
+            android:padding="0dp"
+            app:icon="@drawable/ic_icon_exit"
+            app:iconGravity="textStart"
+            app:iconPadding="0dp"
+            app:iconSize="16dp"
+            app:iconTint="@drawable/tab_close_icon_color" />
+
+    </RelativeLayout>
+
+</com.igalia.wolvic.ui.views.TabsBarItem>

--- a/app/src/main/res/layout/tabs_bar_item_vertical.xml
+++ b/app/src/main/res/layout/tabs_bar_item_vertical.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.igalia.wolvic.ui.views.TabsBarItem xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:layout_width='match_parent'
+    android:layout_height="@dimen/vertical_tabs_bar_item_height"
+    android:padding="1dp">
+
+    <RelativeLayout
+        android:id="@+id/tab_details"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/tabs_bar_item_bg"
+        android:duplicateParentState="true">
+
+        <ImageView
+            android:id="@+id/tab_favicon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerInParent="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_icon_globe" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toStartOf="@id/tab_close_button"
+            android:layout_toEndOf="@id/tab_favicon"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tab_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="start"
+                android:lines="1"
+                android:shadowColor="#00000000"
+                android:textColor="#ffffff"
+                android:textSize="14sp"
+                android:textStyle="normal"
+                tools:text="Title of the page" />
+
+            <TextView
+                android:id="@+id/tab_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="start"
+                android:lines="1"
+                android:shadowColor="#00000000"
+                android:textColor="#ffffff"
+                android:textSize="12sp"
+                android:textStyle="normal"
+                tools:text="example.com" />
+        </LinearLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tab_close_button"
+            style="@style/Widget.Material3.Button.TextButton.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:minWidth="32dp"
+            android:padding="0dp"
+            app:icon="@drawable/ic_icon_exit"
+            app:iconGravity="textStart"
+            app:iconPadding="0dp"
+            app:iconSize="16dp"
+            app:iconTint="@drawable/tab_close_icon_color" />
+    </RelativeLayout>
+
+</com.igalia.wolvic.ui.views.TabsBarItem>

--- a/app/src/main/res/layout/tabs_bar_vertical.xml
+++ b/app/src/main/res/layout/tabs_bar_vertical.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    tools:layout_width="@dimen/vertical_tabs_bar_width"
+    android:layout_height="match_parent"
+    android:background="@drawable/tabs_bar_bg"
+    android:orientation="vertical">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/add_tab"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_margin="4dp"
+        android:background="@drawable/tab_add_background"
+        android:scaleType="fitCenter"
+        app:backgroundTint="@null"
+        app:icon="@drawable/ic_icon_newtab"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
+        app:iconSize="36dp"
+        app:iconTint="@color/rhino" />
+
+    <com.igalia.wolvic.ui.views.CustomRecyclerView
+        android:id="@+id/tabsRecyclerView"
+        style="@style/customRecyclerViewStyle"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="4dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:overScrollMode="never"
+        android:scrollbars="vertical"
+        android:fastScrollAlwaysVisible="false"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/tabs_bar_item_vertical" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -169,6 +169,7 @@
                 app:tooltipDensity="@dimen/tray_tooltip_density"
                 app:tooltipPosition="bottom"
                 app:tooltipLayout="@layout/tooltip_tray"
+                visibleGone="@{traymodel.tabsButtonInTray}"
                 android:src="@drawable/ic_icon_tray_tabs"
                 app:regularModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_unchecked_start : @drawable/tray_background_unchecked_middle}"
                 app:privateModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_start_private : @drawable/tray_background_middle_private}"
@@ -182,7 +183,10 @@
                 app:tooltipPosition="bottom"
                 app:tooltipLayout="@layout/tooltip_tray"
                 android:src="@{viewmodel.isPrivateSession ? @drawable/ic_icon_tray_private_browsing_on_v2 : @drawable/ic_icon_tray_private_browsing_v2}"
-                app:privateMode="@{viewmodel.isPrivateSession}"/>
+                app:privateMode="@{viewmodel.isPrivateSession}"
+                app:regularModeBackground="@{traymodel.isMaxWindows &amp;&amp; viewmodel.isTabsBarVisible ? @drawable/tray_background_unchecked_start : @drawable/tray_background_unchecked_middle}"
+                app:privateModeBackground="@{traymodel.isMaxWindows &amp;&amp; viewmodel.isTabsBarVisible ? @drawable/tray_background_start_private : @drawable/tray_background_middle_private}"
+                app:activeModeBackground="@{traymodel.isMaxWindows &amp;&amp; viewmodel.isTabsBarVisible ? @drawable/tray_background_checked_start : @drawable/tray_background_checked_middle}"/>
 
             <com.igalia.wolvic.ui.views.UIButton
                 android:id="@+id/bookmarksButton"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -117,6 +117,12 @@
     <dimen name="tabs_icon_padding_max">7dp</dimen>
     <dimen name="tabs_icon_padding_min">3dp</dimen>
 
+    <!-- Tabs Bar -->
+    <dimen name="vertical_tabs_bar_width">200dp</dimen>
+    <dimen name="vertical_tabs_bar_item_height">48dp</dimen>
+    <dimen name="horizontal_tabs_bar_height">52dp</dimen>
+    <dimen name="horizontal_tabs_bar_item_width">128dp</dimen>
+
     <!-- No Internet toast -->
     <dimen name="no_internet_width">400dp</dimen>
     <dimen name="no_internet_height">200dp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -85,6 +85,7 @@
     <string name="settings_key_privacy_policy_accepted" translatable="false">settings_key_privacy_policy_accepted</string>
     <string name="settings_key_search_engine_id" translatable="false">settings_key_search_engine_id</string>
     <string name="settings_key_eye_tracking_supported" translatable="false">settings_key_eye_tracking_supported</string>
+    <string name="settings_key_tabs_location" translatable="false">settings_key_tabs_location</string>
     <string name="environment_override_help_url" translatable="false">https://github.com/igalia/wolvic/wiki/Environments</string>
     <string name="private_policy_url" translatable="false">https://wolvic.com/legal/privacy/</string>
     <string name="private_report_url" translatable="false">https://www.igalia.com/privacy/&amp;url=%1$s</string>

--- a/app/src/main/res/values/options_values.xml
+++ b/app/src/main/res/values/options_values.xml
@@ -85,6 +85,23 @@
         <item>2</item>
     </integer-array>
 
+    <!-- Tabs Location Options -->
+    <string-array name="display_options_tabs_location" translatable="false">
+        <item>@string/display_options_tabs_location_tray</item>
+        <item>@string/display_options_tabs_location_horizontal</item>
+        <item>@string/display_options_tabs_location_vertical</item>
+    </string-array>
+
+    <integer-array name="display_options_tabs_location_values" translatable="false">
+        <!-- SettingsStore.TABS_LOCATION_DEFAULT -->
+        <item>0</item>
+        <!-- SettingsStore.TABS_LOCATION_HORIZONTAL -->
+        <item>1</item>
+        <!-- SettingsStore.TABS_LOCATION_VERTICAL -->
+        <item>2</item>
+    </integer-array>
+
+
     <!-- Tracking Options -->
     <string-array name="privacy_options_tracking" translatable="false">
         <item>@string/privacy_options_tracking_etp</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,6 +499,14 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">Start with Passthrough Mode</string>
 
+    <!-- This string labels a set of radio buttons in the 'Display Options' dialog
+         and is used to customize the location of the Tabs pane. -->
+    <string name="display_options_tabs_location">Tabs location</string>
+
+    <string name="display_options_tabs_location_tray">Tray</string>
+    <string name="display_options_tabs_location_horizontal">Horizontal</string>
+    <string name="display_options_tabs_location_vertical">Vertical</string>
+
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Use Sound Effects</string>


### PR DESCRIPTION
The Tabs Bar is a small window that sits next to the current window and which lists the open tabs.
    
There are two implementations in this PR:

- `HorizontalTabsBar` on the top of the window
- `VerticalTabsBar` on the side of the window
    
The Tabs Bar is managed by `VRBrowserActivity`.
    
`SessionStore` now keeps a list of session change listeners so the tabs bar can be updated. `SessionChangeListener` and `TabDelegate` are moved to separate files.
    
The location of tabs can be changed in Settings -> Display.

WindowViewModel gets three new fields:
- isTabsBarVisible

WidgetPlacement gets two new fields:
- horizontalOffset
- verticalOffset

These define a translation offset (in world dimensions), which is applied after the anchors have been calculated. The goal is to be able to move widgets from their initial position in a predictable way, to make space for the tabs bar when necessary.

These windows' offsets are updated in Windows.adjustWindowOffsets(). The primary use case is to make space for the horizontal tabs bar by moving the top widget, and to make space for the vertical tabs bar by moving the browser windows.

Note that Wolvic does not keep track of the relationship between windows and tabs. There is one single list of tabs that can be dynamically displayed on one or more windows. Unfortunately, this means that the interface tends to get a bit confusing when we have more than one window open.
