### PR TITLE
Disable the XR_EXT_hand_interaction extension in Pico

### DIFF
--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -47,6 +47,8 @@ void OpenXRExtensions::Initialize() {
 #elif PICOXR
     // Pico incorrectly advertises this extension as supported but it makes Wolvic not work.
     sSupportedExtensions.erase(XR_EXTX_OVERLAY_EXTENSION_NAME);
+    // Added in Pico OS 5.11.0 (5.10 ?) but due to a bug in its OpenXR runtime it prevents other profiles (eg, controllers) to be used.
+    sSupportedExtensions.erase(XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
 #elif SPACES
     // Spaces incorrectly advertises this extension as supported but it does not really work.
     sSupportedExtensions.erase(XR_EXT_HAND_INTERACTION_EXTENSION_NAME);


### PR DESCRIPTION
It seems that the XR_EXT_hand_interaction is supported in Pico since the OS version 5.11.0, However, due to some bugs
in the OpenXR runtime, it prevents the controller's input profile to be used.


Fixes #1528 