### PR TITLE
[OpenXR] Eye tracking support for navigation

### DIFF
--- a/app/src/aosp/AndroidManifest.xml
+++ b/app/src/aosp/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
     <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
     <uses-permission android:name="com.magicleap.permission.HAND_TRACKING" />
+    <uses-permission android:name="com.magicleap.permission.EYE_TRACKING" />
 
     <queries>
         <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker"/>

--- a/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
@@ -8,11 +8,8 @@ package com.igalia.wolvic;
 import android.app.NativeActivity;
 import android.content.Intent;
 import android.view.KeyEvent;
-import android.view.View;
-import android.view.WindowManager;
 
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
-import com.igalia.wolvic.utils.SystemUtils;
 
 public class PlatformActivity extends NativeActivity {
 
@@ -36,6 +33,11 @@ public class PlatformActivity extends NativeActivity {
     protected Intent getStoreIntent() {
         // Dummy implementation.
         return null;
+    }
+
+    protected String getEyeTrackingPermissionString() {
+        // FIXME: currently returning MagicLeap2 string, should be generalized to other devices.
+        return "com.magicleap.permission.EYE_TRACKING";
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -247,6 +247,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private int mLastBatteryLevel = -1;
     private PlatformActivityPlugin mPlatformPlugin;
     private int mLastMotionEventWidgetHandle;
+    private boolean mIsEyeTrackingSupported;
 
     private boolean callOnAudioManager(Consumer<AudioManager> fn) {
         if (mAudioManager == null) {
@@ -1594,11 +1595,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Keep
     @SuppressWarnings("unused")
-    private void setEyeTrackingSupported(final boolean isSupported) {
-        runOnUiThread(() -> {
-            mSettings.setEyeTrackingSupported(isSupported);
-        });
-    }
+    private void setEyeTrackingSupported(final boolean isSupported) { mIsEyeTrackingSupported = isSupported; }
 
     private SurfaceTexture createSurfaceTexture() {
         int[] ids = new int[1];
@@ -2186,6 +2183,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
         });
     }
+
+    @Override
+    public boolean isEyeTrackingSupported() { return mIsEyeTrackingSupported; }
 
     private native void addWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateWidgetNative(int aHandle, WidgetPlacement aPlacement);

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -2171,17 +2171,29 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             callback.onEyeTrackingPermissionRequest(true);
             return;
         }
-        requestPermission(null, getEyeTrackingPermissionString(), OriginatorType.APPLICATION, new WSession.PermissionDelegate.Callback() {
-            @Override
-            public void grant() {
-                callback.onEyeTrackingPermissionRequest(true);
-            }
 
-            @Override
-            public void reject() {
-                callback.onEyeTrackingPermissionRequest(false);
-            }
+        PromptDialogWidget dialog = new PromptDialogWidget(this);
+        dialog.setTitle(R.string.eye_tracking_permission_title);
+        dialog.setDescription(R.string.eye_tracking_permission_message);
+        dialog.setButtons(new int[] {R.string.ok_button});
+        dialog.setCheckboxVisible(false);
+        dialog.setIcon(R.drawable.mozac_ic_warning_fill_24);
+        dialog.setButtonsDelegate((index, isChecked) -> {
+            dialog.hide(UIWidget.REMOVE_WIDGET);
+            dialog.releaseWidget();
+            requestPermission(null, getEyeTrackingPermissionString(), OriginatorType.APPLICATION, new WSession.PermissionDelegate.Callback() {
+                @Override
+                public void grant() {
+                    callback.onEyeTrackingPermissionRequest(true);
+                }
+
+                @Override
+                public void reject() {
+                    callback.onEyeTrackingPermissionRequest(false);
+                }
+            });
         });
+        dialog.show(UIWidget.REQUEST_FOCUS);
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -27,6 +27,7 @@ import com.igalia.wolvic.browser.engine.EngineProvider;
 import com.igalia.wolvic.speech.SpeechServices;
 import com.igalia.wolvic.telemetry.TelemetryService;
 import com.igalia.wolvic.ui.viewmodel.SettingsViewModel;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.menus.library.SortingContextMenuWidget;
 import com.igalia.wolvic.utils.DeviceType;
 import com.igalia.wolvic.utils.RemoteProperties;
@@ -140,6 +141,7 @@ public class SettingsStore {
     public final static boolean AUTOFILL_ENABLED = true;
     public final static boolean LOGIN_AUTOCOMPLETE_ENABLED = true;
     public final static String SEARCH_ENGINE_DEFAULT = "";
+    public final static @WidgetManagerDelegate.PointerMode int POINTER_MODE_DEFAULT = WidgetManagerDelegate.TRACKED_POINTER;
 
     // Enable telemetry by default (opt-out).
     public final static boolean CRASH_REPORTING_DEFAULT = false;
@@ -699,6 +701,16 @@ public class SettingsStore {
         return mPrefs.getBoolean(mContext.getString(R.string.settings_key_haptic_feedback_enabled), HAPTIC_FEEDBACK_ENABLED);
     }
 
+    public void setPointerMode(@WidgetManagerDelegate.PointerMode int pointerMode) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putInt(mContext.getString(R.string.settings_key_pointer_mode), pointerMode);
+        editor.commit();
+    }
+
+    public @WidgetManagerDelegate.PointerMode int getPointerMode() {
+        return mPrefs.getInt(mContext.getString(R.string.settings_key_pointer_mode), POINTER_MODE_DEFAULT);
+    }
+
     public boolean isCenterWindows() {
         return mPrefs.getBoolean(
                 mContext.getString(R.string.settings_key_center_windows), CENTER_WINDOWS_DEFAULT);
@@ -1091,5 +1103,15 @@ public class SettingsStore {
 
     public String getWebAppsData() {
         return mPrefs.getString(mContext.getString(R.string.settings_key_web_apps_data), "");
+    }
+
+    public void setEyeTrackingSupported(boolean isSupported) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(mContext.getString(R.string.settings_key_eye_tracking_supported), isSupported);
+        editor.commit();
+    }
+
+    public boolean isEyeTrackingSupported() {
+        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_eye_tracking_supported), false);
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -1104,14 +1104,4 @@ public class SettingsStore {
     public String getWebAppsData() {
         return mPrefs.getString(mContext.getString(R.string.settings_key_web_apps_data), "");
     }
-
-    public void setEyeTrackingSupported(boolean isSupported) {
-        SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putBoolean(mContext.getString(R.string.settings_key_eye_tracking_supported), isSupported);
-        editor.commit();
-    }
-
-    public boolean isEyeTrackingSupported() {
-        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_eye_tracking_supported), false);
-    }
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -138,4 +138,5 @@ public interface WidgetManagerDelegate {
     KeyboardWidget getKeyboard();
     void setPointerMode(@PointerMode int mode);
     void checkEyeTrackingPermissions(@NonNull EyeTrackingCallback callback);
+    boolean isEyeTrackingSupported();
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -35,6 +35,10 @@ public interface WidgetManagerDelegate {
         void onWebXRRenderStateChange(boolean aRendering);
     }
 
+    interface EyeTrackingCallback {
+        void onEyeTrackingPermissionRequest(boolean aPermissionGranted);
+    }
+
     float DEFAULT_DIM_BRIGHTNESS = 0.25f;
     float DEFAULT_NO_DIM_BRIGHTNESS = 1.0f;
 
@@ -60,6 +64,12 @@ public interface WidgetManagerDelegate {
     @interface YawTarget {}
     int YAW_TARGET_ALL = 0; // Targets widgets and VR videos.
     int YAW_TARGET_WIDGETS = 1; // Targets widgets only.
+
+    // Keep in sync with DeviceDelegate.h
+    @IntDef(value = { TRACKED_POINTER, TRACKED_EYE })
+    @interface PointerMode {}
+    int TRACKED_POINTER = 0;
+    int TRACKED_EYE = 1;
 
     enum OriginatorType {WEBSITE, APPLICATION}
 
@@ -126,4 +136,6 @@ public interface WidgetManagerDelegate {
     @NonNull
     AppServicesProvider getServicesProvider();
     KeyboardWidget getKeyboard();
+    void setPointerMode(@PointerMode int mode);
+    void checkEyeTrackingPermissions(@NonNull EyeTrackingCallback callback);
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -57,6 +57,13 @@ class ControllerOptionsView extends SettingsView {
 
         mBinding.hapticFeedbackSwitch.setOnCheckedChangeListener(mHapticFeedbackListener);
         setHapticFeedbackEnabled(SettingsStore.getInstance(getContext()).isHapticFeedbackEnabled(), false);
+
+        if (SettingsStore.getInstance(getContext()).isEyeTrackingSupported()) {
+            mBinding.pointerModeRadio.setOnCheckedChangeListener(mPointerModeListener);
+            setPointerMode(SettingsStore.getInstance(getContext()).getPointerMode(), false);
+        } else {
+            mBinding.pointerModeRadio.setVisibility(GONE);
+        }
     }
 
     private void resetOptions() {
@@ -67,6 +74,7 @@ class ControllerOptionsView extends SettingsView {
             setScrollDirection(mBinding.scrollDirectionRadio.getIdForValue(SettingsStore.SCROLL_DIRECTION_DEFAULT), true);
         }
         setHapticFeedbackEnabled(SettingsStore.HAPTIC_FEEDBACK_ENABLED, true);
+        setPointerMode(SettingsStore.POINTER_MODE_DEFAULT, true);
     }
 
     private void setPointerColor(int checkedId, boolean doApply) {
@@ -100,6 +108,17 @@ class ControllerOptionsView extends SettingsView {
         }
     }
 
+    private void setPointerMode(@WidgetManagerDelegate.PointerMode int value, boolean doApply) {
+        mBinding.pointerModeRadio.setOnCheckedChangeListener(null);
+        mBinding.pointerModeRadio.setChecked(value, false);
+        mBinding.pointerModeRadio.setOnCheckedChangeListener(mPointerModeListener);
+
+        if (doApply) {
+            SettingsStore.getInstance(getContext()).setPointerMode(value);
+            mWidgetManager.setPointerMode(value);
+        }
+    }
+
     private RadioGroupSetting.OnCheckedChangeListener mPointerColorListener = (radioGroup, checkedId, doApply) -> {
         setPointerColor(checkedId, doApply);
     };
@@ -110,6 +129,22 @@ class ControllerOptionsView extends SettingsView {
 
     private SwitchSetting.OnCheckedChangeListener mHapticFeedbackListener = (compoundButton, enabled, apply) ->
     setHapticFeedbackEnabled(enabled, true);
+
+    private RadioGroupSetting.OnCheckedChangeListener mPointerModeListener = (compoundButton, checkedId, doApply) -> {
+        if (checkedId == WidgetManagerDelegate.TRACKED_POINTER) {
+            setPointerMode(checkedId, doApply);
+            return;
+        }
+        assert checkedId == WidgetManagerDelegate.TRACKED_EYE;
+        mWidgetManager.checkEyeTrackingPermissions((aPermissionGranted) -> {
+            if (aPermissionGranted) {
+                setPointerMode(checkedId, doApply);
+            } else {
+                // Revert to pointer mode if permission is not granted
+                setPointerMode(WidgetManagerDelegate.TRACKED_POINTER, false);
+            }
+        });
+    };
 
     @Override
     protected SettingViewType getType() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -58,7 +58,7 @@ class ControllerOptionsView extends SettingsView {
         mBinding.hapticFeedbackSwitch.setOnCheckedChangeListener(mHapticFeedbackListener);
         setHapticFeedbackEnabled(SettingsStore.getInstance(getContext()).isHapticFeedbackEnabled(), false);
 
-        if (SettingsStore.getInstance(getContext()).isEyeTrackingSupported()) {
+        if (mWidgetManager.isEyeTrackingSupported()) {
             mBinding.pointerModeRadio.setOnCheckedChangeListener(mPointerModeListener);
             setPointerMode(SettingsStore.getInstance(getContext()).getPointerMode(), false);
         } else {

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -78,6 +78,8 @@ public abstract class PlatformActivity extends FragmentActivity implements Surfa
         return null;
     }
 
+    protected String getEyeTrackingPermissionString() { return null; }
+
     private final SharedPreferences.OnSharedPreferenceChangeListener mOnSharedPreferenceChangeListener =
             (sharedPreferences, key) -> {
                 if (key.equals(getString(R.string.settings_key_privacy_policy_accepted))) {

--- a/app/src/lynx/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/lynx/java/com/igalia/wolvic/PlatformActivity.java
@@ -36,6 +36,8 @@ public class PlatformActivity extends NativeActivity {
         return null;
     }
 
+    protected String getEyeTrackingPermissionString() { return null; }
+
     @Override
     public void onBackPressed() {
         queueRunnable(new Runnable() {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1698,6 +1698,11 @@ BrowserWorld::SetIsServo(const bool aIsServo) {
   m.externalVR->SetSourceBrowser(aIsServo ? ExternalVR::VRBrowserType::Servo : ExternalVR::VRBrowserType::Gecko);
 }
 
+void
+BrowserWorld::SetPointerMode(crow::DeviceDelegate::PointerMode pointerMode) {
+  m.device->SetPointerMode(pointerMode);
+}
+
 JNIEnv*
 BrowserWorld::GetJNIEnv() const {
   ASSERT_ON_RENDER_THREAD(nullptr);
@@ -2197,6 +2202,21 @@ JNI_METHOD(void, setIsServo)
   crow::BrowserWorld::Instance().SetIsServo(aIsServo);
 }
 
-
+JNI_METHOD(void, setPointerModeNative)
+(JNIEnv*, jobject, jint nativePointerMode) {
+    crow::DeviceDelegate::PointerMode pointerMode;
+    switch (nativePointerMode) {
+        case 0:
+            pointerMode = crow::DeviceDelegate::PointerMode::TRACKED_POINTER;
+            break;
+        case 1:
+            pointerMode = crow::DeviceDelegate::PointerMode::TRACKED_EYE;
+            break;
+        default:
+            ASSERT(false);
+            break;
+    }
+    crow::BrowserWorld::Instance().SetPointerMode(pointerMode);
+}
 
 } // extern "C"

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -77,6 +77,7 @@ public:
   void SetWebXRInterstitalState(const WebXRInterstialState aState);
   void SetIsServo(const bool aIsServo);
   void SetCPULevel(const device::CPULevel aLevel);
+  void SetPointerMode(crow::DeviceDelegate::PointerMode);
   JNIEnv* GetJNIEnv() const;
   void OnReorient() override;
 #if HVR

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -448,6 +448,15 @@ ControllerContainer::SetTransform(const int32_t aControllerIndex, const vrb::Mat
 }
 
 void
+ControllerContainer::TranslateTransform(const int32_t aControllerIndex, const vrb::Vector &aTranslation) {
+    if (!m.Contains(aControllerIndex)) {
+        return;
+    }
+    Controller& controller = m.list[aControllerIndex];
+    SetTransform(aControllerIndex, controller.transformMatrix.Translate(aTranslation));
+}
+
+void
 ControllerContainer::SetButtonCount(const int32_t aControllerIndex, const uint32_t aNumButtons) {
   if (!m.Contains(aControllerIndex)) {
     return;

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -47,6 +47,7 @@ public:
   void SetControllerType(const int32_t aControllerIndex, device::DeviceType aType) override;
   void SetTargetRayMode(const int32_t aControllerIndex, device::TargetRayMode aMode) override;
   void SetTransform(const int32_t aControllerIndex, const vrb::Matrix& aTransform) override;
+  void TranslateTransform(const int32_t aControllerIndex, const vrb::Vector &aTranslation) override;
   void SetButtonCount(const int32_t aControllerIndex, const uint32_t aNumButtons) override;
   void SetButtonState(const int32_t aControllerIndex, const Button aWhichButton, const int32_t aImmersiveIndex, const bool aPressed, const bool aTouched, const float aImmersiveTrigger = -1.0f) override;
   void SetAxes(const int32_t aControllerIndex, const float* aData, const uint32_t aLength) override;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -61,6 +61,7 @@ public:
   virtual void SetControllerType(const int32_t aControllerIndex, device::DeviceType aType) = 0;
   virtual void SetTargetRayMode(const int32_t aControllerIndex, device::TargetRayMode aMode) = 0;
   virtual void SetTransform(const int32_t aControllerIndex, const vrb::Matrix& aTransform) = 0;
+  virtual void TranslateTransform(const int32_t aControllerIndex, const vrb::Vector& aTranslation) = 0;
   virtual void SetButtonCount(const int32_t aControllerIndex, const uint32_t aNumButtons) = 0;
   virtual void SetButtonState(const int32_t aControllerIndex, const Button aWhichButton, const int32_t aImmersiveIndex, const bool aPressed, const bool aTouched, const float aImmersiveTrigger = -1.0f) = 0;
   virtual void SetAxes(const int32_t aControllerIndex, const float* aData, const uint32_t aLength) = 0;

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -118,6 +118,11 @@ public:
                               const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) {};
   virtual void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) {};
   virtual void SetHitDistance(const float) {};
+  enum class PointerMode {
+    TRACKED_POINTER,
+    TRACKED_EYE
+  };
+  virtual void SetPointerMode(const PointerMode) {};
 
 protected:
   DeviceDelegate() {}

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -72,6 +72,8 @@ const char* const kUpdateControllerBatteryLevelsName = "updateControllerBatteryL
 const char* const kUpdateControllerBatteryLevelsSignature = "(II)V";
 const char* const kOnAppFocusChangedName = "onAppFocusChanged";
 const char* const kOnAppFocusChangedSignature = "(Z)V";
+const char* const kSetEyeTrackingSupported = "setEyeTrackingSupported";
+const char* const kSetEyeTrackingSupportedSignature = "(Z)V";
 
 JNIEnv* sEnv = nullptr;
 jclass sBrowserClass = nullptr;
@@ -107,7 +109,9 @@ jmethodID sDisableLayers = nullptr;
 jmethodID sAppendAppNotesToCrashReport = nullptr;
 jmethodID sUpdateControllerBatteryLevels = nullptr;
 jmethodID sOnAppFocusChanged = nullptr;
-}
+jmethodID sSetEyeTrackingSupported = nullptr;
+
+} // namespace
 
 namespace crow {
 
@@ -157,6 +161,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sAppendAppNotesToCrashReport = FindJNIMethodID(sEnv, sBrowserClass, kAppendAppNotesToCrashReport, kAppendAppNotesToCrashReportSignature);
   sUpdateControllerBatteryLevels = FindJNIMethodID(sEnv, sBrowserClass, kUpdateControllerBatteryLevelsName, kUpdateControllerBatteryLevelsSignature);
   sOnAppFocusChanged = FindJNIMethodID(sEnv, sBrowserClass, kOnAppFocusChangedName, kOnAppFocusChangedSignature);
+  sSetEyeTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetEyeTrackingSupported, kSetEyeTrackingSupportedSignature);
 }
 
 JNIEnv * VRBrowser::Env()
@@ -467,6 +472,14 @@ VRBrowser::OnAppFocusChanged(const bool aIsFocused) {
   if (!ValidateMethodID(sEnv, sActivity, sOnAppFocusChanged, __FUNCTION__)) { return; }
   sEnv->CallVoidMethod(sActivity, sOnAppFocusChanged, (jboolean) aIsFocused);
   CheckJNIException(sEnv, __FUNCTION__);
+}
+
+// implement the SetEyeTrackingSupported method
+void
+VRBrowser::SetEyeTrackingSupported(bool aIsSupported) {
+    if (!ValidateMethodID(sEnv, sActivity, sSetEyeTrackingSupported, __FUNCTION__)) { return; }
+    sEnv->CallVoidMethod(sActivity, sSetEyeTrackingSupported, (jboolean) aIsSupported);
+    CheckJNIException(sEnv, __FUNCTION__);
 }
 
 } // namespace crow

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -50,6 +50,7 @@ void DisableLayers();
 void AppendAppNotesToCrashLog(const std::string& aNotes);
 void UpdateControllerBatteryLevels(const jint aLeftBatteryLevel, const jint aRightBatteryLevel);
 void OnAppFocusChanged(const bool aIsFocused);
+void SetEyeTrackingSupported(bool aIsSupported);
 } // namespace VRBrowser;
 
 } // namespace crow

--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -40,6 +40,14 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
+                <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
+                    android:id="@+id/pointer_mode_radio"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/controller_options_pointer_mode"
+                    app:options="@array/developer_options_pointer_modes"
+                    app:values="@array/developer_options_pointer_modes_values" />
+
                 <com.igalia.wolvic.ui.views.settings.SwitchSetting
                     android:id="@+id/haptic_feedback_switch"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -40,10 +40,12 @@
     <string name="settings_key_haptic_pulse_duration" translatable="false">settings_haptic_pulse_duration</string>
     <string name="settings_key_haptic_pulse_intensity" translatable="false">settings_haptic_pulse_intensity</string>
     <string name="settings_key_haptic_feedback_enabled" translatable="false">settings_haptic_feedback_enabled</string>
+    <string name="settings_key_gaze_mode_enabled" translatable="false">settings_gaze_mode_enabled</string>
     <string name="settings_key_keyboard_locale" translatable="false">settings_key_keyboard_locale</string>
     <string name="settings_key_crash_restart_count" translatable="false">settings_key_crash_restart_count</string>
     <string name="settings_key_crash_restart_count_timestamp" translatable="false">settings_key_crash_restart_count_timestamp</string>
     <string name="settings_key_keyboard_move" translatable="false">settings_key_keyboard_move</string>
+    <string name="settings_key_pointer_mode" translatable="false">settings_key_pointer_mode</string>
     <string name="private_browsing_support_url" translatable="false">https://support.mozilla.org/kb/private-mode-firefox-reality</string>
     <string name="settings_key_browser_world_width" translatable="false">settings_browser_world_width</string>
     <string name="settings_key_browser_world_height" translatable="false">settings_browser_world_height</string>
@@ -80,6 +82,7 @@
     <string name="settings_key_terms_service_accepted" translatable="false">settings_key_terms_service_accepted</string>
     <string name="settings_key_privacy_policy_accepted" translatable="false">settings_key_privacy_policy_accepted</string>
     <string name="settings_key_search_engine_id" translatable="false">settings_key_search_engine_id</string>
+    <string name="settings_key_eye_tracking_supported" translatable="false">settings_key_eye_tracking_supported</string>
     <string name="environment_override_help_url" translatable="false">https://github.com/igalia/wolvic/wiki/Environments</string>
     <string name="private_policy_url" translatable="false">https://wolvic.com/legal/privacy/</string>
     <string name="private_report_url" translatable="false">https://www.igalia.com/privacy/&amp;url=%1$s</string>

--- a/app/src/main/res/values/options_values.xml
+++ b/app/src/main/res/values/options_values.xml
@@ -40,6 +40,16 @@
         <item>1</item>
     </integer-array>
 
+    <integer-array name="developer_options_pointer_modes" translatable="false">
+        <item>@string/developer_options_pointer_mode_tracked_pointer</item>
+        <item>@string/developer_options_pointer_mode_tracked_eye</item>
+    </integer-array>
+
+    <integer-array name="developer_options_pointer_modes_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+
     <!-- Environments Options -->
     <string-array name="developer_options_ua_modes" translatable="false">
         <item>@string/developer_options_ua_mobile</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2562,5 +2562,7 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="controller_options_pointer_mode">Gaze Mode</string>
     <string name="developer_options_pointer_mode_tracked_pointer">Pointer</string>
     <string name="developer_options_pointer_mode_tracked_eye">Eye Tracking</string>
+    <string name="eye_tracking_permission_title">Eye Tracking Permissions</string>
+    <string name="eye_tracking_permission_message">Enabling eye tracking for browsing the web poses significant privacy risks. This technology captures where and how long a user looks at specific parts of a webpage, revealing intimate details about their interests and emotional reactions. Advertisers and third parties can exploit this data for intrusive marketing and profiling. Moreover, eye movement patterns could infer sensitive information such as medical conditions, cognitive states, or personal habits. Therefore, it is crucial to consider the privacy implications before granting access to eye tracking information to webpages.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2559,5 +2559,8 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="vision_glass_error_message">An error happened.\nPlease try again.</string>
     <!-- Vision Glass: instruct the user to point the phone straight ahead to re-align the controller. -->
     <string name="vision_glass_realign_dialog_explanation">To set up the controller, please point your phone straight ahead and tap the button.</string>
+    <string name="controller_options_pointer_mode">Gaze Mode</string>
+    <string name="developer_options_pointer_mode_tracked_pointer">Pointer</string>
+    <string name="developer_options_pointer_mode_tracked_eye">Eye Tracking</string>
 
 </resources>

--- a/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
@@ -51,6 +51,8 @@ public class PlatformActivity extends ComponentActivity {
         return null;
     }
 
+    protected String getEyeTrackingPermissionString() { return null; }
+
     private GLSurfaceView mView;
     private TextView mFrameRate;
     private final ArrayList<Runnable> mPendingEvents = new ArrayList<>();

--- a/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -51,6 +51,8 @@ public class PlatformActivity extends NativeActivity {
         return intent;
     }
 
+    protected String getEyeTrackingPermissionString() { return null; }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         Log.e(LOGTAG,"in onCreate");

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -66,6 +66,7 @@ public:
                       const vrb::GroupPtr& aRoot, const bool aEnabled, const bool leftHanded) override;
   void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) override;
   void SetHitDistance(const float) override;
+  void SetPointerMode(const PointerMode mode) override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);
@@ -81,6 +82,7 @@ protected:
 private:
   State& m;
   VRB_NO_DEFAULTS(DeviceDelegateOpenXR)
+  void updateEyeGaze();
 };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -751,7 +751,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     delegate.SetCapabilityFlags(mIndex, flags);
 }
 
-void OpenXRInputSource::Update(const XrFrameState &frameState, XrSpace localSpace, const vrb::Matrix &head, const vrb::Vector &offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate)
+void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix &head, const vrb::Vector& offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate)
 {
     if (mActiveMapping &&
         ((mHandeness == OpenXRHandFlags::Left && !mActiveMapping->leftControllerModel) ||

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -744,7 +744,8 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
         delegate.SetBeamTransform(mIndex, vrb::Matrix::Identity());
 #endif
         delegate.SetImmersiveBeamTransform(mIndex, pointerTransform);
-    } else if (pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE) {
+    } else {
+        assert(pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE);
         HandleEyeTrackingScroll(predictedDisplayTime, triggerButtonPressed, pointerTransform, delegate);
     }
 

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -4,6 +4,7 @@
 #include <unordered_set>
 #include "DeviceUtils.h"
 #include "SystemUtils.h"
+#include "DeviceDelegate.h"
 
 #define HAND_JOINT_FOR_AIM XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT
 
@@ -13,6 +14,10 @@ namespace crow {
 // Used when devices don't map the click value for triggers;
 const float kClickThreshold = 0.91f;
 const float kClickLowFiThreshold = 0.8f;
+
+// When doing scrolling with eye tracking we wait until this threshold is reached to start scrolling.
+// Otherwise single (slow) clicks would easily trigger scrolling.
+const XrDuration kEyeTrackingScrollThreshold = 250000000;
 
 OpenXRInputSourcePtr OpenXRInputSource::Create(XrInstance instance, XrSession session, OpenXRActionSet& actionSet, const XrSystemProperties& properties, OpenXRHandFlags handeness, int index)
 {
@@ -641,7 +646,7 @@ OpenXRInputSource::PopulateHandJointLocations(device::RenderMode renderMode, std
 #endif
 }
 
-void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, ControllerDelegate& delegate)
+void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate)
 {
     assert(mHasHandJoints);
 
@@ -654,9 +659,14 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     bool hasAim = mGestureManager->hasAim();
     bool systemGestureDetected = mGestureManager->systemGestureDetected(handJointForAim, head);
 
+    if (!hasAim && !systemGestureDetected && !usingEyeTracking) {
+        delegate.SetEnabled(mIndex, false);
+        return;
+    }
+
     // We should handle the gesture whenever the system does not handle it.
     bool isHandActionEnabled = systemGestureDetected && (!systemTakesOverWhenHandsFacingHead || mHandeness == Left);
-    delegate.SetAimEnabled(mIndex, hasAim);
+    delegate.SetAimEnabled(mIndex, hasAim && pointerMode == DeviceDelegate::PointerMode::TRACKED_POINTER);
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
     delegate.SetMode(mIndex, ControllerMode::Hand);
     delegate.SetEnabled(mIndex, true);
@@ -713,28 +723,35 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     }
 #endif
 
-    if (renderMode == device::RenderMode::StandAlone)
-        pointerTransform.TranslateInPlace(kAverageHeight);
+    device::CapabilityFlags flags = device::Orientation | device::Position;
+    if (pointerMode == DeviceDelegate::PointerMode::TRACKED_POINTER) {
+        if (renderMode == device::RenderMode::StandAlone)
+            pointerTransform.TranslateInPlace(kAverageHeight);
 
+        // TODO: removing this flag will allow us to remove the ifdef. Keeping it just to limit
+        // the scope of the changes.
+        flags = device::GripSpacePosition;
 #if CHROMIUM
-    // Blink WebXR uses the grip space instead of the local space to position the
-    // controller. Since controller's position is the same as the origin of the
-    // grip space, we just set the transform matrix to the identity.
-    // Then we need to correct the beam transform matrix to maintain origin and
-    // direction when we are not in immersive mode.
-    delegate.SetTransform(mIndex, vrb::Matrix::Identity());
-    delegate.SetBeamTransform(mIndex, pointerTransform);
+        // Blink WebXR uses the grip space instead of the local space to position the
+        // controller. Since controller's position is the same as the origin of the
+        // grip space, we just set the transform matrix to the identity.
+        // Then we need to correct the beam transform matrix to maintain origin and
+        // direction when we are not in immersive mode.
+        delegate.SetTransform(mIndex, vrb::Matrix::Identity());
+        delegate.SetBeamTransform(mIndex, pointerTransform);
 #else
-    delegate.SetTransform(mIndex, pointerTransform);
-    delegate.SetBeamTransform(mIndex, vrb::Matrix::Identity());
+        delegate.SetTransform(mIndex, pointerTransform);
+        delegate.SetBeamTransform(mIndex, vrb::Matrix::Identity());
 #endif
-    delegate.SetImmersiveBeamTransform(mIndex, pointerTransform);
+        delegate.SetImmersiveBeamTransform(mIndex, pointerTransform);
+    } else if (pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE) {
+        HandleEyeTrackingScroll(predictedDisplayTime, triggerButtonPressed, pointerTransform, delegate);
+    }
 
-    device::CapabilityFlags flags = device::Orientation | device::Position | device::GripSpacePosition;
     delegate.SetCapabilityFlags(mIndex, flags);
 }
 
-void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, ControllerDelegate& delegate)
+void OpenXRInputSource::Update(const XrFrameState &frameState, XrSpace localSpace, const vrb::Matrix &head, const vrb::Vector &offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate)
 {
     if (mActiveMapping &&
         ((mHandeness == OpenXRHandFlags::Left && !mActiveMapping->leftControllerModel) ||
@@ -794,7 +811,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
             std::vector<float> jointRadii;
             PopulateHandJointLocations(renderMode, jointTransforms, jointRadii);
             if (!mIsHandInteractionEXTSupported) {
-                EmulateControllerFromHand(renderMode, frameState.predictedDisplayTime, head, jointTransforms[HAND_JOINT_FOR_AIM], delegate);
+                EmulateControllerFromHand(renderMode, frameState.predictedDisplayTime, head, jointTransforms[HAND_JOINT_FOR_AIM], pointerMode, usingEyeTracking, delegate);
                 delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
                 return;
             }
@@ -808,10 +825,18 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
         return;
     }
 
+    bool usingTrackedPointer = pointerMode == DeviceDelegate::PointerMode::TRACKED_POINTER;
     bool hasAim = isPoseActive && (poseLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT);
-    delegate.SetAimEnabled(mIndex, hasAim);
 
-    if (!hasAim && !(mUsingHandInteractionProfile && gotHandTrackingInfo && handFacesHead)) {
+    // Don't enable aim for eye tracking as we don't want to paint the beam. Note that we'd still
+    // have an aim, meaning that we can point, focus, click... UI elements.
+    delegate.SetAimEnabled(mIndex, hasAim && usingTrackedPointer);
+
+    // Disable the controller if there is no aim unless:
+    // a) we're using hand interaction profile and we have hand tracking info. In that case the user
+    // is facing their palm to do a hand gesture (that's why there is no aim)
+    // b) we're using eye tracking. In that case the eye gaze will be the aim, not the contorller's
+    if (!hasAim && !(mUsingHandInteractionProfile && gotHandTrackingInfo && handFacesHead) && !usingEyeTracking) {
       delegate.SetEnabled(mIndex, false);
       return;
     }
@@ -834,46 +859,47 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
 
     device::CapabilityFlags flags = device::Orientation;
-    vrb::Matrix pointerTransform = XrPoseToMatrix(poseLocation.pose);
-
     const bool positionTracked = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
+    flags |= positionTracked ? device::Position : device::PositionEmulated;
+
+    vrb::Matrix pointerTransform = XrPoseToMatrix(poseLocation.pose);
     if (positionTracked) {
-      if (renderMode == device::RenderMode::StandAlone) {
-        pointerTransform.TranslateInPlace(kAverageHeight);
-      }
-      flags |= device::Position;
-    } else {
-      auto hand = mHandeness == OpenXRHandFlags::Left ? ElbowModel::HandEnum::Left : ElbowModel::HandEnum::Right;
-      pointerTransform = elbow->GetTransform(hand, head, pointerTransform);
-      flags |= device::PositionEmulated;
-    }
-
-    delegate.SetTransform(mIndex, pointerTransform);
-
-    isPoseActive = false;
-    poseLocation = { XR_TYPE_SPACE_LOCATION };
-    CHECK_XRCMD(GetPoseState(mGripAction, mGripSpace, localSpace, frameState,  isPoseActive, poseLocation));
-    if (isPoseActive) {
-        adjustPoseLocation(offsets);
-        auto gripTransform = XrPoseToMatrix(poseLocation.pose);
-        bool hasPosition = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
-        delegate.SetImmersiveBeamTransform(mIndex, hasPosition ? gripTransform : pointerTransform);
-        flags |= device::GripSpacePosition;
-        delegate.SetBeamTransform(mIndex, vrb::Matrix::Identity());
-#if defined(CHROMIUM) && defined(HVR)
-        // HVR runtime incorrectly return the same values for grip and aim poses. We circumvent that
-        // by inventing a grip pose. The values are chosen to match the controller dimensions. This
-        // is only needed for Chromium because it requires the grip to be based on the aim. As the
-        // runtime returns invalid values for that case, we need to emulate the aim based on grip.
-        if (renderMode == device::RenderMode::Immersive) {
-            static const auto emulatedGripTransform = vrb::Matrix::Translation({0.0, 0.30, 0.0}).Rotation(vrb::Vector(1.0, 0.0, 0.0), -M_PI / 5);
-            delegate.SetTransform(mIndex, emulatedGripTransform);
+        if (renderMode == device::RenderMode::StandAlone) {
+            pointerTransform.TranslateInPlace(kAverageHeight);
         }
-#endif
     } else {
-        delegate.SetImmersiveBeamTransform(mIndex, vrb::Matrix::Identity());
+        auto hand = mHandeness == OpenXRHandFlags::Left ? ElbowModel::HandEnum::Left : ElbowModel::HandEnum::Right;
+        pointerTransform = elbow->GetTransform(hand, head, pointerTransform);
     }
 
+    if (pointerMode == DeviceDelegate::PointerMode::TRACKED_POINTER) {
+        delegate.SetTransform(mIndex, pointerTransform);
+
+        isPoseActive = false;
+        poseLocation = {XR_TYPE_SPACE_LOCATION};
+        CHECK_XRCMD(GetPoseState(mGripAction, mGripSpace, localSpace, frameState, isPoseActive,
+                                 poseLocation));
+        if (isPoseActive) {
+            adjustPoseLocation(offsets);
+            auto gripTransform = XrPoseToMatrix(poseLocation.pose);
+            delegate.SetImmersiveBeamTransform(mIndex,
+                                               positionTracked ? gripTransform : pointerTransform);
+            flags |= device::GripSpacePosition;
+            delegate.SetBeamTransform(mIndex, vrb::Matrix::Identity());
+#if defined(CHROMIUM) && defined(HVR)
+            // HVR runtime incorrectly return the same values for grip and aim poses. We circumvent that
+            // by inventing a grip pose. The values are chosen to match the controller dimensions. This
+            // is only needed for Chromium because it requires the grip to be based on the aim. As the
+            // runtime returns invalid values for that case, we need to emulate the aim based on grip.
+            if (renderMode == device::RenderMode::Immersive) {
+                static const auto emulatedGripTransform = vrb::Matrix::Translation({0.0, 0.30, 0.0}).Rotation(vrb::Vector(1.0, 0.0, 0.0), -M_PI / 5);
+                delegate.SetTransform(mIndex, emulatedGripTransform);
+            }
+#endif
+        } else {
+            delegate.SetImmersiveBeamTransform(mIndex, vrb::Matrix::Identity());
+        }
+    }
     delegate.SetCapabilityFlags(mIndex, flags);
 
     // Buttons.
@@ -916,6 +942,8 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
 
         if (button.type == OpenXRButtonType::Trigger) {
             delegate.SetSelectFactor(mIndex, state->value);
+            if (pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE)
+                HandleEyeTrackingScroll(frameState.predictedDisplayTime, state->clicked, pointerTransform, delegate);
         }
 
         // Select action
@@ -1046,6 +1074,21 @@ HandMeshBufferPtr
 OpenXRInputSource::GetNextHandMeshBuffer() {
     ReleaseHandMeshBuffer();
     return mHandMeshMSFT.buffer;
+}
+
+void OpenXRInputSource::HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix &pointerTransform, ControllerDelegate &controllerDelegate) {
+    if (!mTriggerWasClicked && triggerClicked) {
+        mControllerPositionOnGestureStart =  pointerTransform.GetTranslation();
+        mEyeTrackingPinchStartTime = predictedDisplayTime;
+    } else if (mTriggerWasClicked && triggerClicked) {
+        // Throttle the start of the scroll gesture to avoid scrolling on pinch.
+        if (predictedDisplayTime - mEyeTrackingPinchStartTime > kEyeTrackingScrollThreshold) {
+            vrb::Vector currentControllerPosition = pointerTransform.GetTranslation();
+            auto delta = currentControllerPosition - mControllerPositionOnGestureStart;
+            controllerDelegate.TranslateTransform(mIndex, delta * 10);
+        }
+    }
+    mTriggerWasClicked = triggerClicked;
 }
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -7,6 +7,7 @@
 #include "ElbowModel.h"
 #include "HandMeshRenderer.h"
 #include "OpenXRGestureManager.h"
+#include "DeviceDelegate.h"
 #include <optional>
 #include <unordered_map>
 
@@ -46,7 +47,7 @@ private:
     void UpdateHaptics(ControllerDelegate&);
     bool GetHandTrackingInfo(XrTime predictedDisplayTime, XrSpace, const vrb::Matrix& head);
     float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
-    void EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, ControllerDelegate& delegate);
+    void EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate);
     void PopulateHandJointLocations(device::RenderMode, std::vector<vrb::Matrix>& jointTransforms, std::vector<float>& jointRadii);
 
     XrInstance mInstance { XR_NULL_HANDLE };
@@ -83,6 +84,9 @@ private:
     bool mSupportsHandJointsMotionRangeInfo { false };
     bool mUsingHandInteractionProfile { false };
     device::DeviceType mDeviceType { device::UnknownType };
+    bool mTriggerWasClicked { false };
+    vrb::Vector mControllerPositionOnGestureStart;
+    XrTime mEyeTrackingPinchStartTime { 0 };
 
     struct HandMeshMSFT {
         XrSpace space = XR_NULL_HANDLE;
@@ -103,12 +107,13 @@ private:
 
     bool mIsHandInteractionEXTSupported { false };
 
+    void HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix& pointerTransform, ControllerDelegate &controllerDelegate);
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);
     ~OpenXRInputSource();
 
     XrResult SuggestBindings(SuggestedBindings&) const;
-    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, ControllerDelegate& delegate);
+    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate);
     XrResult UpdateInteractionProfile(ControllerDelegate&);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }

