### PR TITLE
[Chromium] Add support to purge session history

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -168,7 +168,8 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
 
     @Override
     public void purgeHistory() {
-        // TODO: Implement
+        if (isOpen())
+            mTab.purgeHistory();
     }
 
     @NonNull

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabImpl.java
@@ -43,4 +43,8 @@ public class TabImpl extends Tab {
     public void onMediaFullscreen(boolean isFullscreen) {
         mTabMediaSessionObserver.onMediaFullscreen(isFullscreen);
     }
+
+    public void purgeHistory() {
+        mWebContents.getNavigationController().clearHistory();
+    }
 }


### PR DESCRIPTION
The Session's purgeHistory() method was not implemented in Chromium. This method purges the session history.