### PR TITLE
[OpenXR] Workaround phantom click events with hand interaction

### DIFF
--- a/app/src/openxr/cpp/OpenXRGestureManager.h
+++ b/app/src/openxr/cpp/OpenXRGestureManager.h
@@ -25,8 +25,7 @@ virtual XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags
 virtual bool systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const = 0;
 virtual void getTriggerPinchStatusAndFactor(const HandJointsArray& handJoints, bool& isPinching, double& pinchFactor);
 
-protected:
-bool palmFacesHead(const vrb::Matrix& palm, const vrb::Matrix& head) const;
+static bool handFacesHead(const vrb::Matrix& hand, const vrb::Matrix& head);
 
 private:
 double mSmoothIndexThumbDistance { 0 };
@@ -37,7 +36,7 @@ private:
 void populateNextStructureIfNeeded(XrHandJointLocationsEXT& handJointLocations) override;
 bool hasAim() const override;
 XrPosef aimPose(const XrTime predictedDisplayTime, const OpenXRHandFlags, const vrb::Matrix& head) const override;
-bool systemGestureDetected(const vrb::Matrix& palm, const vrb::Matrix& head) const override;
+bool systemGestureDetected(const vrb::Matrix& hand, const vrb::Matrix& head) const override;
 void getTriggerPinchStatusAndFactor(const HandJointsArray& handJoints, bool& isPinching, double& pinchFactor) override;
 
 XrHandTrackingAimStateFB mFBAimState;

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -896,6 +896,9 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
             continue;
         }
 
+        if (!state->ready)
+            continue;
+
         placeholders.erase(button.type);
         buttonCount++;
         auto browserButton = GetBrowserButton(button);
@@ -911,7 +914,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
                                     state->clicked, state->touched, state->value);
         }
 
