### PR TITLE
Remove AppLab build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -382,15 +382,6 @@ android {
             dimension "store"
         }
 
-        appLab {
-            dimension "store"
-            externalNativeBuild {
-                cmake {
-                    cppFlags "-DSTORE_BUILD", "-DMETA_APP_ID=4812663595466206"
-                }
-            }
-        }
-
         metaStore {
             dimension "store"
             applicationIdSuffix ".metastore"
@@ -430,8 +421,8 @@ android {
         if (backend == 'webkit' && !isWebKitAvailable())
             variant.setIgnore(true);
 
-        // MetaStore and AppLab only apply to oculusvr builds.
-        if ((store == 'metaStore' || store == "appLab") && !platform.startsWith('oculusvr'))
+        // MetaStore only apply to oculusvr builds.
+        if (store == 'metaStore' && !platform.startsWith('oculusvr'))
             variant.setIgnore(true);
         
     }

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -378,9 +378,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
         }
 
-        // Show the deprecated version dialog, if needed.
-        showDeprecatedVersionDialogIfNeeded();
-
         getLifecycleRegistry().setCurrentState(Lifecycle.State.CREATED);
     }
 
@@ -486,39 +483,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             Log.e(LOGTAG, "Exception creating the speech recognizer: " + e);
             ((VRBrowserApplication) getApplication()).setSpeechRecognizer(null);
         }
-    }
-
-    // A dialog to tell App Lab users to download Wolvic from the Meta store.
-    // Returns true if the dialog was shown, false otherwise.
-    private void showDeprecatedVersionDialogIfNeeded() {
-        // Only show this dialog to users running the App Lab version of Wolvic.
-        if (!DeviceType.getStoreType().equals(DeviceType.StoreType.META_APP_LAB))
-            return;
-
-        DeprecatedVersionDialogWidget deprecatedVersionDialog = new DeprecatedVersionDialogWidget(this);
-
-        deprecatedVersionDialog.setDelegate(response -> {
-            switch (response) {
-                case DeprecatedVersionDialogWidget.OPEN_STORE:
-                    Intent storeIntent = getStoreIntent();
-                    if (storeIntent != null) {
-                        Log.w(LOGTAG, "Start app store activity.");
-                        startActivity(storeIntent);
-                    } else {
-                        Log.e(LOGTAG, "Unsupported: can not start app store activity.");
-                    }
-                    break;
-
-                case DeprecatedVersionDialogWidget.SHOW_INFO:
-                    mWindows.openNewTabAfterRestore(getString(R.string.deprecated_version_dialog_info_url), Windows.OPEN_IN_FOREGROUND);
-                    break;
-
-                case DeprecatedVersionDialogWidget.DISMISS:
-                    // no action
-            }
-        });
-        deprecatedVersionDialog.attachToWindow(mWindows.getFocusedWindow());
-        deprecatedVersionDialog.show(UIWidget.REQUEST_FOCUS);
     }
 
     // Returns true if the dialog was shown, false otherwise.

--- a/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/DeviceType.java
@@ -140,13 +140,11 @@ public class DeviceType {
     }
 
     // Identifiers for store-specific builds.
-    public enum StoreType {NONE, META_STORE, META_APP_LAB, MAINLAND_CHINA}
+    public enum StoreType {NONE, META_STORE, MAINLAND_CHINA}
 
     public static StoreType getStoreType() {
         if (BuildConfig.FLAVOR_store.toLowerCase().contains("metastore"))
             return StoreType.META_STORE;
-        else if (BuildConfig.FLAVOR_store.toLowerCase().contains("applab"))
-            return StoreType.META_APP_LAB;
         else if (BuildConfig.FLAVOR_store.toLowerCase().contains("mainlandchina"))
             return StoreType.MAINLAND_CHINA;
         else


### PR DESCRIPTION
Meta discontinued AppLab as devs can now publish apps in the Meta Store in beta status for people to try, which is more or less what AppLab was for.

We can get rid of the build options for AppLab and also the deprecation dialog we were showing in AppLab builds encouraging users to switch to the Meta Store version.