### PR TITLE
[OpenXR] Add basic support for WebXR AR module

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -599,6 +599,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 }
             }
         }
+
+        // Chromium does fullscreen windows when entering immersive-ar sessions. We have to restore
+        // the fullscreen window when exiting.
+        if (mFullscreenWindow != null)
+            mFullscreenWindow.getSession().exitFullScreen();
     }
 
     private void closeLibraryPanelInFocusedWindowIfNeeded() {

--- a/app/src/main/cpp/Assertions.h
+++ b/app/src/main/cpp/Assertions.h
@@ -1,9 +1,42 @@
 #pragma once
 
+#include <string>
+
 // MACROS to define to-string and logging function utils
 #define STRINGIFY(x) #x
 #define FILE_AND_LINE_INTERNAL(LINE) __FILE__ ":" STRINGIFY(LINE)
 #define FILE_AND_LINE FILE_AND_LINE_INTERNAL(__LINE__)
+
+inline std::string Fmt(const char* fmt, ...) {
+    va_list vl;
+    va_start(vl, fmt);
+    int size = vsnprintf(nullptr, 0, fmt, vl);
+    va_end(vl);
+
+    if (size != -1) {
+        std::unique_ptr<char[]> buffer(new char[size + 1]);
+
+        va_start(vl, fmt);
+        size = vsnprintf(buffer.get(), size + 1, fmt, vl);
+        va_end(vl);
+        if (size != -1) {
+            return std::string(buffer.get(), size);
+        }
+    }
+
+    throw std::runtime_error("Unexpected vsnprintf failure");
+}
+
+[[noreturn]] inline void Throw(std::string failureMessage, const char* originator = nullptr, const char* sourceLocation = nullptr) {
+    if (originator != nullptr) {
+        failureMessage += Fmt("\n    Origin: %s", originator);
+    }
+    if (sourceLocation != nullptr) {
+        failureMessage += Fmt("\n    Source: %s", sourceLocation);
+    }
+
+    throw std::logic_error(failureMessage);
+}
 
 #define THROW(msg) Throw(msg, nullptr, FILE_AND_LINE);
 

--- a/app/src/main/cpp/Device.h
+++ b/app/src/main/cpp/Device.h
@@ -28,6 +28,7 @@ const CapabilityFlags GripSpacePosition = 1u << 13u;
 enum class Eye { Left, Right };
 enum class RenderMode { StandAlone, Immersive };
 enum class CPULevel { Normal = 0, High };
+enum class BlendMode { Opaque, AlphaBlend, Additive };
 const int32_t EyeCount = 2;
 inline int32_t EyeIndex(const Eye aEye) { return aEye == Eye::Left ? 0 : 1; }
 // The type values need to match those defined in DeviceType.java

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -45,6 +45,7 @@ public:
   virtual void SetStageSize(const float aWidth, const float aDepth) = 0;
   virtual void SetSittingToStandingTransform(const vrb::Matrix& aTransform) = 0;
   virtual void CompleteEnumeration() = 0;
+  virtual void SetBlendModes(std::vector<device::BlendMode> aBlendModes) = 0;
 };
 
 class DeviceDelegate {
@@ -57,9 +58,14 @@ public:
       APPLY,
       DISCARD
   };
+  enum class ImmersiveXRSessionType {
+      VR,
+      AR
+  };
   virtual device::DeviceType GetDeviceType() { return device::UnknownType; }
   virtual void SetRenderMode(const device::RenderMode aMode) = 0;
   virtual device::RenderMode GetRenderMode() = 0;
+  virtual void SetImmersiveXRSessionType(const ImmersiveXRSessionType aSessionType) { mImmersiveXrSessionType = aSessionType; }
   virtual void RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) = 0;
   virtual void SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) {};
   virtual GestureDelegateConstPtr GetGestureDelegate() = 0;
@@ -110,7 +116,7 @@ public:
     virtual ~ReorientClient() {};
   };
   void SetReorientClient(ReorientClient* client) { mReorientClient = client; }
-  bool IsPassthroughEnabled() const { return mIsPassthroughEnabled; }
+  virtual bool IsPassthroughEnabled() const { return mIsPassthroughEnabled; }
   void TogglePassthroughEnabled() { mIsPassthroughEnabled = !mIsPassthroughEnabled; }
   virtual bool usesPassthroughCompositorLayer() const { return false; }
   virtual int32_t GetHandTrackingJointIndex(const HandTrackingJoints aJoint) { return -1; };
