### PR TITLE
Allow cancelling selections in restart dialog

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/UIWidget.java
@@ -439,9 +439,11 @@ public abstract class UIWidget extends FrameLayout implements Widget {
     }
 
     protected void onDismiss() {
+        Log.e("CancelSelectionPR", "UIWidget onDismiss() is called");
         hide(REMOVE_WIDGET);
 
         if (mDelegate != null) {
+            Log.e("CancelSelectionPR", "mDelegate in UIWidget onDismiss() is not null");
             mDelegate.onDismiss();
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/UIWidget.java
@@ -439,11 +439,9 @@ public abstract class UIWidget extends FrameLayout implements Widget {
     }
 
     protected void onDismiss() {
-        Log.e("CancelSelectionPR", "UIWidget onDismiss() is called");
         hide(REMOVE_WIDGET);
 
         if (mDelegate != null) {
-            Log.e("CancelSelectionPR", "mDelegate in UIWidget onDismiss() is not null");
             mDelegate.onDismiss();
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
@@ -39,6 +39,7 @@ public class PromptDialogWidget extends UIDialog {
     public static final int NEGATIVE = 0;
     public static final int POSITIVE = 1;
     public static final int OTHER = 2;
+    public static final int BACK = 3;
 
     protected PromptDialogBinding mBinding;
     private Delegate mAppDialogDelegate;
@@ -74,6 +75,11 @@ public class PromptDialogWidget extends UIDialog {
         mBinding.optionallyAddedButton.setOnClickListener(v -> {
             if (mAppDialogDelegate != null) {
                 mAppDialogDelegate.onButtonClicked(OTHER, isChecked());
+            }
+        });
+        mBinding.backButton.setOnClickListener(v -> {
+            if (mAppDialogDelegate != null) {
+                mAppDialogDelegate.onButtonClicked(BACK, isChecked());
             }
         });
     }
@@ -259,6 +265,12 @@ public class PromptDialogWidget extends UIDialog {
         } else {
             mBinding.optionallyAddedButton.setVisibility(View.GONE);
         }
+
+        if (buttons.length > 3) {
+            mBinding.backButton.setVisibility(View.VISIBLE);
+        } else {
+            mBinding.backButton.setVisibility(View.GONE);
+        }
     }
 
     public void setButtons(@NonNull String[] buttons) {
@@ -281,6 +293,12 @@ public class PromptDialogWidget extends UIDialog {
             mBinding.optionallyAddedButton.setVisibility(View.VISIBLE);
         } else {
             mBinding.optionallyAddedButton.setVisibility(View.GONE);
+        }
+
+        if (buttons.length > 3) {
+            mBinding.backButton.setVisibility(View.VISIBLE);
+        } else {
+            mBinding.backButton.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
@@ -38,6 +38,7 @@ public class PromptDialogWidget extends UIDialog {
 
     public static final int NEGATIVE = 0;
     public static final int POSITIVE = 1;
+    public static final int OTHER = 2;
 
     protected PromptDialogBinding mBinding;
     private Delegate mAppDialogDelegate;
@@ -68,6 +69,11 @@ public class PromptDialogWidget extends UIDialog {
         mBinding.rightButton.setOnClickListener(v -> {
             if (mAppDialogDelegate != null) {
                 mAppDialogDelegate.onButtonClicked(POSITIVE, isChecked());
+            }
+        });
+        mBinding.optionallyAddedButton.setOnClickListener(v -> {
+            if (mAppDialogDelegate != null) {
+                mAppDialogDelegate.onButtonClicked(OTHER, isChecked());
             }
         });
     }
@@ -236,7 +242,6 @@ public class PromptDialogWidget extends UIDialog {
         if (buttons.length > 0) {
             mBinding.leftButton.setText(buttons[NEGATIVE]);
             mBinding.leftButton.setVisibility(View.VISIBLE);
-
         } else {
             mBinding.leftButton.setVisibility(View.GONE);
         }
@@ -244,9 +249,15 @@ public class PromptDialogWidget extends UIDialog {
         if (buttons.length > 1) {
             mBinding.rightButton.setText(buttons[POSITIVE]);
             mBinding.rightButton.setVisibility(View.VISIBLE);
-
         } else {
             mBinding.rightButton.setVisibility(View.GONE);
+        }
+
+        if (buttons.length > 2) {
+            mBinding.optionallyAddedButton.setText(buttons[OTHER]);
+            mBinding.optionallyAddedButton.setVisibility(View.VISIBLE);
+        } else {
+            mBinding.optionallyAddedButton.setVisibility(View.GONE);
         }
     }
 
@@ -254,7 +265,6 @@ public class PromptDialogWidget extends UIDialog {
         if (buttons.length > 0) {
             mBinding.leftButton.setText(buttons[NEGATIVE]);
             mBinding.leftButton.setVisibility(View.VISIBLE);
-
         } else {
             mBinding.leftButton.setVisibility(View.GONE);
         }
@@ -262,9 +272,15 @@ public class PromptDialogWidget extends UIDialog {
         if (buttons.length > 1) {
             mBinding.rightButton.setText(buttons[POSITIVE]);
             mBinding.rightButton.setVisibility(View.VISIBLE);
-
         } else {
             mBinding.rightButton.setVisibility(View.GONE);
+        }
+
+        if (buttons.length > 2) {
+            mBinding.optionallyAddedButton.setText(buttons[OTHER]);
+            mBinding.optionallyAddedButton.setVisibility(View.VISIBLE);
+        } else {
+            mBinding.optionallyAddedButton.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
@@ -38,8 +38,7 @@ public class PromptDialogWidget extends UIDialog {
 
     public static final int NEGATIVE = 0;
     public static final int POSITIVE = 1;
-    public static final int OTHER = 2;
-    public static final int BACK = 3;
+    public static final int BACK = 2;
 
     protected PromptDialogBinding mBinding;
     private Delegate mAppDialogDelegate;
@@ -70,11 +69,6 @@ public class PromptDialogWidget extends UIDialog {
         mBinding.rightButton.setOnClickListener(v -> {
             if (mAppDialogDelegate != null) {
                 mAppDialogDelegate.onButtonClicked(POSITIVE, isChecked());
-            }
-        });
-        mBinding.optionallyAddedButton.setOnClickListener(v -> {
-            if (mAppDialogDelegate != null) {
-                mAppDialogDelegate.onButtonClicked(OTHER, isChecked());
             }
         });
         mBinding.backButton.setOnClickListener(v -> {
@@ -260,13 +254,6 @@ public class PromptDialogWidget extends UIDialog {
         }
 
         if (buttons.length > 2) {
-            mBinding.optionallyAddedButton.setText(buttons[OTHER]);
-            mBinding.optionallyAddedButton.setVisibility(View.VISIBLE);
-        } else {
-            mBinding.optionallyAddedButton.setVisibility(View.GONE);
-        }
-
-        if (buttons.length > 3) {
             mBinding.backButton.setVisibility(View.VISIBLE);
         } else {
             mBinding.backButton.setVisibility(View.GONE);
@@ -289,13 +276,6 @@ public class PromptDialogWidget extends UIDialog {
         }
 
         if (buttons.length > 2) {
-            mBinding.optionallyAddedButton.setText(buttons[OTHER]);
-            mBinding.optionallyAddedButton.setVisibility(View.VISIBLE);
-        } else {
-            mBinding.optionallyAddedButton.setVisibility(View.GONE);
-        }
-
-        if (buttons.length > 3) {
             mBinding.backButton.setVisibility(View.VISIBLE);
         } else {
             mBinding.backButton.setVisibility(View.GONE);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
@@ -11,7 +11,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 
@@ -34,9 +33,7 @@ public class PromptDialogWidget extends UIDialog {
 
     public interface Delegate {
         void onButtonClicked(int index, boolean isChecked);
-        default void onDismiss() {
-            Log.e("CancelSelectionPR", "PromptDialogWidget onDismiss() is called");
-        }
+        default void onDismiss() {}
     }
 
     public static final int NEGATIVE = 0;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
@@ -11,6 +11,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 
@@ -33,7 +34,9 @@ public class PromptDialogWidget extends UIDialog {
 
     public interface Delegate {
         void onButtonClicked(int index, boolean isChecked);
-        default void onDismiss() {}
+        default void onDismiss() {
+            Log.e("CancelSelectionPR", "PromptDialogWidget onDismiss() is called");
+        }
     }
 
     public static final int NEGATIVE = 0;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
@@ -14,6 +14,8 @@ public class RestartDialogWidget extends PromptDialogWidget {
 
     private CancelCallback mCancelCallback;
 
+    private boolean noButtonsClicked;
+
     public RestartDialogWidget(Context aContext) {
         super(aContext);
         initialize(aContext);
@@ -25,6 +27,8 @@ public class RestartDialogWidget extends PromptDialogWidget {
 
     @Override
     public void updateUI() {
+        noButtonsClicked = true;
+
         super.updateUI();
 
         setButtons(new int[] {
@@ -34,16 +38,20 @@ public class RestartDialogWidget extends PromptDialogWidget {
         });
         setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
+                noButtonsClicked = false;
                 onDismiss();
             } else if (index == PromptDialogWidget.POSITIVE) {
+                noButtonsClicked = false;
                 mWidgetManager.saveState();
                 postDelayed(() -> SystemUtils.restart(getContext()), 500);
             } else if (index == PromptDialogWidget.BACK) {
+                noButtonsClicked = false;
                 if (mCancelCallback != null) {
                     mCancelCallback.cancel();
                 }
                 onDismiss();
             }
+            noButtonsClicked = true;
         });
         setCheckboxVisible(false);
         setDescriptionVisible(false);
@@ -51,6 +59,15 @@ public class RestartDialogWidget extends PromptDialogWidget {
         setIcon(R.drawable.ff_logo);
         setTitle(R.string.restart_dialog_restart);
         setBody(getContext().getString(R.string.restart_dialog_text, getContext().getString(R.string.app_name)));
+    }
+
+    @Override
+    public void onDismiss() {
+        if (noButtonsClicked && mCancelCallback != null) {
+            mCancelCallback.cancel();
+        }
+
+        hide(REMOVE_WIDGET);
     }
 
     public interface CancelCallback {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
@@ -14,8 +14,6 @@ public class RestartDialogWidget extends PromptDialogWidget {
 
     private CancelCallback mCancelCallback;
 
-    private boolean noButtonsClicked;
-
     public RestartDialogWidget(Context aContext) {
         super(aContext);
         initialize(aContext);
@@ -27,31 +25,22 @@ public class RestartDialogWidget extends PromptDialogWidget {
 
     @Override
     public void updateUI() {
-        noButtonsClicked = true;
-
         super.updateUI();
 
         setButtons(new int[] {
                 R.string.restart_later_dialog_button,
                 R.string.restart_now_dialog_button,
-                R.string.restart_back_dialog_button,
+                R.string.back_button,
         });
         setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
-                noButtonsClicked = false;
-                onDismiss();
+                hide(REMOVE_WIDGET);
             } else if (index == PromptDialogWidget.POSITIVE) {
-                noButtonsClicked = false;
                 mWidgetManager.saveState();
                 postDelayed(() -> SystemUtils.restart(getContext()), 500);
             } else if (index == PromptDialogWidget.BACK) {
-                noButtonsClicked = false;
-                if (mCancelCallback != null) {
-                    mCancelCallback.cancel();
-                }
                 onDismiss();
             }
-            noButtonsClicked = true;
         });
         setCheckboxVisible(false);
         setDescriptionVisible(false);
@@ -63,7 +52,7 @@ public class RestartDialogWidget extends PromptDialogWidget {
 
     @Override
     public void onDismiss() {
-        if (noButtonsClicked && mCancelCallback != null) {
+        if (mCancelCallback != null) {
             mCancelCallback.cancel();
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
@@ -31,6 +31,7 @@ public class RestartDialogWidget extends PromptDialogWidget {
                 R.string.restart_later_dialog_button,
                 R.string.restart_now_dialog_button,
                 R.string.restart_cancel_dialog_button,
+                R.string.restart_back_dialog_button,
         });
         setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
@@ -39,6 +40,11 @@ public class RestartDialogWidget extends PromptDialogWidget {
                 mWidgetManager.saveState();
                 postDelayed(() -> SystemUtils.restart(getContext()), 500);
             } else if (index == PromptDialogWidget.OTHER) {
+                if (mCancelCallback != null) {
+                    mCancelCallback.cancel();
+                }
+                onDismiss();
+            } else if (index == PromptDialogWidget.BACK) {
                 if (mCancelCallback != null) {
                     mCancelCallback.cancel();
                 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
@@ -12,6 +12,8 @@ import com.igalia.wolvic.utils.SystemUtils;
 
 public class RestartDialogWidget extends PromptDialogWidget {
 
+    public CancelCallback cancelCallback;
+
     public RestartDialogWidget(Context aContext) {
         super(aContext);
         initialize(aContext);
@@ -23,15 +25,20 @@ public class RestartDialogWidget extends PromptDialogWidget {
 
         setButtons(new int[] {
                 R.string.restart_later_dialog_button,
-                R.string.restart_now_dialog_button
+                R.string.restart_now_dialog_button,
+                R.string.restart_cancel_dialog_button,
         });
         setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
                 onDismiss();
-
             } else if (index == PromptDialogWidget.POSITIVE) {
                 mWidgetManager.saveState();
                 postDelayed(() -> SystemUtils.restart(getContext()), 500);
+            } else if (index == PromptDialogWidget.OTHER) {
+                if (cancelCallback != null) {
+                    cancelCallback.cancel();
+                }
+                onDismiss();
             }
         });
         setCheckboxVisible(false);
@@ -40,5 +47,9 @@ public class RestartDialogWidget extends PromptDialogWidget {
         setIcon(R.drawable.ff_logo);
         setTitle(R.string.restart_dialog_restart);
         setBody(getContext().getString(R.string.restart_dialog_text, getContext().getString(R.string.app_name)));
+    }
+
+    public interface CancelCallback {
+        void cancel();
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
@@ -12,11 +12,15 @@ import com.igalia.wolvic.utils.SystemUtils;
 
 public class RestartDialogWidget extends PromptDialogWidget {
 
-    public CancelCallback cancelCallback;
+    private CancelCallback mCancelCallback;
 
     public RestartDialogWidget(Context aContext) {
         super(aContext);
         initialize(aContext);
+    }
+
+    public void setCancelCallback(CancelCallback cancelCallback) {
+        mCancelCallback = cancelCallback;
     }
 
     @Override
@@ -35,8 +39,8 @@ public class RestartDialogWidget extends PromptDialogWidget {
                 mWidgetManager.saveState();
                 postDelayed(() -> SystemUtils.restart(getContext()), 500);
             } else if (index == PromptDialogWidget.OTHER) {
-                if (cancelCallback != null) {
-                    cancelCallback.cancel();
+                if (mCancelCallback != null) {
+                    mCancelCallback.cancel();
                 }
                 onDismiss();
             }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/RestartDialogWidget.java
@@ -30,7 +30,6 @@ public class RestartDialogWidget extends PromptDialogWidget {
         setButtons(new int[] {
                 R.string.restart_later_dialog_button,
                 R.string.restart_now_dialog_button,
-                R.string.restart_cancel_dialog_button,
                 R.string.restart_back_dialog_button,
         });
         setButtonsDelegate((index, isChecked) -> {
@@ -39,11 +38,6 @@ public class RestartDialogWidget extends PromptDialogWidget {
             } else if (index == PromptDialogWidget.POSITIVE) {
                 mWidgetManager.saveState();
                 postDelayed(() -> SystemUtils.restart(getContext()), 500);
-            } else if (index == PromptDialogWidget.OTHER) {
-                if (mCancelCallback != null) {
-                    mCancelCallback.cancel();
-                }
-                onDismiss();
             } else if (index == PromptDialogWidget.BACK) {
                 if (mCancelCallback != null) {
                     mCancelCallback.cancel();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
@@ -18,7 +18,6 @@ import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.OptionsDeveloperBinding;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
-import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 import com.igalia.wolvic.utils.DeviceType;
 
 class DeveloperOptionsView extends SettingsView {
@@ -167,6 +166,8 @@ class DeveloperOptionsView extends SettingsView {
     }
 
     private void setUIHardwareAcceleration(boolean value, boolean doApply) {
+        boolean prevValue = SettingsStore.getInstance(getContext()).isUIHardwareAccelerationEnabled();
+
         mBinding.hardwareAccelerationSwitch.setOnCheckedChangeListener(null);
         mBinding.hardwareAccelerationSwitch.setValue(value, false);
         mBinding.hardwareAccelerationSwitch.setOnCheckedChangeListener(mUIHardwareAccelerationListener);
@@ -175,7 +176,7 @@ class DeveloperOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setUIHardwareAccelerationEnabled(value);
             showRestartDialog(() -> {
-                setUIHardwareAcceleration(!value, true);
+                setUIHardwareAcceleration(prevValue,true);
             });
         }
     }
@@ -191,6 +192,8 @@ class DeveloperOptionsView extends SettingsView {
     }
 
     private void setDebugLogging(boolean value, boolean doApply) {
+        boolean prevValue = SettingsStore.getInstance(getContext()).isDebugLoggingEnabled();
+
         mBinding.debugLoggingSwitch.setOnCheckedChangeListener(null);
         mBinding.debugLoggingSwitch.setValue(value, false);
         mBinding.debugLoggingSwitch.setOnCheckedChangeListener(mDebugLogginListener);
@@ -198,7 +201,7 @@ class DeveloperOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setDebugLoggingEnabled(value);
             showRestartDialog(() -> {
-                setDebugLogging(!value, true);
+                setDebugLogging(prevValue, true);
             });
         }
     }
@@ -214,6 +217,8 @@ class DeveloperOptionsView extends SettingsView {
     }
 
     private void setWebGLOutOfProcess(boolean value, boolean doApply) {
+        boolean prevValue = SettingsStore.getInstance(getContext()).isWebGLOutOfProcess();
+
         mBinding.webglOutOfProcessSwitch.setOnCheckedChangeListener(null);
         mBinding.webglOutOfProcessSwitch.setValue(value, false);
         mBinding.webglOutOfProcessSwitch.setOnCheckedChangeListener(mWebGLOutOfProcessListener);
@@ -221,7 +226,7 @@ class DeveloperOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setWebGLOutOfProcess(value);
             showRestartDialog(() -> {
-                setWebGLOutOfProcess(!value, true);
+                setWebGLOutOfProcess(prevValue, true);
             });
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
@@ -175,9 +175,7 @@ class DeveloperOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setUIHardwareAccelerationEnabled(value);
-            showRestartDialog(() -> {
-                setUIHardwareAcceleration(prevValue,true);
-            });
+            showRestartDialog(() -> {setUIHardwareAcceleration(prevValue,true);});
         }
     }
 
@@ -200,9 +198,7 @@ class DeveloperOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setDebugLoggingEnabled(value);
-            showRestartDialog(() -> {
-                setDebugLogging(prevValue, true);
-            });
+            showRestartDialog(() -> {setDebugLogging(prevValue, true);});
         }
     }
 
@@ -225,9 +221,7 @@ class DeveloperOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setWebGLOutOfProcess(value);
-            showRestartDialog(() -> {
-                setWebGLOutOfProcess(prevValue, true);
-            });
+            showRestartDialog(() -> {setWebGLOutOfProcess(prevValue, true);});
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DeveloperOptionsView.java
@@ -154,26 +154,6 @@ class DeveloperOptionsView extends SettingsView {
         }
     };
 
-    private RestartDialogWidget.CancelCallback cancelReset(boolean restartDebugLogging,
-                                                           boolean restartUIHardwareAcceleration,
-                                                           boolean restartWebGLOutOfProcess) {
-        RestartDialogWidget.CancelCallback cancelCallback = () -> {
-            if (restartDebugLogging) {
-                setDebugLogging(!SettingsStore.DEBUG_LOGGING_DEFAULT, true);
-            }
-
-            if (restartUIHardwareAcceleration) {
-                setUIHardwareAcceleration(!SettingsStore.UI_HARDWARE_ACCELERATION_DEFAULT, true);
-            }
-
-            if (restartWebGLOutOfProcess) {
-                setWebGLOutOfProcess(!SettingsStore.WEBGL_OUT_OF_PROCESS, true);
-            }
-        };
-
-        return cancelCallback;
-    }
-
     private void setRemoteDebugging(boolean value, boolean doApply) {
         mBinding.remoteDebuggingSwitch.setOnCheckedChangeListener(null);
         mBinding.remoteDebuggingSwitch.setValue(value, doApply);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -21,7 +21,6 @@ import com.igalia.wolvic.ui.views.settings.SliderSetting;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
-import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 
 class DisplayOptionsView extends SettingsView {
 
@@ -252,8 +251,10 @@ class DisplayOptionsView extends SettingsView {
             setUaMode(mBinding.uaRadio.getIdForValue(SettingsStore.UA_MODE_DEFAULT), true);
         }
 
-        if (!mBinding.msaaRadio.getValueForId(mBinding.msaaRadio.getCheckedRadioButtonId()).equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
+        Object prevMSAA = mBinding.msaaRadio.getValueForId(mBinding.msaaRadio.getCheckedRadioButtonId());
+        if (!prevMSAA.equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
             setMSAAMode(mBinding.msaaRadio.getIdForValue(SettingsStore.MSAA_DEFAULT_LEVEL), true);
+            restart = true;
         }
 
         float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
@@ -278,6 +279,7 @@ class DisplayOptionsView extends SettingsView {
 
         if (restart) {
             showRestartDialog(() -> {
+                setMSAAMode(mBinding.msaaRadio.getIdForValue(prevMSAA), true);
                 setDisplayDensity(prevDensity);
                 setDisplayDpi(prevDpi);
             });

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -203,17 +203,13 @@ class DisplayOptionsView extends SettingsView {
             float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
             float newDensity = Float.parseFloat(mBinding.densityEdit.getFirstText());
             if (setDisplayDensity(newDensity)) {
-                showRestartDialog(() -> {
-                    setDisplayDensity(prevDensity);
-                });
+                showRestartDialog(() -> {setDisplayDensity(prevDensity);});
             }
 
         } catch (NumberFormatException e) {
             float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
             if (setDisplayDensity(SettingsStore.DISPLAY_DENSITY_DEFAULT)) {
-                showRestartDialog(() -> {
-                    setDisplayDensity(prevDensity);
-                });
+                showRestartDialog(() -> {setDisplayDensity(prevDensity);});
             }
         }
     };
@@ -223,17 +219,13 @@ class DisplayOptionsView extends SettingsView {
             int prevDpi = SettingsStore.getInstance(getContext()).getDisplayDpi();
             int newDpi = Integer.parseInt(mBinding.dpiEdit.getFirstText());
             if (setDisplayDpi(newDpi)) {
-                showRestartDialog(() -> {
-                    setDisplayDpi(prevDpi);
-                });
+                showRestartDialog(() -> {setDisplayDpi(prevDpi);});
             }
 
         } catch (NumberFormatException e) {
             int prevDpi = SettingsStore.getInstance(getContext()).getDisplayDpi();
             if (setDisplayDpi(SettingsStore.DISPLAY_DPI_DEFAULT)) {
-                showRestartDialog(() -> {
-                    setDisplayDpi(prevDpi);
-                });
+                showRestartDialog(() -> {setDisplayDpi(prevDpi);});
             }
         }
     };
@@ -414,9 +406,7 @@ class DisplayOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setMSAALevel((Integer)mBinding.msaaRadio.getValueForId(checkedId));
-            showRestartDialog(() -> {
-                setMSAAMode(previouslyCheckedMSAAId, true);
-            });
+            showRestartDialog(() -> {setMSAAMode(previouslyCheckedMSAAId, true);});
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -438,11 +438,11 @@ class DisplayOptionsView extends SettingsView {
     private boolean setDisplayDpi(int newDpi) {
         mBinding.dpiEdit.setOnClickListener(null);
         boolean restart = false;
-        int prevDensity = SettingsStore.getInstance(getContext()).getDisplayDpi();
+        int prevDpi = SettingsStore.getInstance(getContext()).getDisplayDpi();
         if (newDpi < SettingsStore.DISPLAY_DPI_MIN || newDpi > SettingsStore.DISPLAY_DPI_MAX) {
-            newDpi = prevDensity;
+            newDpi = prevDpi;
 
-        } else if (prevDensity != newDpi) {
+        } else if (prevDpi != newDpi) {
             SettingsStore.getInstance(getContext()).setDisplayDpi(newDpi);
             restart = true;
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -21,6 +21,7 @@ import com.igalia.wolvic.ui.views.settings.SliderSetting;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
+import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 
 class DisplayOptionsView extends SettingsView {
 
@@ -200,28 +201,40 @@ class DisplayOptionsView extends SettingsView {
 
     private OnClickListener mDensityListener = (view) -> {
         try {
+            float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
             float newDensity = Float.parseFloat(mBinding.densityEdit.getFirstText());
             if (setDisplayDensity(newDensity)) {
-                showRestartDialog();
+                showRestartDialog(() -> {
+                    setDisplayDensity(prevDensity);
+                });
             }
 
         } catch (NumberFormatException e) {
+            float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
             if (setDisplayDensity(SettingsStore.DISPLAY_DENSITY_DEFAULT)) {
-                showRestartDialog();
+                showRestartDialog(() -> {
+                    setDisplayDensity(prevDensity);
+                });
             }
         }
     };
 
     private OnClickListener mDpiListener = (view) -> {
         try {
+            int prevDpi = SettingsStore.getInstance(getContext()).getDisplayDpi();
             int newDpi = Integer.parseInt(mBinding.dpiEdit.getFirstText());
             if (setDisplayDpi(newDpi)) {
-                showRestartDialog();
+                showRestartDialog(() -> {
+                    setDisplayDpi(prevDpi);
+                });
             }
 
         } catch (NumberFormatException e) {
+            int prevDpi = SettingsStore.getInstance(getContext()).getDisplayDpi();
             if (setDisplayDpi(SettingsStore.DISPLAY_DPI_DEFAULT)) {
-                showRestartDialog();
+                showRestartDialog(() -> {
+                    setDisplayDpi(prevDpi);
+                });
             }
         }
     };
@@ -238,11 +251,14 @@ class DisplayOptionsView extends SettingsView {
         if (!mBinding.uaRadio.getValueForId(mBinding.uaRadio.getCheckedRadioButtonId()).equals(SettingsStore.UA_MODE_DEFAULT)) {
             setUaMode(mBinding.uaRadio.getIdForValue(SettingsStore.UA_MODE_DEFAULT), true);
         }
+
         if (!mBinding.msaaRadio.getValueForId(mBinding.msaaRadio.getCheckedRadioButtonId()).equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
             setMSAAMode(mBinding.msaaRadio.getIdForValue(SettingsStore.MSAA_DEFAULT_LEVEL), true);
         }
 
+        float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
         restart = restart | setDisplayDensity(SettingsStore.DISPLAY_DENSITY_DEFAULT);
+        int prevDpi = SettingsStore.getInstance(getContext()).getDisplayDpi();
         restart = restart | setDisplayDpi(SettingsStore.DISPLAY_DPI_DEFAULT);
 
 
@@ -261,7 +277,10 @@ class DisplayOptionsView extends SettingsView {
         }
 
         if (restart) {
-            showRestartDialog();
+            showRestartDialog(() -> {
+                setDisplayDensity(prevDensity);
+                setDisplayDpi(prevDpi);
+            });
         }
     };
 
@@ -385,13 +404,17 @@ class DisplayOptionsView extends SettingsView {
     }
 
     private void setMSAAMode(int checkedId, boolean doApply) {
+        int previouslyCheckedMSAAId = mBinding.msaaRadio.getIdForValue(SettingsStore.getInstance(getContext()).getMSAALevel());
+
         mBinding.msaaRadio.setOnCheckedChangeListener(null);
         mBinding.msaaRadio.setChecked(checkedId, doApply);
         mBinding.msaaRadio.setOnCheckedChangeListener(mMSSAChangeListener);
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setMSAALevel((Integer)mBinding.msaaRadio.getValueForId(checkedId));
-            showRestartDialog();
+            showRestartDialog(() -> {
+                setMSAAMode(previouslyCheckedMSAAId, true);
+            });
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
@@ -29,7 +29,6 @@ import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 import com.igalia.wolvic.ui.widgets.WindowWidget;
-import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 import com.igalia.wolvic.utils.DeviceType;
 
 import java.util.ArrayList;
@@ -347,6 +346,8 @@ class PrivacyOptionsView extends SettingsView {
     }
 
     private void setUseSystemRootCA(boolean value, boolean doApply) {
+        boolean prevValue = SettingsStore.getInstance(getContext()).isSystemRootCAEnabled();
+
         mBinding.useSystemRootCASwitch.setOnCheckedChangeListener(null);
         mBinding.useSystemRootCASwitch.setValue(value, false);
         mBinding.useSystemRootCASwitch.setOnCheckedChangeListener(mUseSystemRootCAListener);
@@ -354,7 +355,7 @@ class PrivacyOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setSystemRootCAEnabled(value);
             showRestartDialog(() -> {
-                setUseSystemRootCA(!value, true);
+                setUseSystemRootCA(prevValue, true);
             });
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
@@ -29,6 +29,7 @@ import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 import com.igalia.wolvic.ui.widgets.WindowWidget;
+import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 import com.igalia.wolvic.utils.DeviceType;
 
 import java.util.ArrayList;
@@ -352,7 +353,9 @@ class PrivacyOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setSystemRootCAEnabled(value);
-            showRestartDialog();
+            showRestartDialog(() -> {
+                setUseSystemRootCA(!value, true);
+            });
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/PrivacyOptionsView.java
@@ -354,9 +354,7 @@ class PrivacyOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setSystemRootCAEnabled(value);
-            showRestartDialog(() -> {
-                setUseSystemRootCA(prevValue, true);
-            });
+            showRestartDialog(() -> {setUseSystemRootCA(prevValue, true);});
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
@@ -49,7 +49,7 @@ public abstract class SettingsView extends FrameLayout {
     public interface Delegate {
         void onDismiss();
         void exitWholeSettings();
-        void showRestartDialog();
+        void showRestartDialog(RestartDialogWidget.CancelCallback cancelCallback);
         void showClearUserDataDialog();
         void showAlert(String aTitle, String aMessage);
         void showView(SettingsView.SettingViewType type);
@@ -79,11 +79,7 @@ public abstract class SettingsView extends FrameLayout {
 
     protected void showRestartDialog(RestartDialogWidget.CancelCallback cancelCallback) {
         if (mDelegate != null) {
-            if (mDelegate instanceof SettingsWidget) {
-                ((SettingsWidget) mDelegate).cancelCallback = cancelCallback;
-            }
-
-            mDelegate.showRestartDialog();
+            mDelegate.showRestartDialog(cancelCallback);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
@@ -13,6 +13,7 @@ import com.igalia.wolvic.R;
 import com.igalia.wolvic.ui.views.CustomScrollView;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
+import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 
 public abstract class SettingsView extends FrameLayout {
 
@@ -76,8 +77,12 @@ public abstract class SettingsView extends FrameLayout {
         }
     }
 
-    protected void showRestartDialog() {
+    protected void showRestartDialog(RestartDialogWidget.CancelCallback cancelCallback) {
         if (mDelegate != null) {
+            if (mDelegate instanceof SettingsWidget) {
+                ((SettingsWidget) mDelegate).cancelCallback = cancelCallback;
+            }
+
             mDelegate.showRestartDialog();
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -62,8 +62,6 @@ import mozilla.components.concept.sync.OAuthAccount;
 import mozilla.components.concept.sync.Profile;
 
 public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
-    public RestartDialogWidget.CancelCallback cancelCallback;
-
     private SettingsBinding mBinding;
     private AudioEngine mAudio;
     private SettingsView mCurrentView;
@@ -592,12 +590,12 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     }
 
     @Override
-    public void showRestartDialog() {
+    public void showRestartDialog(RestartDialogWidget.CancelCallback cancelCallback) {
         if (mRestartDialog == null) {
             mRestartDialog = new RestartDialogWidget(getContext());
         }
 
-        mRestartDialog.cancelCallback = cancelCallback;
+        mRestartDialog.setCancelCallback(cancelCallback);
 
         mRestartDialog.show(REQUEST_FOCUS);
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -62,6 +62,7 @@ import mozilla.components.concept.sync.OAuthAccount;
 import mozilla.components.concept.sync.Profile;
 
 public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
+    public RestartDialogWidget.CancelCallback cancelCallback;
 
     private SettingsBinding mBinding;
     private AudioEngine mAudio;
@@ -595,6 +596,8 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
         if (mRestartDialog == null) {
             mRestartDialog = new RestartDialogWidget(getContext());
         }
+
+        mRestartDialog.cancelCallback = cancelCallback;
 
         mRestartDialog.show(REQUEST_FOCUS);
     }

--- a/app/src/main/res/layout/prompt_dialog.xml
+++ b/app/src/main/res/layout/prompt_dialog.xml
@@ -9,7 +9,19 @@
         android:paddingStart="@dimen/prompt_dialog_padding_sides"
         android:paddingTop="@dimen/prompt_dialog_padding_top"
         android:paddingEnd="@dimen/prompt_dialog_padding_sides"
-        android:paddingBottom="@dimen/prompt_dialog_padding_bottom">
+        android:paddingBottom="@dimen/prompt_dialog_padding_bottom"
+        android:clipToPadding="false">
+
+        <com.igalia.wolvic.ui.views.UIButton
+            android:id="@+id/backButton"
+            style="?attr/navigationBarButtonStyle"
+            android:layout_width="40dp"
+            android:layout_marginStart="-34dp"
+            android:layout_height="40dp"
+            android:layout_alignParentStart="true"
+            android:src="@drawable/ic_icon_back"
+            android:tint="@color/midnight"
+            android:visibility="gone" />
 
         <FrameLayout
             android:id="@+id/imageContainer"

--- a/app/src/main/res/layout/prompt_dialog.xml
+++ b/app/src/main/res/layout/prompt_dialog.xml
@@ -147,21 +147,6 @@
                 android:textColor="@drawable/dialog_button_text_color"
                 android:textStyle="bold"
                 tools:text="Accept" />
-
-            <Button
-                android:id="@+id/optionallyAddedButton"
-                android:layout_width="156dp"
-                android:layout_height="36dp"
-                android:layout_below="@id/rightButton"
-                android:layout_centerHorizontal="true"
-                android:layout_marginTop="20dp"
-                android:visibility="gone"
-                android:background="@drawable/dialog_regular_button_background"
-                android:fontFamily="sans-serif"
-                android:scaleType="fitCenter"
-                android:textColor="@drawable/dialog_button_text_color"
-                android:textStyle="bold"
-                tools:text="Other" />
         </RelativeLayout>
     </RelativeLayout>
 </layout>

--- a/app/src/main/res/layout/prompt_dialog.xml
+++ b/app/src/main/res/layout/prompt_dialog.xml
@@ -135,6 +135,21 @@
                 android:textColor="@drawable/dialog_button_text_color"
                 android:textStyle="bold"
                 tools:text="Accept" />
+
+            <Button
+                android:id="@+id/optionallyAddedButton"
+                android:layout_width="156dp"
+                android:layout_height="36dp"
+                android:layout_below="@id/rightButton"
+                android:layout_centerHorizontal="true"
+                android:layout_marginTop="20dp"
+                android:visibility="gone"
+                android:background="@drawable/dialog_regular_button_background"
+                android:fontFamily="sans-serif"
+                android:scaleType="fitCenter"
+                android:textColor="@drawable/dialog_button_text_color"
+                android:textStyle="bold"
+                tools:text="Other" />
         </RelativeLayout>
     </RelativeLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,10 +483,6 @@
          from being restarted. -->
     <string name="restart_later_dialog_button">Restart Later</string>
 
-    <!-- This string is used to label the button the user presses in order to cancel the selection
-         that required restart. -->
-    <string name="restart_cancel_dialog_button">Cancel Selection</string>
-
     <!-- This string represents the back button the user presses in order to cancel the selection
          that required restart. -->
     <string name="restart_back_dialog_button">Back</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,6 +487,10 @@
          that required restart. -->
     <string name="restart_cancel_dialog_button">Cancel Selection</string>
 
+    <!-- This string represents the back button the user presses in order to cancel the selection
+         that required restart. -->
+    <string name="restart_back_dialog_button">Back</string>
+
     <!-- This string labels an On/Off switch in the 'Developer Options' dialog
      and is used to enable or disable curved display. -->
     <string name="developer_options_curved_display">Enable Curved Display</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,10 +483,6 @@
          from being restarted. -->
     <string name="restart_later_dialog_button">Restart Later</string>
 
-    <!-- This string represents the back button the user presses in order to cancel the selection
-         that required restart. -->
-    <string name="restart_back_dialog_button">Back</string>
-
     <!-- This string labels an On/Off switch in the 'Developer Options' dialog
      and is used to enable or disable curved display. -->
     <string name="developer_options_curved_display">Enable Curved Display</string>
@@ -1004,7 +1000,8 @@
     <!-- This string is used when the list of files that can be uploaded is empty. -->
     <string name="upload_list_empty">No files available for upload</string>
 
-    <!-- This string labels a button that is used to approve an action. -->
+    <!-- This string labels the back button. In some places, it is used to approve an action.
+         In other places, it is used to cancel an action. -->
     <string name="back_button">Back</string>
 
     <!-- This string is displayed in a dialog after an application crash. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,6 +483,10 @@
          from being restarted. -->
     <string name="restart_later_dialog_button">Restart Later</string>
 
+    <!-- This string is used to label the button the user presses in order to cancel the selection
+         that required restart. -->
+    <string name="restart_cancel_dialog_button">Cancel Selection</string>
+
     <!-- This string labels an On/Off switch in the 'Developer Options' dialog
      and is used to enable or disable curved display. -->
     <string name="developer_options_curved_display">Enable Curved Display</string>


### PR DESCRIPTION
This PR adds a back button in restart dialog. If users click it or dismiss the dialog, the selections that users made (that leaded to restart requirement) will be cancelled.

This PR was originally created to fix https://github.com/Igalia/wolvic/issues/1546 But the scope of this PR covers more than MSAA selection cancelling. It covers all the settings that require restart:
- Display options: MSAA, Display Density, Display Dpi, Reset
- Developer options: UI Hardware Acceleration, Debug Logging, WebGL Out Of Process, Reset
- Privacy options: System Root CA, Reset