-        if (button.type == OpenXRButtonType::Trigger && state->ready) {
+        if (button.type == OpenXRButtonType::Trigger) {
             delegate.SetSelectFactor(mIndex, state->value);
         }
 

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -5,12 +5,7 @@
 #include "DeviceUtils.h"
 #include "SystemUtils.h"
 
-#if defined(PICOXR)
-    // Pico system version prior to 5.7.1 doesn't provide palm joint info :( so we use the wrist instead.
-#define HAND_JOINT_FOR_AIM (CompareBuildIdString(kPicoVersionHandTrackingUpdate) ? XR_HAND_JOINT_WRIST_EXT : XR_HAND_JOINT_PALM_EXT)
-#else
-#define HAND_JOINT_FOR_AIM XR_HAND_JOINT_PALM_EXT
-#endif
+#define HAND_JOINT_FOR_AIM XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT
 
 namespace crow {
 
@@ -791,6 +786,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
 #endif
 
     auto gotHandTrackingInfo = false;
+    auto handFacesHead = false;
     if (isControllerUnavailable || mUsingHandInteractionProfile) {
         gotHandTrackingInfo = GetHandTrackingInfo(frameState.predictedDisplayTime, localSpace, head);
         if (gotHandTrackingInfo) {
@@ -802,6 +798,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
                 delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
                 return;
             }
+            handFacesHead = OpenXRGestureManager::handFacesHead(jointTransforms[HAND_JOINT_FOR_AIM], head);
             delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
         }
     }
@@ -814,7 +811,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     bool hasAim = isPoseActive && (poseLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT);
     delegate.SetAimEnabled(mIndex, hasAim);
 
-    if (!hasAim && !mUsingHandInteractionProfile) {
+    if (!hasAim && !(mUsingHandInteractionProfile && gotHandTrackingInfo && handFacesHead)) {
       delegate.SetEnabled(mIndex, false);
       return;
     }
@@ -833,7 +830,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     delegate.SetMode(mIndex, mUsingHandInteractionProfile && gotHandTrackingInfo ? ControllerMode::Hand : ControllerMode::Device);
     delegate.SetEnabled(mIndex, true);
 
-    bool isHandActionEnabled = !hasAim && mUsingHandInteractionProfile;
+    bool isHandActionEnabled = !hasAim && mUsingHandInteractionProfile && handFacesHead;
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
 
     device::CapabilityFlags flags = device::Orientation;

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -790,17 +790,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     bool isControllerUnavailable = (poseLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) == 0;
 #endif
 
-    // TODO: merge this with the one in OpenXRGestureManager
-    auto isPalmFacingHead = [](const vrb::Matrix& palm, const vrb::Matrix& head) {
-        auto palmToHead = (head.GetTranslation() - palm.GetTranslation()).Normalize();
-        // Extract the orientation of -Y axis which is the one pointing from the palm out.
-        auto palmNormalizedOrientation = palm.MultiplyDirection({0, -1, 0}).Normalize();
-
-        return palmNormalizedOrientation.Dot(palmToHead) > 0.9;
-    };
-
     auto gotHandTrackingInfo = false;
-    auto palmFacesHead = false;
     if (isControllerUnavailable || mUsingHandInteractionProfile) {
         gotHandTrackingInfo = GetHandTrackingInfo(frameState.predictedDisplayTime, localSpace, head);
         if (gotHandTrackingInfo) {
@@ -812,7 +802,6 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
                 delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
                 return;
             }
-            palmFacesHead = isPalmFacingHead(jointTransforms[HAND_JOINT_FOR_AIM], head);
             delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
         }
     }
@@ -825,7 +814,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     bool hasAim = isPoseActive && (poseLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT);
     delegate.SetAimEnabled(mIndex, hasAim);
 
-    if (!hasAim && (!mUsingHandInteractionProfile || !gotHandTrackingInfo)) {
+    if (!hasAim && !mUsingHandInteractionProfile) {
       delegate.SetEnabled(mIndex, false);
       return;
     }
@@ -844,7 +833,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     delegate.SetMode(mIndex, mUsingHandInteractionProfile && gotHandTrackingInfo ? ControllerMode::Hand : ControllerMode::Device);
     delegate.SetEnabled(mIndex, true);
 
-    auto isHandActionEnabled = !hasAim && mUsingHandInteractionProfile && palmFacesHead;
+    bool isHandActionEnabled = !hasAim && mUsingHandInteractionProfile;
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
 
     device::CapabilityFlags flags = device::Orientation;
@@ -916,31 +905,14 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
         auto immersiveButton = GetImmersiveButton(button);
 
         if (isHandActionEnabled) {
-            ASSERT(button.type == OpenXRButtonType::Trigger);
-            if (mDeviceType == device::MagicLeap2) {
-                // The MagicLeap2 sometimes return pinches when the hand transitions from tracked
-                // to untracked states. We need to filter them out, otherwise we'd get phantom clicks
-                // when moving hands out of sight while them face the head. The change threshold value
-                // is based on testing, but it seems to work well.
-                const float kPinchChangeThreshold = 0.35f;
-                const float change = abs(mLastHandActionTriggerValue - state->value);
-                mLastHandActionTriggerValue = state->value;
-                if (change > kPinchChangeThreshold)
-                    continue;
-            }
-
             // When hand faces head, tracking systems do not have the same level of precision
             // detecting pinches, that's why we need to lower the bar to detect them.
             delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_APP, -1, state->value >= kClickLowFiThreshold,
-                                    state->value > 0, state->value);
-            continue;
+                                    state->value > 0, 1.0);
+        } else {
+            delegate.SetButtonState(mIndex, browserButton, immersiveButton.has_value() ? immersiveButton.value() : -1,
+                                    state->clicked, state->touched, state->value);
         }
-
-        if (!hasAim)
-            continue;
-
-        delegate.SetButtonState(mIndex, browserButton, immersiveButton.has_value() ? immersiveButton.value() : -1,
-                                state->clicked, state->touched, state->value);
 
         if (button.type == OpenXRButtonType::Trigger && state->ready) {
             delegate.SetSelectFactor(mIndex, state->value);

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -83,7 +83,6 @@ private:
     bool mSupportsHandJointsMotionRangeInfo { false };
     bool mUsingHandInteractionProfile { false };
     device::DeviceType mDeviceType { device::UnknownType };
-    float mLastHandActionTriggerValue { 0.0f };
 
     struct HandMeshMSFT {
         XrSpace space = XR_NULL_HANDLE;


### PR DESCRIPTION
This PR tries to workaround the phantom clicks we get from the MagicLeap OpenXR runtime when moving the hands out of sight and using the hand interaction profile.

First of all it reverts the previous attempt to solve this as it was not working fine. Then it implements a new solution based on gesture detection. We now require a detection of the gesture of the hands facing the head from the hand joints data.