### PR TITLE
Set flags explicitly on registerReceiver calls

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1560,7 +1560,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             mLastBatteryLevel = bm == null ? 100 : bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
         }
 
-        Intent intent = this.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        Intent intent = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            intent = this.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            intent = this.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        }
         int plugged = intent == null ? -1 : intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
         boolean isCharging = plugged == BatteryManager.BATTERY_PLUGGED_AC || plugged == BatteryManager.BATTERY_PLUGGED_USB || plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS;
         mTray.setBatteryLevels(mLastBatteryLevel, isCharging, leftLevel, rightLevel);

--- a/app/src/common/shared/com/igalia/wolvic/search/SearchEngineWrapper.kt
+++ b/app/src/common/shared/com/igalia/wolvic/search/SearchEngineWrapper.kt
@@ -7,6 +7,7 @@ import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.net.Uri
+import android.os.Build
 import android.util.Log
 import androidx.preference.PreferenceManager
 import com.igalia.wolvic.R
@@ -23,11 +24,9 @@ import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.searchEngines
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.search.ext.buildSearchUrl
-import mozilla.components.feature.search.ext.createSearchEngine
 import mozilla.components.feature.search.middleware.SearchMiddleware
 import mozilla.components.feature.search.suggestions.SearchSuggestionClient
 import java.lang.ref.WeakReference
-import java.util.Locale
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
 
@@ -48,10 +47,17 @@ class SearchEngineWrapper private constructor(aContext: Context) :
         ))
     fun registerForUpdates() {
         if (hasContext()) {
-            context!!.registerReceiver(
-                mLocaleChangedReceiver,
-                IntentFilter(Intent.ACTION_LOCALE_CHANGED)
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                context!!.registerReceiver(
+                    mLocaleChangedReceiver,
+                    IntentFilter(Intent.ACTION_LOCALE_CHANGED), Context.RECEIVER_NOT_EXPORTED
+                )
+            } else {
+                context!!.registerReceiver(
+                        mLocaleChangedReceiver,
+                        IntentFilter(Intent.ACTION_LOCALE_CHANGED)
+                )
+            }
             mPrefs?.registerOnSharedPreferenceChangeListener(this)
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -366,7 +366,11 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
                 }
             };
         }
-        context.registerReceiver(mBroadcastReceiver, new IntentFilter(Intent.ACTION_TIME_TICK));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            context.registerReceiver(mBroadcastReceiver, new IntentFilter(Intent.ACTION_TIME_TICK), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(mBroadcastReceiver, new IntentFilter(Intent.ACTION_TIME_TICK));
+        }
     }
 
     public void stop(Context context) {

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -13,6 +13,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.hardware.display.DisplayManager;
 import android.os.Bundle;
+import android.os.Build;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Surface;
@@ -268,7 +269,11 @@ public abstract class PlatformActivity extends FragmentActivity implements Surfa
 
         IntentFilter filter = new IntentFilter();
         filter.addAction(WolvicHmsMessageService.MESSAGE_RECEIVED_ACTION);
-        registerReceiver(mHmsMessageBroadcastReceiver, filter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            registerReceiver(mHmsMessageBroadcastReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            registerReceiver(mHmsMessageBroadcastReceiver, filter);
+        }
 
         setHmsMessageServiceAutoInit(true);
         getHmsMessageServiceToken();

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -168,7 +168,7 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
         // Alternatively: android.hardware.usb.action.USB_DEVICE_ATTACHED, USB_DEVICE_DETACHED.
         IntentFilter usbPermissionFilter = new IntentFilter();
         usbPermissionFilter.addAction(HUAWEI_USB_PERMISSION);
-        registerReceiver(mUsbPermissionReceiver, usbPermissionFilter);
+        registerReceiver(mUsbPermissionReceiver, usbPermissionFilter, Context.RECEIVER_NOT_EXPORTED);
 
         initializeAGConnect();
 


### PR DESCRIPTION
According to the [registerReceiver](https://developer.android.com/reference/android/content/Context#registerReceiver(android.content.BroadcastReceiver,%20android.content.IntentFilter)) documentation, we should pass flags explicitly in the registerReceiver calls: 

> For apps targeting [Build.VERSION_CODES.UPSIDE_DOWN_CAKE](https://developer.android.com/reference/android/os/Build.VERSION_CODES#UPSIDE_DOWN_CAKE) either [RECEIVER_EXPORTED](https://developer.android.com/reference/android/content/Context#RECEIVER_EXPORTED) or [RECEIVER_NOT_EXPORTED](https://developer.android.com/reference/android/content/Context#RECEIVER_NOT_EXPORTED) must be specified if the receiver isn't being registered for [system broadcasts](https://developer.android.com/guide/components/broadcasts#system-broadcasts) or a [SecurityException](https://developer.android.com/reference/java/lang/SecurityException) will be thrown.