### PR TITLE
[Chromium] Add an UA override for matterport.com

### DIFF
--- a/app/src/chromium/assets/userAgentOverride.json
+++ b/app/src/chromium/assets/userAgentOverride.json
@@ -1,5 +1,6 @@
 {
   "ae0755740e4354ac67025056e775ad06d8a529ae4f37244fbb02d72199e2c780311e47aa9895079b980ec4bfa676f1f39c4ab41ea995c524e52bde9a73623da2": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
-  "e6137b4c2f49a3917c2c90a50fb270a5eebb962f2c72344ae2e29e321bb21891e5ca4fec06cae78e14f4a8510473e934234e9ec3f60e8415f5f6da754c55b9b1": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36"
+  "e6137b4c2f49a3917c2c90a50fb270a5eebb962f2c72344ae2e29e321bb21891e5ca4fec06cae78e14f4a8510473e934234e9ec3f60e8415f5f6da754c55b9b1": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
+  "3ea7a4815f1fb9d3a7da08cfde65e2aa547ff1d7399a5015adbc36a19a7893f7e1dae7db39f43a631dc43bcd634be8ef1b7ce7f7c22bd3ff36e7d6c7b5038ebd": "Mozilla/5.0 (Linux; Android 10; Quest 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Mobile VR Wolvic/1.0"
 }
 


### PR DESCRIPTION
It was not loading because it was filtering by device type in the UA string. Just using "Quest 3" allows us to properly load the VR version.