### PR TITLE
Revert UA overrides for Disney and Amazon

### DIFF
--- a/app/src/chromium/assets/userAgentOverride.json
+++ b/app/src/chromium/assets/userAgentOverride.json
@@ -1,8 +1,6 @@
 {
   "ae0755740e4354ac67025056e775ad06d8a529ae4f37244fbb02d72199e2c780311e47aa9895079b980ec4bfa676f1f39c4ab41ea995c524e52bde9a73623da2": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
   "e6137b4c2f49a3917c2c90a50fb270a5eebb962f2c72344ae2e29e321bb21891e5ca4fec06cae78e14f4a8510473e934234e9ec3f60e8415f5f6da754c55b9b1": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
-  "e6a740804943c9a6d77b6a49a82f47cd71d104ffb6d32ab4a12ace6bc6486e04281398f1d29850b11a72a4ea39a24b9b5d6a9084837bbfe9ced0fd35cafd9af4": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
-  "e58914f27c01b528e8da341105fd1a88b18bcb7e5adb0248e37f192cd5cfb76a0af18d0403db34887e817ed149d92861d73be4c370a0c9b88e4ed90229545882": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
-  "3ea7a4815f1fb9d3a7da08cfde65e2aa547ff1d7399a5015adbc36a19a7893f7e1dae7db39f43a631dc43bcd634be8ef1b7ce7f7c22bd3ff36e7d6c7b5038ebd": "Mozilla/5.0 (Linux; Android 10; Quest 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Mobile VR Wolvic/1.0"
+  "e6a740804943c9a6d77b6a49a82f47cd71d104ffb6d32ab4a12ace6bc6486e04281398f1d2f43a631dc43bcd634be8ef1b7ce7f7c22bd3ff36e7d6c7b5038ebd": "Mozilla/5.0 (Linux; Android 10; Quest 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Mobile VR Wolvic/1.0"
 }
 


### PR DESCRIPTION
It's unclear this UA overrides are necessary and the one for Amazon is causing an incorrect behavior. 