### PR TITLE
Allow setting window's default size

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -105,6 +105,36 @@ public class SettingsStore {
     // The maximum size is computed so the resulting texture fits within 2560x2560.
     public final static int MAX_WINDOW_WIDTH_DEFAULT = 1200;
     public final static int MAX_WINDOW_HEIGHT_DEFAULT = 800;
+    public enum WindowSizePreset {
+        PRESET_0(WINDOW_WIDTH_DEFAULT, WINDOW_HEIGHT_DEFAULT),
+        PRESET_1(750, 500),
+        PRESET_2(825, 550),
+        PRESET_3(900, 600);
+
+        public final int width;
+        public final int height;
+
+        WindowSizePreset(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+        public static WindowSizePreset fromId(int id) {
+            if (id >= 0 && id < values().length) {
+                return values()[id];
+            } else {
+                return WINDOW_SIZE_PRESET_DEFAULT;
+            }
+        }
+        public static WindowSizePreset fromValues(int width, int height) {
+            for (WindowSizePreset preset : values()) {
+                if (preset.width == width && preset.height == height) {
+                    return preset;
+                }
+            }
+            return WINDOW_SIZE_PRESET_DEFAULT;
+        }
+    }
+    public final static WindowSizePreset WINDOW_SIZE_PRESET_DEFAULT = WindowSizePreset.PRESET_0;
 
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;
@@ -477,11 +507,21 @@ public class SettingsStore {
     }
 
     public int getWindowWidth() {
-        return WINDOW_WIDTH_DEFAULT;
+        return mPrefs.getInt(
+                mContext.getString(R.string.settings_key_window_width), WINDOW_WIDTH_DEFAULT);
     }
 
     public int getWindowHeight() {
-        return WINDOW_HEIGHT_DEFAULT;
+        return mPrefs.getInt(
+                mContext.getString(R.string.settings_key_window_height), WINDOW_HEIGHT_DEFAULT);
+    }
+
+    public void setWindowSizePreset(int presetId) {
+        WindowSizePreset preset = WindowSizePreset.fromId(presetId);
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putInt(mContext.getString(R.string.settings_key_window_width), preset.width);
+        editor.putInt(mContext.getString(R.string.settings_key_window_height), preset.height);
+        editor.commit();
     }
 
     public float getWindowAspect() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1050,7 +1050,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         // default position
         mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.window_world_y);
         // center vertically relative to the default position
-        mWidgetPlacement.translationY += (SettingsStore.WINDOW_HEIGHT_DEFAULT - mWidgetPlacement.height) / 2.0f;
+        mWidgetPlacement.translationY += (SettingsStore.getInstance(getContext()).getWindowHeight() - mWidgetPlacement.height) / 2.0f;
         mWidgetManager.updateWidget(this);
         mWidgetManager.updateVisibleWidgets();
     }
@@ -1568,14 +1568,23 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public Pair<Float, Float> getMinWorldSize() {
+        SettingsStore settings = SettingsStore.getInstance(getContext());
         float minWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) * MIN_SCALE;
-        float minHeight = minWidth * SettingsStore.WINDOW_HEIGHT_DEFAULT / SettingsStore.WINDOW_WIDTH_DEFAULT;
+        float minHeight = minWidth * settings.getWindowHeight() / settings.getWindowWidth();
         return new Pair<>(minWidth, minHeight);