--- a/app/src/picoxr/AndroidManifest.xml
+++ b/app/src/picoxr/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" />
     <!-- Required in Pico platform to avoid a crash during app resuming -->
     <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="replace"/>
+    <uses-permission android:name="com.picovr.permission.EYE_TRACKING"/>
 
     <application android:requestLegacyExternalStorage="true">
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
@@ -16,5 +17,6 @@
         </activity>
         <meta-data android:name="pvr.app.type" android:value="vr" />
         <meta-data android:name="handtracking" android:value="1" />
+        <meta-data android:name="picovr.software.eye_tracking" android:value="true" />
     </application>
 </manifest>

--- a/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
@@ -35,6 +35,8 @@ public class PlatformActivity extends NativeActivity {
         return null;
     }
 
+    protected String getEyeTrackingPermissionString() { return "com.picovr.permission.EYE_TRACKING"; }
+
     @Override
     public void onBackPressed() {
         queueRunnable(new Runnable() {

--- a/app/src/spaces/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/spaces/java/com/igalia/wolvic/PlatformActivity.java
@@ -36,6 +36,8 @@ public class PlatformActivity extends NativeActivity {
         return null;
     }
 
+    protected String getEyeTrackingPermissionString() { return null; }
+
     public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) { return null; }
 
     @Override

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -100,6 +100,8 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
         return null;
     }
 
+    protected String getEyeTrackingPermissionString() { return null; }
+
     private final ArrayList<Runnable> mPendingEvents = new ArrayList<>();
     private SensorManager mSensorManager;
 

--- a/app/src/wavevr/java/org/mozilla/vrbrowser/PlatformActivity.java
+++ b/app/src/wavevr/java/org/mozilla/vrbrowser/PlatformActivity.java
@@ -40,6 +40,8 @@ public class PlatformActivity extends VRActivity {
         return null;
     }
 
+    protected String getEyeTrackingPermissionString() { return null; }
+
     public PlatformActivity() {}
 
     @Override


### PR DESCRIPTION
This PR provides an implementation for eye tracking based navigation àla Apple VisionPro (not as good yet but quite usable).

It's implemented using OpenXR's XR_EXT_eye_gaze_interaction extension. This extension provides a path to retrieve gaze input from the runtime. Wolvic uses that data as the aim. All the other input interactions remain the same, meaning that users can use hand tracking or the physical controllers to perform actions like clicks or scrolling.

Speaking about scrolling, some extra code had to be added to properly handle scrolling. This is the rationale, when not using eye tracking scrolling happens when the aim is moved (up/down) while pressing the trigger button (or a pinch with hand tracking). However when eye tracking is enabled we cannot do that, because we don't want to scroll by moving our eyes but by moving either the hand or the controller we are using for clicking/pinching. That's why some code to detect scrolling (based on heuristics) was added for the eye tracking case.

Eye tracking is a very sensitive technology from the privacy POV as it can be used for fingerprinting for example. That's why Wolvic asks for permissions before using it. In case users reject the request the usual hand tracking or controllers input will be used instead. For devices supporting eye tracking, a new radio button group is now visible in the controller options in settings.

The eye tracking implementation supports devices using both hand interaction profiles (like the MagicLeap2) or controller emulation via hand tracking (like the Pico4E). This implementation was tested on both devices, but it might work well in others supporting the eye gaze extension.