### PR TITLE
Correct screen size override

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/EngineProvider.kt
@@ -39,9 +39,11 @@ object EngineProvider {
                     .build())
             builder.displayDensityOverride(settingsStore.displayDensity)
             builder.displayDpiOverride(settingsStore.displayDpi)
+            // This calculation ensures that screen.width and screen.height are always greater or
+            // equal than window.innerWidth and window.innerHeight, even with different densities.
             builder.screenSizeOverride(
-                (settingsStore.maxWindowWidth * settingsStore.displayDensity).toInt(),
-                (settingsStore.maxWindowHeight * settingsStore.displayDensity).toInt()
+                (settingsStore.maxWindowWidth * settingsStore.displayDpi / 100.0).toInt(),
+                (settingsStore.maxWindowHeight * settingsStore.displayDpi / 100.0).toInt()
             )
             builder.enterpriseRootsEnabled(settingsStore.isSystemRootCAEnabled)
             builder.inputAutoZoomEnabled(false)


### PR DESCRIPTION
The screen size override needs to use the DPI as reference, not the density.

For websites, screen.width and screen.height must be always greater or equal than window.innerWidth and window.innerHeight, otherwise there could be layout issues as the Wolvic window becomes too large.

Fixes https://github.com/Igalia/wolvic/issues/1517