### PR TITLE
New Controller's setting to disable hand tracking

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -240,6 +240,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private ScheduledFuture<?> mNativeWidgetUpdatesTask = null;
     private Media mPrevActiveMedia = null;
     private boolean mIsPassthroughEnabled = false;
+    private boolean mIsHandTrackingEnabled = true;
+    private boolean mIsHandTrackingSupported = false;
+    private boolean mAreControllersAvailable = false;
     private long mLastBatteryUpdate = System.nanoTime();
     private int mLastBatteryLevel = -1;
     private PlatformActivityPlugin mPlatformPlugin;
@@ -1596,6 +1599,18 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @SuppressWarnings("unused")
     private void setEyeTrackingSupported(final boolean isSupported) { mIsEyeTrackingSupported = isSupported; }
 
+    @Keep
+    @SuppressWarnings("unused")
+    private void setHandTrackingSupported(final boolean isSupported) {
+        mIsHandTrackingSupported = isSupported;
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
+    private void onControllersAvailable() {
+        mAreControllersAvailable = true;
+    }
+
     private SurfaceTexture createSurfaceTexture() {
         int[] ids = new int[1];
         GLES20.glGenTextures(1, ids, 0);
@@ -2014,6 +2029,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     public boolean isPassthroughSupported() {
         return DeviceType.isOculusBuild() || DeviceType.isLynx() || DeviceType.isSnapdragonSpaces() || DeviceType.isPicoXR();
     }
+    @Override
+    public boolean areControllersAvailable() {
+        return mAreControllersAvailable;
+    }
 
     @Override
     public boolean isPageZoomEnabled() {
@@ -2149,6 +2168,22 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    public void setHandTrackingEnabled(boolean value) {
+        mIsHandTrackingEnabled = value;
+        queueRunnable(() -> setHandTrackingEnabledNative(value));
+    }
+
+    @Override
+    public boolean isHandTrackingEnabled() {
+        return mIsHandTrackingEnabled;
+    }
+
+    @Override
+    public boolean isHandTrackingSupported() {
+        return mIsHandTrackingSupported;
+    }
+
+    @Override
     @NonNull
     public AppServicesProvider getServicesProvider() {
         return (AppServicesProvider)getApplication();
@@ -2226,4 +2261,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void setWebXRIntersitialStateNative(@WebXRInterstitialState int aState);
     private native void setIsServo(boolean aIsServo);
     private native void setPointerModeNative(@PointerMode int aMode);
+    private native void setHandTrackingEnabledNative(boolean value);
+
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -137,6 +137,11 @@ public interface WidgetManagerDelegate {
     AppServicesProvider getServicesProvider();
     KeyboardWidget getKeyboard();
     void setPointerMode(@PointerMode int mode);
+    void setHandTrackingEnabled(boolean value);
+    boolean isHandTrackingEnabled();
     void checkEyeTrackingPermissions(@NonNull EyeTrackingCallback callback);
     boolean isEyeTrackingSupported();
+    boolean isHandTrackingSupported();
+    boolean areControllersAvailable();
+
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -64,6 +64,12 @@ class ControllerOptionsView extends SettingsView {
         } else {
             mBinding.pointerModeRadio.setVisibility(GONE);
         }
+
+        if (mWidgetManager.isHandTrackingSupported() && mWidgetManager.areControllersAvailable()) {
+            setHandTrackingEnabled(mWidgetManager.isHandTrackingEnabled(), false);
+        } else {
+            mBinding.handtrackingSwitch.setVisibility(GONE);
+        }
     }
 
     private void resetOptions() {
@@ -75,6 +81,7 @@ class ControllerOptionsView extends SettingsView {
         }
         setHapticFeedbackEnabled(SettingsStore.HAPTIC_FEEDBACK_ENABLED, true);
         setPointerMode(SettingsStore.POINTER_MODE_DEFAULT, true);
+        setHandTrackingEnabled(true, true);
     }
 
     private void setPointerColor(int checkedId, boolean doApply) {
@@ -119,6 +126,16 @@ class ControllerOptionsView extends SettingsView {
         }
     }
 
+    private void setHandTrackingEnabled(boolean value, boolean doApply) {
+        mBinding.handtrackingSwitch.setOnCheckedChangeListener(null);
+        mBinding.handtrackingSwitch.setValue(value, false);
+        mBinding.handtrackingSwitch.setOnCheckedChangeListener(mHandtrackingListener);
+
+        if (doApply) {
+            mWidgetManager.setHandTrackingEnabled(value);
+        }
+    }
+
     private RadioGroupSetting.OnCheckedChangeListener mPointerColorListener = (radioGroup, checkedId, doApply) -> {
         setPointerColor(checkedId, doApply);
     };
@@ -145,6 +162,9 @@ class ControllerOptionsView extends SettingsView {
             }
         });
     };
+
+    private SwitchSetting.OnCheckedChangeListener mHandtrackingListener = (compoundButton, enabled, apply) ->
+            setHandTrackingEnabled(enabled, true);
 
     @Override
     protected SettingViewType getType() {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1742,6 +1742,11 @@ BrowserWorld::SetPointerMode(crow::DeviceDelegate::PointerMode pointerMode) {
   m.device->SetPointerMode(pointerMode);
 }
 
+void
+BrowserWorld::SetHandTrackingEnabled(bool value) {
+    m.device->SetHandTrackingEnabled(value);
+}
+
 JNIEnv*
 BrowserWorld::GetJNIEnv() const {
   ASSERT_ON_RENDER_THREAD(nullptr);
@@ -2263,6 +2268,11 @@ JNI_METHOD(void, setPointerModeNative)
             break;
     }
     crow::BrowserWorld::Instance().SetPointerMode(pointerMode);
+}
+
+JNI_METHOD(void, setHandTrackingEnabledNative)
+(JNIEnv*, jobject, jboolean value) {
+    crow::BrowserWorld::Instance().SetHandTrackingEnabled(value);
 }
 
 } // extern "C"

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -78,6 +78,7 @@ public:
   void SetIsServo(const bool aIsServo);
   void SetCPULevel(const device::CPULevel aLevel);
   void SetPointerMode(crow::DeviceDelegate::PointerMode);
