### PR TITLE
Improve hand interaction profiles support

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -217,6 +217,8 @@ struct DeviceDelegateOpenXR::State {
 
     if (OpenXRExtensions::IsExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME))
         extensions.push_back(XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
+    else if (OpenXRExtensions::IsExtensionSupported(XR_MSFT_HAND_INTERACTION_EXTENSION_NAME))
+        extensions.push_back(XR_MSFT_HAND_INTERACTION_EXTENSION_NAME);
 
     if (OpenXRExtensions::IsExtensionSupported(XR_EXT_VIEW_CONFIGURATION_DEPTH_RANGE_EXTENSION_NAME))
         extensions.push_back(XR_EXT_VIEW_CONFIGURATION_DEPTH_RANGE_EXTENSION_NAME);

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -45,6 +45,7 @@ namespace crow {
     constexpr const char* kPathActionValue { "value" };
     constexpr const char* kPathActionReady { "ready_ext" };
     constexpr const char* kInteractionProfileHandInteraction { "/interaction_profiles/ext/hand_interaction_ext" };
+    constexpr const char* kInteractionProfileMSFTHandInteraction { "/interaction_profiles/microsoft/hand_interaction" };
 
     // OpenXR Button List
     enum class OpenXRButtonType {
@@ -436,8 +437,24 @@ namespace crow {
         {}
     };
 
-    const std::array<OpenXRInputMapping, 12> OpenXRInputMappings {
-            OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4x, Pico4xOld, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, HandInteraction
+    const OpenXRInputMapping MSFTHandInteraction {
+            kInteractionProfileMSFTHandInteraction,
+            IS_6DOF,
+            "",
+            "",
+            device::UnknownType,
+            std::vector<OpenXRInputProfile> { "generic-hand-select-grasp", "generic-hand-select", "generic-hand" },
+            std::vector<OpenXRButton> {
+                    { OpenXRButtonType::Trigger, "input/select", OpenXRButtonFlags::Value, OpenXRHandFlags::Both },
+                    { OpenXRButtonType::Squeeze, kPathSqueeze, OpenXRButtonFlags::Value, OpenXRHandFlags::Both },
+            },
+            {},
+            {}
+    };
+
+
+    const std::array<OpenXRInputMapping, 13> OpenXRInputMappings {
+            OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4x, Pico4xOld, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, HandInteraction, MSFTHandInteraction
     };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -907,9 +907,6 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
             continue;
         }
 
-        if (!state->ready)
-            continue;
-
         placeholders.erase(button.type);
         buttonCount++;
         auto browserButton = GetBrowserButton(button);

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -13,7 +13,6 @@ namespace crow {
 // Threshold to consider a trigger value as a click
 // Used when devices don't map the click value for triggers;
 const float kClickThreshold = 0.91f;
-const float kClickLowFiThreshold = 0.8f;
 
 // When doing scrolling with eye tracking we wait until this threshold is reached to start scrolling.
 // Otherwise single (slow) clicks would easily trigger scrolling.
@@ -916,10 +915,8 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
         auto browserButton = GetBrowserButton(button);
         auto immersiveButton = GetImmersiveButton(button);
 
-        if (isHandActionEnabled) {
-            // When hand faces head, tracking systems do not have the same level of precision
-            // detecting pinches, that's why we need to lower the bar to detect them.
-            delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_APP, -1, state->value >= kClickLowFiThreshold,
+        if (isHandActionEnabled && button.type == OpenXRButtonType::Trigger) {
+            delegate.SetButtonState(mIndex, ControllerDelegate::BUTTON_APP, -1, state->value >= kClickThreshold,
                                     state->value > 0, 1.0);
         } else {
             delegate.SetButtonState(mIndex, browserButton, immersiveButton.has_value() ? immersiveButton.value() : -1,

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -105,7 +105,7 @@ private:
     HandMeshBufferPtr AcquireHandMeshBuffer();
     void ReleaseHandMeshBuffer();
 
-    bool mIsHandInteractionEXTSupported { false };
+    bool mIsHandInteractionSupported { false };
 
     void HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix& pointerTransform, ControllerDelegate &controllerDelegate);
 public:


### PR DESCRIPTION
This PR addresses 3 issues:

1. improve gesture detection with hand interaction profiles. We were mixing pinch and squeeze events
2. do not filter out events when ready action is false, that is not the meaning of ready state value
3. Add support for XR_MSFT_hand_interaction profile, similar to the khronos one. Available in several devices/OS where the khronos one is not supported.