### PR TITLE
[Vision Glass] Correctly update applicationId for global App Gallery

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -837,9 +837,6 @@ android.applicationVariants.configureEach { variant ->
             variant.resValue 'string', 'HOMEPAGE_URL', '"https://wolvic.com/zh/start/pico.html"'
             variant.buildConfigField "String[]", "SPEECH_SERVICES", "{ com.igalia.wolvic.speech.SpeechServices.MEETKAI }"
         }
-    } else if (platform.toLowerCase().startsWith('visionglass')) {
-        // Adjust the applicationId so it matches what the store expects.
-        variant.mergedFlavor.applicationIdSuffix ".world.visionglass"
     }
 
     // Append "Dev" to the app name for debug builds. We do it by directly modifying the resource

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -436,6 +436,18 @@ android {
         
     }
 
+    androidComponents {
+        onVariants(selector().all()) { variant ->
+            def platform = variant.productFlavors.get(0).second
+            def store = variant.productFlavors.get(3).second
+
+            // Adjust the applicationId so it matches what the store expects.
+            if (platform == "visionglass" && store == "generic") {
+                variant.applicationId.set("com.igalia.wolvic.world.visionglass")
+            }
+        }
+    }
+
     sourceSets {
         main {
             java.srcDirs = [


### PR DESCRIPTION
To release Wolvic in the global App Gallery, we need to use this application ID:

    com.igalia.wolvic.world.visionglass

This change replaces an earlier one that was not working as expected.