### PR TITLE
[Chromium] Disable Mozilla Accounts

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -582,7 +582,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     private void showWhatsNewDialogIfNeeded() {
-        if (SettingsStore.getInstance(this).isWhatsNewDisplayed() || mWindows.getFocusedWindow().isKioskMode()) {
+        if (SettingsStore.getInstance(this).isWhatsNewDisplayed() || mWindows.getFocusedWindow().isKioskMode()
+            || BuildConfig.FLAVOR_backend.equals("chromium")) {
             return;
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1410,8 +1410,9 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             }
         });
         boolean isSendTabEnabled = false;
-        if (URLUtil.isHttpUrl(mAttachedWindow.getSession().getCurrentUri()) ||
-                URLUtil.isHttpsUrl(mAttachedWindow.getSession().getCurrentUri())) {
+        if (!BuildConfig.FLAVOR_backend.equals("chromium") &&
+                (URLUtil.isHttpUrl(mAttachedWindow.getSession().getCurrentUri()) ||
+                URLUtil.isHttpsUrl(mAttachedWindow.getSession().getCurrentUri()))) {
             isSendTabEnabled = true;
         }
         mHamburgerMenu.setSendTabEnabled(isSendTabEnabled);

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -177,7 +177,8 @@
                             app:honeycombButtonIcon="@drawable/ic_icon_settings_account"
                             app:honeycombButtonText="@string/settings_fxa_account_sign_in"
                             app:honeycombButtonTextSize="@dimen/settings_main_button_text_width"
-                            app:honeycombButtonIconHover="false"/>
+                            app:honeycombButtonIconHover="false"
+                            app:visibleGone="@{BuildConfig.FLAVOR_backend != &quot;chromium&quot;}"/>
 
                     </LinearLayout>
 


### PR DESCRIPTION
It does not work with Chromium backend (we suspect there is some kind of UA/capability checking on the server side) so we better remove it from the UI in order not to confuse users.

Disabling it includes:
* Disabling status updates
* Remove "Sign in account" button from settings
* Remove "Send Tab to device" option in hamburger menu