+  void SetHandTrackingEnabled(bool);
   JNIEnv* GetJNIEnv() const;
   void OnReorient() override;
 #if HVR

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -137,6 +137,7 @@ public:
   virtual void SetPointerMode(const PointerMode) {};
   virtual void SetImmersiveBlendMode(device::BlendMode) {};
   virtual bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) { return false; };
+  virtual void SetHandTrackingEnabled(bool value) {};
 
 protected:
   DeviceDelegate() {}

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -74,6 +74,11 @@ const char* const kOnAppFocusChangedName = "onAppFocusChanged";
 const char* const kOnAppFocusChangedSignature = "(Z)V";
 const char* const kSetEyeTrackingSupported = "setEyeTrackingSupported";
 const char* const kSetEyeTrackingSupportedSignature = "(Z)V";
+const char* const kSetHandTrackingSupported = "setHandTrackingSupported";
+const char* const kSetHandTrackingSupportedSignature = "(Z)V";
+const char* const kOnControllersAvailable = "onControllersAvailable";
+const char* const kOnControllersAvailableSignature = "()V";
+
 
 JNIEnv* sEnv = nullptr;
 jclass sBrowserClass = nullptr;
@@ -110,6 +115,8 @@ jmethodID sAppendAppNotesToCrashReport = nullptr;
 jmethodID sUpdateControllerBatteryLevels = nullptr;
 jmethodID sOnAppFocusChanged = nullptr;
 jmethodID sSetEyeTrackingSupported = nullptr;
+jmethodID sSetHandTrackingSupported = nullptr;
+jmethodID sOnControllersAvailable = nullptr;
 
 } // namespace
 
