### PR TITLE
Optimize UrlUtils::isPrivateAboutPage

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -93,6 +93,8 @@ public class UrlUtils {
         return localhostPattern.matcher(uri).find() || ipPattern.matcher(uri).find();
     }
 
+    private static String privateAboutPageBytes;
+
     public static boolean isLocalIP(@Nullable String aUri) {
         if (!isIPUri(aUri)) {
             return false;
@@ -105,9 +107,14 @@ public class UrlUtils {
     }
 
     public static boolean isPrivateAboutPage(@Nullable Context context,  @Nullable String uri) {
+        if (uri == null || !isDataUri(uri))
+            return false;
+
         InternalPages.PageResources pageResources = InternalPages.PageResources.create(R.raw.private_mode, R.raw.private_style);
-        byte[] privatePageBytes = InternalPages.createAboutPage(context, pageResources);
-        return uri != null && uri.equals("data:text/html;base64," + Base64.encodeToString(privatePageBytes, Base64.NO_WRAP));
+        if (privateAboutPageBytes == null)
+            privateAboutPageBytes = "data:text/html;base64," + Base64.encodeToString(InternalPages.createAboutPage(context, pageResources), Base64.NO_WRAP);
+
+        return uri.equals(privateAboutPageBytes);
     }
 
     public static Boolean isHomeUri(@Nullable Context context, @Nullable String aUri) {


### PR DESCRIPTION
The isPrivateAboutPage was called 18! times just during the startup process of Wolvic. That method was doing a couple of things very badly:
1. Most of the time users would load http(s) URLs and this method was not filtering out non-data:// URLs at the very beginning
2. For each call (as long as URL was not null) it was creating the private about page and encoding it in base64.

We can do it much better by:
1. filter out non-data:// URIs
2. create and decode the about page on demand just once as it never changes

With this optimization we moved from 18 about page creations to 0 (when using the default start page).