@@ -123,6 +129,7 @@ public:
     TRACKED_EYE
   };
   virtual void SetPointerMode(const PointerMode) {};
+  virtual void SetImmersiveBlendMode(device::BlendMode) {};
 
 protected:
   DeviceDelegate() {}
@@ -132,6 +139,7 @@ protected:
   bool mShouldRender { false };
   ReorientClient* mReorientClient { nullptr };
   bool mIsPassthroughEnabled { false };
+  ImmersiveXRSessionType mImmersiveXrSessionType { ImmersiveXRSessionType::VR };
 private:
   VRB_NO_DEFAULTS(DeviceDelegate)
 };

--- a/app/src/main/cpp/ExternalVR.h
+++ b/app/src/main/cpp/ExternalVR.h
@@ -50,6 +50,7 @@ public:
   void SetStageSize(const float aWidth, const float aDepth) override;
   void SetSittingToStandingTransform(const vrb::Matrix& aTransform) override;
   void CompleteEnumeration() override;
+  void SetBlendModes(std::vector<device::BlendMode>) override;
   // ExternalVR interface
   void PushSystemState();
   void PullBrowserState();
@@ -69,6 +70,8 @@ public:
   void OnPause();
   void OnResume();
   uint64_t GetFrameId() const;
+  device::BlendMode GetImmersiveBlendMode() const;
+  DeviceDelegate::ImmersiveXRSessionType GetImmersiveXRSessionType() const;
   ExternalVR();
   ~ExternalVR() = default;
 protected:

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -48,7 +48,7 @@ namespace gfx {
 // running at the same time? Or...what if we have multiple
 // release builds running on same machine? (Bug 1563232)
 #define SHMEM_VERSION "0.0.11"
-static const int32_t kVRExternalVersion = 19;
+static const int32_t kVRExternalVersion = 20;
 
 // We assign VR presentations to groups with a bitmask.
 // Currently, we will only display either content or chrome.
@@ -68,6 +68,7 @@ static const int kVRControllerMaxButtons = 64;
 static const int kVRControllerMaxAxis = 16;
 static const int kVRLayerMaxCount = 8;
 static const int kVRHapticsMaxCount = 32;
+static const int kVRBlendModesMaxLen = 3;
 
 #if defined(__ANDROID__)
 typedef uint64_t VRLayerTextureHandle;
@@ -162,7 +163,9 @@ enum class TargetRayMode : uint8_t { Gaze, TrackedPointer, Screen };
 
 enum class GamepadMappingType : uint8_t { _empty, Standard, XRStandard };
 
-enum class VRDisplayBlendMode : uint8_t { Opaque, Additive, AlphaBlend };
+enum class VRDisplayBlendMode : uint8_t { _empty, Opaque, Additive, AlphaBlend };
+
+enum class ImmersiveXRSessionType : uint8_t { VR, AR };
 
 enum class VRDisplayCapabilityFlags : uint16_t {
   Cap_None = 0,
@@ -346,7 +349,7 @@ struct VRDisplayState {
   //                             ('B'<<8) + 'A').
   uint64_t eightCC;
   VRDisplayCapabilityFlags capabilityFlags;
-  VRDisplayBlendMode blendMode;
+  VRDisplayBlendMode blendModes[kVRBlendModesMaxLen];
   VRFieldOfView eyeFOV[VRDisplayState::NumEyes];
   float eyeTransform[VRDisplayState::NumEyes][16];
   IntSize_POD eyeResolution;
@@ -549,6 +552,8 @@ struct VRBrowserState {
 #endif
   VRLayerState layerState[kVRLayerMaxCount];
   VRHapticState hapticState[kVRHapticsMaxCount];
+  VRDisplayBlendMode blendMode;
+  ImmersiveXRSessionType sessionType;
 
 #ifdef MOZILLA_INTERNAL_API
   void Clear() { memset(this, 0, sizeof(VRBrowserState)); }

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -67,6 +67,7 @@ public:
   void DrawHandMesh(const uint32_t aControllerIndex, const vrb::Camera&) override;
   void SetHitDistance(const float) override;
   void SetPointerMode(const PointerMode mode) override;
+  bool IsPassthroughEnabled() const override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);
@@ -75,6 +76,8 @@ public:
   bool IsInVRMode() const;
   bool ExitApp();
   bool ShouldExitRenderLoop() const;
+  void SetImmersiveBlendMode(device::BlendMode) override;
+
 protected:
   struct State;
   DeviceDelegateOpenXR(State& aState);

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -10,6 +10,7 @@
 #include <openxr/openxr_reflection.h>
 #include "SystemUtils.h"
 #include "vrb/Matrix.h"
+#include "Device.h"
 
 namespace crow {
 
@@ -117,6 +118,20 @@ inline bool IsHandJointPositionValid(const enum XrHandJointEXT aJoint, const Han
     return pose.position.x != 0.0 && pose.position.y != 0.0 && pose.position.z != 0.0;
 #endif
     return (handJoints[aJoint].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0;
+}
+
+inline XrEnvironmentBlendMode toOpenXRBlendMode(device::BlendMode blendMode) {
+    switch (blendMode) {
+        case device::BlendMode::Opaque:
+            return XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+        case device::BlendMode::Additive:
+            return XR_ENVIRONMENT_BLEND_MODE_ADDITIVE;
+        case device::BlendMode::AlphaBlend:
+            return XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND;
+        default:
+            THROW(Fmt("Unknown blend mode %d", blendMode));
+            return XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+    }
 }
 
 }  // namespace crow

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -27,26 +27,6 @@ inline bool CompareBuildIdString(const std::string str) {
     return CompareSemanticVersionStrings(GetBuildIdString(buildId), str);
 }
 
-inline std::string Fmt(const char* fmt, ...) {
-    va_list vl;
-    va_start(vl, fmt);
-    int size = std::vsnprintf(nullptr, 0, fmt, vl);
-    va_end(vl);
-
-    if (size != -1) {
-        std::unique_ptr<char[]> buffer(new char[size + 1]);
-
-        va_start(vl, fmt);
-        size = std::vsnprintf(buffer.get(), size + 1, fmt, vl);
-        va_end(vl);
-        if (size != -1) {
-            return std::string(buffer.get(), size);
-        }
-    }
-
-    throw std::runtime_error("Unexpected vsnprintf failure");
-}
-
 inline std::string GetXrVersionString(XrVersion ver) {
     return Fmt("%d.%d.%d", XR_VERSION_MAJOR(ver), XR_VERSION_MINOR(ver), XR_VERSION_PATCH(ver));
 }
@@ -69,17 +49,6 @@ MAKE_TO_STRING_FUNC(XrEnvironmentBlendMode);
 MAKE_TO_STRING_FUNC(XrSessionState);
 MAKE_TO_STRING_FUNC(XrResult);
 MAKE_TO_STRING_FUNC(XrFormFactor);
-
-[[noreturn]] inline void Throw(std::string failureMessage, const char* originator = nullptr, const char* sourceLocation = nullptr) {
-    if (originator != nullptr) {
-        failureMessage += Fmt("\n    Origin: %s", originator);
-    }
-    if (sourceLocation != nullptr) {
-        failureMessage += Fmt("\n    Source: %s", sourceLocation);
-    }
-
-    throw std::logic_error(failureMessage);
-}
 
 [[noreturn]] inline void ThrowXrResult(XrResult res, const char* originator = nullptr, const char* sourceLocation = nullptr) {
     Throw(Fmt("XrResult failure [%s]", to_string(res)), originator, sourceLocation);


### PR DESCRIPTION
Wolvic can now start and render WebXR's immersive-ar sessions for those devices supporting passthrough, either via non-opaque blend modes or passthrough compositor layers.

This requires a few changes in the communication protocol with the web engine:
1. pass the available blend modes to the web engine so it can select the desired one depending on the requested WebXR session.
2. use the selected blend mode from the web engine to render the immersive scene
3. notify Wolvic about the type of WebXR session (AR/VR)

Change #3 is required for those devices that do support passthrough but not via AR blend modes. Examples of those are the Meta devices that implement passthrough via a passthrough compositor layer.

Note that WebXR's session type will prevail over the current passthrough status in standalone mode. There are 4 different scenarios (PT stands for passthrough):
1. PT ON, VR session: PT will be disabled on entering and reenabled on exiting
2. PT ON, AR session: PT will be activated all the time
3. PT OFF, VR session: PT will be off all the time
4. PT OFF, AR session: PT will be activated on entering and reenabled on exiting

This change requires
https://github.com/Igalia/wolvic-chromium/pull/114 which implements the required bits on the Chromium backend.

Fixes #242