### PR TITLE
Bring back the title bar widget

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
@@ -215,7 +215,7 @@ public class WindowViewModel extends AndroidViewModel {
     private Observer<ObservableBoolean> mIsTitleBarVisibleObserver = new Observer<ObservableBoolean>() {
         @Override
         public void onChanged(ObservableBoolean o) {
-            if (isFullscreen.getValue().get() || !isKioskMode.getValue().get() || isResizeMode.getValue().get() || isActiveWindow.getValue().get()) {
+            if (isFullscreen.getValue().get() || isKioskMode.getValue().get() || isResizeMode.getValue().get() || isActiveWindow.getValue().get()) {
                 isTitleBarVisible.postValue(new ObservableBoolean(false));
 
             } else {


### PR DESCRIPTION
Amazingly the title bar widget visibility has been broken for almost two years without anyone realizing about it. I figured it out by chance after doing some testing with the old FxR and then voilà the title bar was there with the very cool play/pause media button.

The visibility was broken in 136950b0 when Kiosk mode was added to Wolvic. The problem was that the visibility observer was returning false whenever kiosk mode was disabled instead of doing it when kiosk mode was enabled (as there are not multiple windows in kiosk).