### PR TITLE
Use a different Android property to get the OS version

### DIFF
--- a/app/src/main/cpp/SystemUtils.h
+++ b/app/src/main/cpp/SystemUtils.h
@@ -6,7 +6,7 @@
 
 namespace crow {
 
-#define ANDROID_OS_BUILD_ID "ro.build.id"
+#define ANDROID_OS_BUILD_ID "ro.build.display.id"
 #define ANDROID_OS_MODEL_ID "ro.product.vendor.model"
 
 // Get the Build ID of the current Android system.
@@ -38,6 +38,8 @@ inline void ParseVersionString(const std::string& aString, int result[], int res
 inline bool CompareSemanticVersionStrings(const std::string& str1, const std::string& str2) {
   int parsedStr1[3]{}, parsedStr2[3]{};
   ParseVersionString(str1, parsedStr1, 3);
+  if (parsedStr1[0] == 0 && parsedStr1[1] == 0 && parsedStr1[2] == 0)
+    return false;
   ParseVersionString(str2, parsedStr2, 3);
   return std::lexicographical_compare(parsedStr1, parsedStr1 + 3, parsedStr2, parsedStr2 + 3);
 }


### PR DESCRIPTION
Recent upgrades in the Pico OS changed the way OS releases are named. We depend on those release numbers to enable/disable some workarounds we had to add for runtime issues.

What was not changed is the property that stores the OS version id to be displayed in the UI, which is ro.build.display.id so we are going to use it from now on.

Apart from that we're adding an extra security layer by adding a fallback in case the version number cannot be parsed. In that case we will always assume that we have the most recent version of the OS and won't apply any workarounds. This fixes a crash when launching Wolvic on the new Pico4 Ultra.