### PR TITLE
Compare semantic versions

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -2016,7 +2016,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     public boolean isPassthroughSupported() {
         return DeviceType.isOculusBuild() || DeviceType.isLynx() || DeviceType.isSnapdragonSpaces() ||
-               (DeviceType.isPicoXR() && Build.ID.compareTo(kPicoVersionPassthroughUpdate) >= 0);
+               (DeviceType.isPicoXR() && StringUtils.compareVersions(Build.ID, kPicoVersionPassthroughUpdate) >= 0);
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/utils/StringUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/StringUtils.java
@@ -8,11 +8,6 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.igalia.wolvic.R;
-
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.Locale;
 
 public class StringUtils {
@@ -88,5 +83,37 @@ public class StringUtils {
             Log.e(LOGTAG, "String index is out of bound at capitalize(). " + e);
             return input;
         }
+    }
+
+    public static int compareVersions(@NonNull String version1, @NonNull String version2) {
+        if (version1.isEmpty() && version2.isEmpty())
+            return 0;
+        if (version1.isEmpty())
+            return -1;
+        if (version2.isEmpty())
+            return 1;
+
+        String[] components1 = version1.split("\\.");
+        String[] components2 = version2.split("\\.");
+        int len = Math.max(components1.length, components2.length);
+
+        for (int i = 0; i < len; i++) {
+            String component1 = i < components1.length ? components1[i] : "0";
+            String component2 = i < components2.length ? components2[i] : "0";
+            try {
+                int num1 = Integer.parseInt(component1);
+                int num2 = Integer.parseInt(component2);
+                int comparison = Integer.compare(num1, num2);
+                if (comparison != 0) {
+                    return comparison;
+                }
+            } catch (NumberFormatException e) {
+                int comparison = component1.compareTo(component2);
+                if (comparison != 0) {
+                    return comparison;
+                }
+            }
+        }
+        return 0;
     }
 }

--- a/app/src/test/java/com/igalia/wolvic/StringUtilsTest.java
+++ b/app/src/test/java/com/igalia/wolvic/StringUtilsTest.java
@@ -1,0 +1,23 @@
+package com.igalia.wolvic;
+
+import static org.junit.Assert.assertEquals;
+
+import com.igalia.wolvic.utils.StringUtils;
+
+import org.junit.Test;
+
+public class StringUtilsTest {
+    @Test
+    public void testCompareVersions() {
+        assertEquals(1, StringUtils.compareVersions("5.11.1", "5.7.1"));
+        assertEquals(-1, StringUtils.compareVersions("1.0.0", "1.0.1"));
+        assertEquals(1, StringUtils.compareVersions("1.0.2", "1.0.1"));
+        assertEquals(1, StringUtils.compareVersions("2.0", "1.9.9"));
+        assertEquals(0, StringUtils.compareVersions("1.0", "1.0"));
+        assertEquals(1, StringUtils.compareVersions("1.0.0a", "1.0.0"));
+        assertEquals(-1, StringUtils.compareVersions("1.0", "1.0a"));
+        assertEquals(0, StringUtils.compareVersions("1.0", "1.0.0"));
+        assertEquals(-1, StringUtils.compareVersions("", "1.0"));
+        assertEquals(1, StringUtils.compareVersions("1.1", ""));
+    }
+}


### PR DESCRIPTION
Add a method `StringUtils.compareVersions()` that compares semantic versions. We assume that versions are defined as integer numbers separated by periods (`.`), but the method also takes into account empty strings and the possibility that some components can not be parsed as integers.

Use `StringUtils.compareVersions()` to check the version of the PICO operating system when enabling passthrough.

Tests are included.