### PR TITLE
[META] Add eye tracking support

### DIFF
--- a/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -51,7 +51,7 @@ public class PlatformActivity extends NativeActivity {
         return intent;
     }
 
-    protected String getEyeTrackingPermissionString() { return null; }
+    protected String getEyeTrackingPermissionString() { return "com.oculus.permission.EYE_TRACKING"; }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -24,6 +24,8 @@
     <uses-feature android:name="com.oculus.feature.RENDER_MODEL" android:required="true" />
     <uses-permission android:name="com.oculus.permission.RENDER_MODEL" />
 
+    <uses-permission android:name="com.oculus.permission.EYE_TRACKING" />
+
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -28,6 +28,8 @@
 
     <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
 
+    <uses-permission android:name="com.oculus.permission.EYE_TRACKING" />
+
     <application
         android:name=".VRBrowserApplication"
         android:allowBackup="true"


### PR DESCRIPTION
Meta OS v71 beta adds support for the XR_EXT_eye_gaze_interaction extension meaning that eye tracking could be used in those devices supporting it. So far the only one is the Meta Quest Pro.