### PR TITLE
[VisionGlass] Fix controller orientation issues

### DIFF
--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -274,7 +274,7 @@ DeviceDelegateVisionGlass::StartFrame(const FramePrediction aPrediction) {
   }
   float* filteredOrientation = m.orientationFilter->filter(timestamp, m.controllerOrientation.Data());
   auto calibratedControllerOrientation = m.controllerCalibration * vrb::Quaternion(filteredOrientation);
-  vrb::Matrix transformMatrix = vrb::Matrix::Rotation(calibratedControllerOrientation.Conjugate());
+  vrb::Matrix transformMatrix = vrb::Matrix::Rotation(calibratedControllerOrientation);
   auto pointerTransform = m.elbow->GetTransform(ElbowModel::HandEnum::None, headTransform, transformMatrix);
   m.controller->SetTransform(kControllerIndex, pointerTransform);
 }
@@ -376,12 +376,7 @@ DeviceDelegateVisionGlass::setControllerOrientation(const float aX, const float 
 
 void
 DeviceDelegateVisionGlass::CalibrateController() {
-  // When the controller is calibrated we reset the phone IMU. This means that the controller
-  // orientation is the identity quaternion ATM. So we store the current head position, and then we
-  // just need to revert this rotation (conjugate) to get controller orientation that points to the
-  // same direction as the head.
-  // Last but not least, we directly store the conjugate here to avoid computing it on each frame.
-  m.controllerCalibration = CorrectedHeadOrientation().Conjugate();
+  m.controllerCalibration = CorrectedHeadOrientation();
   m.SetupOrientationFilter();
 }
 


### PR DESCRIPTION
Controller orientation was suffering from gimbal lock. This means that rotations higher than 90º started to exhibit weird behaviours like inverted or swapped axis. We tried to fix that in the past without much success, but now we do now the actual culprit of that gimbal lock and can fix that once for all.

The quaternion returned by the phone sensor is using Android axis. If the phone is on a table in horizontal position and portrait orientation with respect to the user, X goes right, Y goes forward and Z goes up. However in our world coordinates, X goes right (same) but Y goes up and Z goes backward (-Z is forward direction). So we have to transform the quaternion to follow that coordinate system.

Once that was fixed gimbal lock dissappeared. The only missing thing was to fix the calibration code removing some workarounds we had to add to get it "working" with the previous incorrect version of the orientation code.

Last but not least, we changed the sensor delay from NORMAL to GAME to get a little bit more accuracy in tracking.

Fixes #1484 