+    }
+
+    public Pair<Float, Float> getDefaultWorldSize() {
+        SettingsStore settings = SettingsStore.getInstance(getContext());
+        float defaultWidth = settings.getWindowWidth() * WidgetPlacement.worldToDpRatio(getContext());
+        float defaultHeight = settings.getWindowHeight() * WidgetPlacement.worldToDpRatio(getContext());
+        return new Pair<>(defaultWidth, defaultHeight);
     }
 
     public @NonNull Pair<Float, Float> getSizeForScale(float aScale, float aAspect) {
         Pair<Float, Float> minWorldSize = getMinWorldSize();
         Pair<Float, Float> maxWorldSize = getMaxWorldSize();
+        Pair<Float, Float> defaultWorldSize = getDefaultWorldSize();
         Pair<Float,Float> mainAxisMinMax, crossAxisMinMax;
         float mainAxisDefault, mainAxisTarget;
         float mainCrossAspect;
@@ -1583,13 +1592,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         boolean isHorizontal = aAspect >= 1.0;
         if (isHorizontal) {
             // horizontal orientation
-            mainAxisDefault = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+            mainAxisDefault = defaultWorldSize.first;
             mainAxisMinMax = Pair.create(minWorldSize.first, maxWorldSize.first);
             crossAxisMinMax = Pair.create(minWorldSize.second, maxWorldSize.second);
             mainCrossAspect = aAspect;
         } else {
             // vertical orientation
-            mainAxisDefault = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) * aAspect;
+            mainAxisDefault = defaultWorldSize.second;
             mainAxisMinMax = Pair.create(minWorldSize.second, maxWorldSize.second);
             crossAxisMinMax = Pair.create(minWorldSize.first, maxWorldSize.first);
             mainCrossAspect = 1 / aAspect;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -915,7 +915,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 placement.translationY = WidgetPlacement.unitFromMeters(mContext, R.dimen.window_world_y);
                 if (centerWindow) {
                     // center the window vertically relative to its default position
-                    placement.translationY += (SettingsStore.WINDOW_HEIGHT_DEFAULT - placement.height) / 2.0f;
+                    placement.translationY += (SettingsStore.getInstance(mContext).getWindowHeight() - placement.height) / 2.0f;
                 }
                 placement.translationZ = WidgetPlacement.getWindowWorldZMeters(mContext);
                 break;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -22,6 +22,9 @@ import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 
+import java.util.ArrayList;
+import java.util.List;
+
 class DisplayOptionsView extends SettingsView {
 
     private OptionsDisplayBinding mBinding;
@@ -71,6 +74,17 @@ class DisplayOptionsView extends SettingsView {
         int msaaLevel = SettingsStore.getInstance(getContext()).getMSAALevel();
         mBinding.msaaRadio.setOnCheckedChangeListener(mMSSAChangeListener);
         setMSAAMode(mBinding.msaaRadio.getIdForValue(msaaLevel), false);
+
+        List<String> windowSizePresets = new ArrayList<>();
+        for (SettingsStore.WindowSizePreset preset : SettingsStore.WindowSizePreset.values()) {
+            windowSizePresets.add(getContext().getString(R.string.window_size_preset, preset.width, preset.height));
+        }
+        mBinding.windowsSize.setOptions(windowSizePresets.toArray(new String[0]));
+        mBinding.windowsSize.setOnCheckedChangeListener(mWindowsSizeChangeListener);
+        int windowWidth = SettingsStore.getInstance(getContext()).getWindowWidth();
+        int windowHeight = SettingsStore.getInstance(getContext()).getWindowHeight();
+        SettingsStore.WindowSizePreset windowSizePreset = SettingsStore.WindowSizePreset.fromValues(windowWidth, windowHeight);
+        setWindowsSizePreset(windowSizePreset.ordinal(), false);
 
         mBinding.autoplaySwitch.setOnCheckedChangeListener(mAutoplayListener);
         setAutoplay(SettingsStore.getInstance(getContext()).isAutoplayEnabled(), false);
@@ -165,6 +179,10 @@ class DisplayOptionsView extends SettingsView {
         setMSAAMode(checkedId, true);
     };
 
+    private RadioGroupSetting.OnCheckedChangeListener mWindowsSizeChangeListener = (radioGroup, checkedId, doApply) -> {
+        setWindowsSizePreset(checkedId, true);
+    };
+
     private SwitchSetting.OnCheckedChangeListener mAutoplayListener = (compoundButton, enabled, apply) -> {
         setAutoplay(enabled, true);
     };
@@ -247,6 +265,10 @@ class DisplayOptionsView extends SettingsView {
         if (!prevMSAA.equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
             setMSAAMode(mBinding.msaaRadio.getIdForValue(SettingsStore.MSAA_DEFAULT_LEVEL), true);
             restart = true;
+        }
+
+        if (mBinding.windowsSize.getCheckedRadioButtonId() != SettingsStore.WINDOW_SIZE_PRESET_DEFAULT.ordinal()) {
+            setWindowsSizePreset(SettingsStore.WINDOW_SIZE_PRESET_DEFAULT.ordinal(), true);
         }
 
         float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
@@ -408,6 +430,14 @@ class DisplayOptionsView extends SettingsView {
             SettingsStore.getInstance(getContext()).setMSAALevel((Integer)mBinding.msaaRadio.getValueForId(checkedId));
             showRestartDialog(() -> {setMSAAMode(previouslyCheckedMSAAId, true);});
         }
+    }
+
+    private void setWindowsSizePreset(int checkedId, boolean doApply) {
+        mBinding.windowsSize.setOnCheckedChangeListener(null);
+        mBinding.windowsSize.setChecked(checkedId, doApply);
+        mBinding.windowsSize.setOnCheckedChangeListener(mWindowsSizeChangeListener);
+
+        SettingsStore.getInstance(getContext()).setWindowSizePreset(checkedId);
     }
 
     private boolean setDisplayDensity(float newDensity) {

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -90,6 +90,12 @@
                     app:options="@array/developer_options_msaa"
                     app:values="@array/developer_options_msaa_mode_values" />
 
+                <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
+                    android:id="@+id/windows_size"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:description="@string/settings_window_size" />
+
                 <com.igalia.wolvic.ui.views.settings.SingleEditSetting
                     android:id="@+id/homepage_edit"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/setting_radio_group.xml
+++ b/app/src/main/res/layout/setting_radio_group.xml
@@ -1,33 +1,44 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="5dp"
-        android:paddingBottom="5dp"
-        android:orientation="vertical">
+        android:paddingBottom="5dp">
 
-        <RelativeLayout
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/setting_description"
+            style="@style/settingsText"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical">
+            android:maxLines="1"
+            tools:text="Radio Setting Description" />
 
-            <TextView
-                android:id="@+id/setting_description"
-                style="@style/settingsText"
-                android:layout_alignParentStart="true"
-                android:layout_centerVertical="true"
-                tools:text="Radio Setting Description" />
+        <RadioGroup
+            android:id="@+id/radio_group"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" />
 
-            <RadioGroup
-                android:id="@+id/radio_group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
-                android:orientation="horizontal" />
-        </RelativeLayout>
+        <androidx.constraintlayout.helper.widget.Flow
+            android:id="@+id/flow"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="setting_description,radio_group"
+            app:flow_horizontalAlign="start"
+            app:flow_horizontalBias="0"
+            app:flow_horizontalGap="10dp"
+            app:flow_horizontalStyle="spread_inside"
+            app:flow_verticalAlign="top"
+            app:flow_verticalGap="10dp"
+            app:flow_verticalStyle="spread_inside"
+            app:flow_wrapMode="chain"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </LinearLayout>
 </merge>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -21,6 +21,8 @@
     <string name="settings_key_speech_data_collection" translatable="false">settings_key_speech_data_collection</string>
     <string name="settings_key_speech_data_collection_reviewed" translatable="false">settings_key_speech_data_collection_accept</string>
     <string name="settings_key_window_distance" translatable="false">settings_window_distance</string>
+    <string name="settings_key_window_width" translatable="false">settings_window_width</string>
+    <string name="settings_key_window_height" translatable="false">settings_window_height</string>
     <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version_v2</string>
     <string name="settings_key_input_mode" translatable="false">settings_touch_mode</string>
     <string name="settings_key_center_windows" translatable="false">settings_center_windows</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -607,6 +607,12 @@
     <!-- This string is used to label the MSAA radio button that enables two times MSAA in Immersive Mode. -->
     <string name="developer_options_msaa_4">4x</string>
 
+    <!-- This string is used to label the description of radio buttons for setting the default size of windows. -->
+    <string name="settings_window_size">Default Window Size</string>
+
+    <!-- This string is used to label the radio buttons that set the default size of windows. -->
+    <string name="window_size_preset">%1$d×%2$d</string>
+
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          User-Agent (UA) string of the browser. -->
     <string name="developer_options_ua_mode">User-Agent Mode</string>


### PR DESCRIPTION
Fix #1491

Allow users to choose window's default size in Display settings. There are four options: 800x450 (default), 750x500, 825x550, 900x600.

For 900x600, the Window Resize feature that is existing in each window will only allow 1x at maximum, because bigger scales don't work.