### PR TITLE
[AOSP] Migrate to GameActivity

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -79,6 +79,16 @@ elseif(HVR)
             ${CMAKE_SOURCE_DIR}/src/hvr/cpp/native-lib.cpp
             ${CMAKE_SOURCE_DIR}/src/main/cpp/BrowserEGLContext.cpp
     )
+elseif(AOSP)
+target_sources(
+        native-lib
+        PUBLIC
+        ${CMAKE_SOURCE_DIR}/src/main/cpp/native-lib.cpp
+        ${CMAKE_SOURCE_DIR}/src/main/cpp/BrowserEGLContext.cpp
+)
+find_package(game-activity REQUIRED CONFIG)
+target_link_libraries(native-lib PRIVATE game-activity::game-activity_static)
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u Java_com_google_androidgamesdk_GameActivity_initializeNativeCode")
 else()
 target_sources(
     native-lib

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -716,6 +716,9 @@ dependencies {
     implementation 'net.lingala.zip4j:zip4j:2.11.5'
     implementation 'org.apache.commons:commons-math3:3.6.1'
 
+    // AOSP
+    aospImplementation 'androidx.games:games-activity:3.0.5'
+
     // HVR
     hvrImplementation fileTree(dir: "${project.rootDir}/third_party/hvr", include: ['*.jar'])
     hvrImplementation 'com.huawei.agconnect:agconnect-core-harmony:1.1.0.300'
@@ -728,7 +731,7 @@ dependencies {
     // Snapdragon Spaces
     spacesImplementation fileTree(dir: "${project.rootDir}/third_party/spaces", include: ['*.aar'])
 
-    // Vission Glass
+    // Vision Glass
     visionglassImplementation fileTree(dir: "${project.rootDir}/third_party/aliceimu/", include: ['*.aar'])
     visionglassImplementation fileTree(dir: "${project.rootDir}/third_party/hvr", include: ['*.jar'])
     visionglassImplementation 'com.huawei.agconnect:agconnect-core-harmony:1.1.0.300'

--- a/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
@@ -5,13 +5,13 @@
 
 package com.igalia.wolvic;
 
-import android.app.NativeActivity;
 import android.content.Intent;
 import android.view.KeyEvent;
 
+import com.google.androidgamesdk.GameActivity;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 
-public class PlatformActivity extends NativeActivity {
+public class PlatformActivity extends GameActivity {
 
     public static boolean filterPermission(final String aPermission) {
         // Dummy implementation.
@@ -41,14 +41,14 @@ public class PlatformActivity extends NativeActivity {
     }
 
     @Override
-    public void onBackPressed() {
-        queueRunnable(new Runnable() {
-            @Override
-            public void run() {
-                platformExit();
-            }
-        });
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            // GameActivity does not invoke onBackPressed() on KEYCODE_BACK
+            onBackPressed();
+        }
+        return super.onKeyUp(keyCode, event);
     }
+
     protected native void queueRunnable(Runnable aRunnable);
     protected native boolean platformExit();
 }

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1238,7 +1238,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 return;
             }
             dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
-            dispatchKeyEvent(new KeyEvent (KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
+            dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
         });
     }
 

--- a/app/src/main/cpp/BrowserEGLContext.cpp
+++ b/app/src/main/cpp/BrowserEGLContext.cpp
@@ -8,7 +8,11 @@
 #include <EGL/eglext.h>
 
 #ifndef HVR
+#if (AOSP)
+#include <game-activity/native_app_glue/android_native_app_glue.h>
+#else
 #include <android_native_app_glue.h>
+#endif
 #endif
 
 namespace crow {


### PR DESCRIPTION
NativeActivity was the original choice for the Android activity for the AOSP port because it's a natural choice for an activity with native code. That was causing issues in MagicLeap2 because key strokes in external bluetooth keyboards were filtered out.

By switching to GameActivity we can get rid of that limitation. The migration only required an small adjustment in the back button handling code because the onKeyUp() event for the back button was not triggering the onBackPressed() as it does in NativeActivity.