### PR TITLE
[Spaces] Blacklist MSFT_hand_interaction

### DIFF
--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -50,8 +50,10 @@ void OpenXRExtensions::Initialize() {
     // Added in Pico OS 5.11.0 (5.10 ?) but due to a bug in its OpenXR runtime it prevents other profiles (eg, controllers) to be used.
     sSupportedExtensions.erase(XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
 #elif SPACES
-    // Spaces incorrectly advertises this extension as supported but it does not really work.
+    // Spaces incorrectly advertises these extensions as supported but they don't really work.
+    // We get no poses for aim/grip... and we get flooded by profiles change events.
     sSupportedExtensions.erase(XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
+    sSupportedExtensions.erase(XR_MSFT_HAND_INTERACTION_EXTENSION_NAME);
 #endif
 
     // Adding this check here is ugly but required to have a working build for VRX. With the current


### PR DESCRIPTION
The Spaces platform supports both EXT and MSFT hand_interaction extensions in theory. However when enabling them some issues appear that make Wolvic unusable:
1. If we suggest bindings for both profiles we get flooded by a neverending input profile change events
2. Neither of them report valid poses for aim/grip...

So until we don't have time to figure out how to make them work is better to keep them disabled and use hand joints.