### PR TITLE
[OpenXR] Properly detect eye tracking availability

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -124,6 +124,7 @@ struct DeviceDelegateOpenXR::State {
   PointerMode pointerMode { PointerMode::TRACKED_POINTER };
   std::vector<XrEnvironmentBlendMode> blendModes;
   XrEnvironmentBlendMode immersiveBlendMode { XR_ENVIRONMENT_BLEND_MODE_OPAQUE };
+  bool isEyeTrackingSupported { false };
 
   bool IsPositionTrackingSupported() {
       CHECK(system != XR_NULL_SYSTEM_ID);
@@ -337,7 +338,6 @@ struct DeviceDelegateOpenXR::State {
       VRB_LOG("OpenXR runtime supports XR_FB_render_model");
     }
 
-    bool isEyeTrackingSupported { false };
     if (OpenXRExtensions::IsExtensionSupported(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME)) {
         isEyeTrackingSupported = eyeGazeProperties.supportsEyeGazeInteraction;
         VRB_LOG("OpenXR runtime %s support XR_EXT_eye_gaze_interaction", isEyeTrackingSupported ? "does" : "doesn't");
@@ -1648,7 +1648,7 @@ DeviceDelegateOpenXR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
 
   m.passthroughStrategy->initializePassthrough(m.session);
 
-  m.input = OpenXRInput::Create(m.instance, m.session, m.systemProperties, m.localSpace, *m.controller.get());
+  m.input = OpenXRInput::Create(m.instance, m.session, m.systemProperties, m.localSpace, m.isEyeTrackingSupported, *m.controller.get());
   ProcessEvents();
   if (m.controllersCreatedCallback) {
     m.controllersCreatedCallback();

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -39,7 +39,7 @@ private:
   };
   typedef std::unique_ptr<KeyboardTrackingFB> KeyboardTrackingFBPtr;
 
-  OpenXRInput(XrInstance, XrSession, XrSystemProperties, XrSpace localSpace, ControllerDelegate& delegate);
+  OpenXRInput(XrInstance, XrSession, XrSystemProperties, XrSpace localSpace);
   void UpdateTrackedKeyboard(const XrFrameState& frameState, XrSpace baseSpace);
   void LoadKeyboardModel();
 
@@ -57,8 +57,9 @@ private:
   std::unique_ptr<OneEuroFilterQuaternion> mOneEuroFilterGazeOrientation;
 
 public:
-  static OpenXRInputPtr Create(XrInstance, XrSession, XrSystemProperties, XrSpace localSpace, ControllerDelegate& delegate);
-  XrResult Initialize(ControllerDelegate& delegate);
+  static OpenXRInputPtr Create(XrInstance, XrSession, XrSystemProperties, XrSpace localSpace,
+                               bool isEyeTrackingSupported, ControllerDelegate &delegate);
+  XrResult Initialize(ControllerDelegate &delegate, bool isEyeTrackingSupported);
   XrResult Update(const XrFrameState&, XrSpace baseSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode, ControllerDelegate &);
   int32_t GetControllerModelCount() const;
   std::string GetControllerModelName(const int32_t aModelIndex) const;


### PR DESCRIPTION
In order to use eye tracking we need to perform two different tests, first of all the runtime must advertise the extension as supported and secondly, the runtime must acknowledge that the extension is ready to be used.

In the OpenXRInput code that was initializing the eye trackers we were only checking the first condition. However we should also check the value of eyeGazeProperties.supportsEyeGazeInteraction in order to verify that eye tracking is indeed ready to be used in the specific device we're using.

That's why OpenXRInput now receives a new bool parameter in the creation method which is only true if the extension is available in the runtime *and* enabled in the device.