### PR TITLE
Specify the controller Id when triggering haptic feedback

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -268,7 +268,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         @Override
         public void onGlobalFocusChanged(View oldFocus, View newFocus) {
             Log.d(LOGTAG, "======> OnGlobalFocusChangeListener: old(" + oldFocus + ") new(" + newFocus + ")");
-            triggerHapticFeedback();
+            // TODO: Which controller should we send the haptic feedback to ?
+            triggerHapticFeedback(0);
             for (FocusChangeListener listener: mFocusChangeListeners) {
                 listener.onGlobalFocusChanged(oldFocus, newFocus);
             }
@@ -1933,10 +1934,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
-    public void triggerHapticFeedback() {
+    public void triggerHapticFeedback(int controllerId) {
         SettingsStore settings = SettingsStore.getInstance(this);
         if (settings.isHapticFeedbackEnabled()) {
-            queueRunnable(() -> triggerHapticFeedbackNative(settings.getHapticPulseDuration(), settings.getHapticPulseIntensity()));
+            queueRunnable(() -> triggerHapticFeedbackNative(settings.getHapticPulseDuration(), settings.getHapticPulseIntensity(), controllerId));
         }
     }
 
@@ -2210,7 +2211,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void startWidgetMoveNative(int aHandle, int aMoveBehaviour);
     private native void finishWidgetMoveNative();
     private native void setWorldBrightnessNative(float aBrightness);
-    private native void triggerHapticFeedbackNative(float aPulseDuration, float aPulseIntensity);
+    private native void triggerHapticFeedbackNative(float aPulseDuration, float aPulseIntensity, int aControllerId);
     private native void setTemporaryFilePath(String aPath);
     private native void exitImmersiveNative();
     private native void workaroundGeckoSigAction();

--- a/app/src/common/shared/com/igalia/wolvic/input/MotionEventGenerator.java
+++ b/app/src/common/shared/com/igalia/wolvic/input/MotionEventGenerator.java
@@ -120,7 +120,7 @@ public class MotionEventGenerator {
         }
         if (aWidget != device.mPreviousWidget && !aPressed) {
             generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_ENTER, true);
-            widgetManager.triggerHapticFeedback();
+            widgetManager.triggerHapticFeedback(aDevice);
             device.mHoverStartWidget = aWidget;
         }
         if (aPressed && !device.mWasPressed) {
@@ -142,7 +142,7 @@ public class MotionEventGenerator {
             if (!isOtherDeviceDown(device.mDevice)) {
                 generateEvent(device.mTouchStartWidget, device, aFocused, MotionEvent.ACTION_UP, false);
                 generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_ENTER, true);
-                widgetManager.triggerHapticFeedback();
+                widgetManager.triggerHapticFeedback(aDevice);
                 device.mHoverStartWidget = aWidget;
             }
             device.mTouchStartWidget = null;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -566,7 +566,6 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     @Override
     public void onPress(int primaryCode) {
         Log.d(LOGTAG, "Keyboard onPress " + primaryCode);
-        mWidgetManager.triggerHapticFeedback();
     }
 
     @Override
@@ -615,7 +614,6 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             handleDomainLongPress();
             mIsLongPress = true;
         }
-        mWidgetManager.triggerHapticFeedback();
     }
 
     public void onMultiTap(Keyboard.Key key) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -91,7 +91,7 @@ public interface WidgetManagerDelegate {
     void pushWorldBrightness(Object aKey, float aBrightness);
     void setWorldBrightness(Object aKey, float aBrightness);
     void popWorldBrightness(Object aKey);
-    void triggerHapticFeedback();
+    void triggerHapticFeedback(int deviceID);
     void setControllersVisible(boolean visible);
     void keyboardDismissed();
     void updateEnvironment();

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1202,13 +1202,13 @@ BrowserWorld::EndFrame() {
 }
 
 void
-BrowserWorld::TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity) {
+BrowserWorld::TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity, const int aControllerId) {
   if (!m.controllers) {
     return;
   }
 
   for (Controller& controller: m.controllers->GetControllers()) {
-    if (!controller.focused || !m.controllers->GetHapticCount(controller.index)) {
+    if (controller.index != aControllerId || !m.controllers->GetHapticCount(controller.index)) {
       continue;
     }
     m.controllers->SetHapticFeedback(controller.index, controller.inputFrameID + 1, aPulseDuration, aPulseIntensity);
@@ -2082,8 +2082,8 @@ JNI_METHOD(void, setWorldBrightnessNative)
 }
 
 JNI_METHOD(void, triggerHapticFeedbackNative)
-(JNIEnv*, jobject, jfloat aPulseDuration, jfloat aPulseIntensity) {
-  crow::BrowserWorld::Instance().TriggerHapticFeedback(aPulseDuration, aPulseIntensity);
+(JNIEnv*, jobject, jfloat aPulseDuration, jfloat aPulseIntensity, jint aControllerId) {
+  crow::BrowserWorld::Instance().TriggerHapticFeedback(aPulseDuration, aPulseIntensity, aControllerId);
 }
 
 JNI_METHOD(void, setTemporaryFilePath)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -47,7 +47,7 @@ public:
   void StartFrame();
   void Draw(device::Eye aEye);
   void EndFrame();
-  void TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity);
+  void TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity, const int aControllerId);
   void TogglePassthrough();
   void SetHeadLockEnabled(const bool isEnabled);
   void SetTemporaryFilePath(const std::string& aPath);


### PR DESCRIPTION
We are sending the haptic feedback to the controller that got the focus due to the last click event. This causes that hovering events generated by the other controller still send the haptic feedback to the inactive controller.

This change defines a new argument in the triggerHapticFeedback function to pass the Id associated to the controller that generated the hovering event.

Fixes #1488