### PR TITLE
Show autocomplete select prompt if there is at least 1 login

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/PromptDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/PromptDelegate.java
@@ -433,7 +433,7 @@ public class PromptDelegate implements
     public WResult<PromptResponse> onLoginSelect(@NonNull WSession session, final @NonNull AutocompleteRequest<WAutocomplete.LoginSelectOption> autocompleteRequest) {
         final WResult<PromptResponse> result = WResult.create();
 
-        if (autocompleteRequest.options().length > 1 && SettingsStore.getInstance(mContext).isAutoFillEnabled()) {
+        if (autocompleteRequest.options().length > 0 && SettingsStore.getInstance(mContext).isAutoFillEnabled()) {
             List<Login> logins = Arrays.stream(autocompleteRequest.options()).map(item -> LoginDelegateWrapper.toLogin(item.value)).collect(Collectors.toList());
             if (mSelectLoginPrompt == null) {
                 mSelectLoginPrompt = new SelectLoginPromptWidget(mContext);


### PR DESCRIPTION
Login selection prompt was not shown if there was only 1 login available under the assumption that in that case the web engine will automatically fill in the saved data in the HTML form.

That's usually correct, however there is an scenario where it does not happen. And that scenario is private browsing mode. In that mode the login/pass is requested as usual, but it isn't autofilled in the form until the user clicks on the login/pass HTML input elements.

The consequence was that when in private browsing mode, for those sites with only 1 password was saved (most common case) the user/pass were not autofilled and the prompt dialog was not shown giving the impression that no user/pass tuple was retrieved from the logins storage.

Fixes #1510