@@ -162,6 +169,8 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sUpdateControllerBatteryLevels = FindJNIMethodID(sEnv, sBrowserClass, kUpdateControllerBatteryLevelsName, kUpdateControllerBatteryLevelsSignature);
   sOnAppFocusChanged = FindJNIMethodID(sEnv, sBrowserClass, kOnAppFocusChangedName, kOnAppFocusChangedSignature);
   sSetEyeTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetEyeTrackingSupported, kSetEyeTrackingSupportedSignature);
+  sSetHandTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetHandTrackingSupported, kSetHandTrackingSupportedSignature);
+  sOnControllersAvailable = FindJNIMethodID(sEnv, sBrowserClass, kOnControllersAvailable, kOnControllersAvailableSignature);
 }
 
 JNIEnv * VRBrowser::Env()
@@ -480,6 +489,21 @@ VRBrowser::SetEyeTrackingSupported(bool aIsSupported) {
     if (!ValidateMethodID(sEnv, sActivity, sSetEyeTrackingSupported, __FUNCTION__)) { return; }
     sEnv->CallVoidMethod(sActivity, sSetEyeTrackingSupported, (jboolean) aIsSupported);
     CheckJNIException(sEnv, __FUNCTION__);
+}
+
+void
+VRBrowser::SetHandTrackingSupported(bool aIsSupported) {
+    if (!ValidateMethodID(sEnv, sActivity, sSetHandTrackingSupported, __FUNCTION__)) { return; }
+    sEnv->CallVoidMethod(sActivity, sSetHandTrackingSupported, (jboolean) aIsSupported);
+    CheckJNIException(sEnv, __FUNCTION__);
+}
+
+void
+VRBrowser::OnControllersAvailable() {
+    if (!ValidateMethodID(sEnv, sActivity, sOnControllersAvailable, __FUNCTION__)) { return; }
+    sEnv->CallVoidMethod(sActivity, sOnControllersAvailable);
+    CheckJNIException(sEnv, __FUNCTION__);
+
 }
 
 } // namespace crow

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -51,6 +51,8 @@ void AppendAppNotesToCrashLog(const std::string& aNotes);
 void UpdateControllerBatteryLevels(const jint aLeftBatteryLevel, const jint aRightBatteryLevel);
 void OnAppFocusChanged(const bool aIsFocused);
 void SetEyeTrackingSupported(bool aIsSupported);
+void SetHandTrackingSupported(bool aIsSupported);
+void OnControllersAvailable();
 } // namespace VRBrowser;
 
 } // namespace crow

--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -54,6 +54,12 @@
                     android:layout_height="wrap_content"
                     app:description="@string/controller_options_haptic_feedback" />
 
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/handtracking_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/controller_options_handtracking" />
+
                 <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
                     android:id="@+id/pointer_color_radio"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -685,6 +685,10 @@
          haptic feedback of the remote controller. -->
     <string name="controller_options_haptic_feedback">Haptic Feedback</string>
 
+    <!-- This string is used to label the switch that allow the user to enable/disable
+         the hand-tracking capabilities. -->
+    <string name="controller_options_handtracking">Hand Tracking</string>
+
     <!-- This string describes what the 'Reset' button in the developer options does which is
          restore all the developer settings to their default value. -->
     <string name="developer_options_reset">Reset Developer Settings</string>

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -69,6 +69,7 @@ public:
   void SetPointerMode(const PointerMode mode) override;
   bool IsPassthroughEnabled() const override;
   bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) override;
+  void SetHandTrackingEnabled(bool value) override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -76,7 +76,7 @@ XrResult OpenXRInput::Initialize(ControllerDelegate &delegate, bool isEyeTrackin
   return XR_SUCCESS;
 }
 
-XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, ControllerDelegate& delegate)
+XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool handTrackingEnabled, ControllerDelegate& delegate)
 {
   XrActiveActionSet activeActionSet {
     mActionSet->ActionSet(), XR_NULL_PATH
@@ -90,7 +90,7 @@ XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, 
   bool usingEyeTracking = pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE && updateEyeGaze(frameState, head, delegate);
 
   for (auto& input : mInputSources) {
-    input->Update(frameState, baseSpace, head, offsets, renderMode, pointerMode, usingEyeTracking, delegate);
+    input->Update(frameState, baseSpace, head, offsets, renderMode, pointerMode, usingEyeTracking, handTrackingEnabled, delegate);
   }
 
   // Update tracked keyboard
@@ -145,6 +145,14 @@ OpenXRInputMapping* OpenXRInput::GetActiveInputMapping() const
   }
 
   return nullptr;
+}
+
+bool OpenXRInput::HasPhysicalControllersAvailable() const {
+    for (auto& input : mInputSources) {
+        if (input->HasPhysicalControllersAvailable())
+            return true;
+    }
+    return false;
 }
 
 void OpenXRInput::SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount) {

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -61,11 +61,12 @@ public:
   static OpenXRInputPtr Create(XrInstance, XrSession, XrSystemProperties, XrSpace localSpace,
                                bool isEyeTrackingSupported, ControllerDelegate &delegate);
   XrResult Initialize(ControllerDelegate &delegate, bool isEyeTrackingSupported);
-  XrResult Update(const XrFrameState&, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode, ControllerDelegate &);
+  XrResult Update(const XrFrameState&, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode, bool handTrackingEnabled, ControllerDelegate &);
   int32_t GetControllerModelCount() const;
   std::string GetControllerModelName(const int32_t aModelIndex) const;
   void UpdateInteractionProfile(ControllerDelegate&);
   bool AreControllersReady() const;
+  bool HasPhysicalControllersAvailable() const;
   void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
   HandMeshBufferPtr GetNextHandMeshBuffer(const int32_t aControllerIndex);
   void SetKeyboardTrackingEnabled(bool enabled);

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -733,7 +733,7 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     delegate.SetCapabilityFlags(mIndex, flags);
 }
 
-void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix &head, const vrb::Vector& offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate)
+void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix &head, const vrb::Vector& offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, bool handTrackingEnabled, ControllerDelegate& delegate)
 {
     if (mActiveMapping &&
         ((mHandeness == OpenXRHandFlags::Left && !mActiveMapping->leftControllerModel) ||
@@ -787,6 +787,10 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     auto gotHandTrackingInfo = false;
     auto handFacesHead = false;
     if (isControllerUnavailable || mUsingHandInteractionProfile) {
+        if (!handTrackingEnabled) {
+            delegate.SetEnabled(mIndex, false);
+            return;
+        }
         gotHandTrackingInfo = GetHandTrackingInfo(frameState.predictedDisplayTime, localSpace, head);
         if (gotHandTrackingInfo) {
             std::vector<vrb::Matrix> jointTransforms;
@@ -1072,6 +1076,10 @@ void OpenXRInputSource::HandleEyeTrackingScroll(XrTime predictedDisplayTime, boo
         }
     }
     mTriggerWasClicked = triggerClicked;
+}
+
+bool OpenXRInputSource::HasPhysicalControllersAvailable() const {
+    return mActiveMapping && (!mUsingHandInteractionProfile || mMappings.size() > 1);
 }
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -113,10 +113,12 @@ public:
     ~OpenXRInputSource();
 
     XrResult SuggestBindings(SuggestedBindings&) const;
-    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate);
+    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, bool handTrackingEnabled, ControllerDelegate& delegate);
     XrResult UpdateInteractionProfile(ControllerDelegate&);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }
+    bool IsUsingHandInteractionProfile() { return mUsingHandInteractionProfile; }
+    bool HasPhysicalControllersAvailable() const;
     void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
     HandMeshBufferPtr GetNextHandMeshBuffer();
 };


### PR DESCRIPTION
There maybe be cases where the user wants to prevent the hand tracking to take the control when the controllers got untracked.

This change defines a new switch in the Controller's settings dialog to to disable the hand trakckig capabilities. This setting has been defined as non-persistent, so it will be reset just restarting Wolvic.