### PR TITLE
Fix HTTP Error 400 in consent.youtube.com

### DIFF
--- a/app/src/main/assets/extensions/fxr_youtube/background.js
+++ b/app/src/main/assets/extensions/fxr_youtube/background.js
@@ -39,7 +39,9 @@ function redirect(details) {
             return { };
         }
 
-        if (!uri.searchParams.has("app")) {
+        // Add app=desktop to the query string if it's not already there. Don't do it for
+        // the consent page as it breaks the request.
+        if (!uri.searchParams.has("app") && !uri.hostname.startsWith("consent.youtube.com")) {
             uri.searchParams.append('app', 'desktop');
             return { redirectUrl: uri.href };
         }


### PR DESCRIPTION
Our YouTube internal extension appends "app=desktop" param to the YouTube URLs in order to get immersive videos. That unfortunatelly breaks the new consent page making the request invalid. The server returns a HTTP 400 code.

The solution is not to add that param for those URLs.