### PR TITLE
[Chromium] Show private mode about page

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -1,6 +1,7 @@
 package com.igalia.wolvic.browser.api.impl;
 
 import android.graphics.Matrix;
+import android.util.Base64;
 import android.view.ViewGroup;
 
 import androidx.annotation.AnyThread;
@@ -92,8 +93,9 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     }
 
     @Override
-    public void loadData(@NonNull byte[] data, String mymeType) {
-        // TODO: Implement
+    public void loadData(@NonNull byte[] data, String mimeType) {
+        if (isOpen())
+            mTab.loadData(Base64.encodeToString(data, Base64.NO_WRAP), mimeType, "base64");
     }
 
     @Override


### PR DESCRIPTION
When entering private mode Wolvic displays a custom web page that explains the user what private mode is and what is not.

In the case of Chromium backend it was not showing anything because the Session::loadData interface was not implemented. This PR implements it using the new API added in
https://github.com/Igalia/wolvic-chromium/pull/119