### PR TITLE
[OpenXR] Fix a regression when emulating a controller in WebXR

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -730,7 +730,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
 
         // TODO: removing this flag will allow us to remove the ifdef. Keeping it just to limit
         // the scope of the changes.
-        flags = device::GripSpacePosition;
+        flags |= device::GripSpacePosition;
 #if CHROMIUM
         // Blink WebXR uses the grip space instead of the local space to position the
         // controller. Since controller's position is the same as the origin of the


### PR DESCRIPTION
When eye tracking navigation was introduced in c94ab62a it required some changes in the code that emulates a controller from a hand. It was basically just making that code aware of eye tracking in order not to use the hand aim but the eye gaze.

That required some code refactorings. In one of them the grip space flag was removed from the initialization of flags and set later inside an if block. The problem was that we were setting that flag but at the same time removing the previous ones as we used a " = " instead of a " |= ".