### PR TITLE
Improve scrolling using eye tracking

### DIFF
--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -90,7 +90,7 @@ XrResult OpenXRInput::Update(const XrFrameState& frameState, XrSpace baseSpace, 
   bool usingEyeTracking = pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE && updateEyeGaze(frameState, head, delegate);
 
   for (auto& input : mInputSources) {
-    input->Update(frameState, baseSpace, head, offsets, renderMode, pointerMode, usingEyeTracking, handTrackingEnabled, delegate);
+    input->Update(frameState, baseSpace, head, offsets, renderMode, pointerMode, usingEyeTracking, handTrackingEnabled, mEyeTrackingTransform, delegate);
   }
 
   // Update tracked keyboard
@@ -374,8 +374,7 @@ bool OpenXRInput::updateEyeGaze(XrFrameState frameState, const vrb::Matrix& head
     vrb::Quaternion gazeOrientation(gazeLocation.pose.orientation.x, gazeLocation.pose.orientation.y, gazeLocation.pose.orientation.z, gazeLocation.pose.orientation.w);
     float* filteredOrientation = mOneEuroFilterGazeOrientation->filter(frameState.predictedDisplayTime, gazeOrientation.Data());
     gazeOrientation = {filteredOrientation[0], filteredOrientation[1], filteredOrientation[2], filteredOrientation[3]};
-    delegate.SetTransform(0, vrb::Matrix::Rotation(gazeOrientation).Translate(gazePosition));
-    delegate.SetImmersiveBeamTransform(0, vrb::Matrix::Identity());
+    mEyeTrackingTransform = vrb::Matrix::Rotation(gazeOrientation).Translate(gazePosition);
 
     return true;
 }

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -56,6 +56,7 @@ private:
   XrSpace mEyeGazeActionSpace {XR_NULL_HANDLE };
   XrSpace mLocalReferenceSpace { XR_NULL_HANDLE};
   std::unique_ptr<OneEuroFilterQuaternion> mOneEuroFilterGazeOrientation;
+  vrb::Matrix mEyeTrackingTransform;
 
 public:
   static OpenXRInputPtr Create(XrInstance, XrSession, XrSystemProperties, XrSpace localSpace,

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -639,7 +639,7 @@ OpenXRInputSource::PopulateHandJointLocations(device::RenderMode renderMode, std
     }
 }
 
-void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate)
+void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate& delegate)
 {
     assert(mHasHandJoints);
 
@@ -731,13 +731,14 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
         delegate.SetImmersiveBeamTransform(mIndex, pointerTransform);
     } else {
         assert(pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE);
-        HandleEyeTrackingScroll(predictedDisplayTime, triggerButtonPressed, pointerTransform, delegate);
+        if (!HandleEyeTrackingScroll(predictedDisplayTime, triggerButtonPressed, pointerTransform, eyeTrackingTransform, delegate))
+            delegate.SetTransform(mIndex, eyeTrackingTransform);
     }
 
     delegate.SetCapabilityFlags(mIndex, flags);
 }
 
-void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix &head, const vrb::Vector& offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, bool handTrackingEnabled, ControllerDelegate& delegate)
+void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpace, const vrb::Matrix &head, const vrb::Vector& offsets, device::RenderMode renderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, bool handTrackingEnabled, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate& delegate)
 {
     if (mActiveMapping &&
         ((mHandeness == OpenXRHandFlags::Left && !mActiveMapping->leftControllerModel) ||
@@ -801,7 +802,7 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
             std::vector<float> jointRadii;
             PopulateHandJointLocations(renderMode, jointTransforms, jointRadii);
             if (!mIsHandInteractionSupported) {
-                EmulateControllerFromHand(renderMode, frameState.predictedDisplayTime, head, jointTransforms[HAND_JOINT_FOR_AIM], pointerMode, usingEyeTracking, delegate);
+                EmulateControllerFromHand(renderMode, frameState.predictedDisplayTime, head, jointTransforms[HAND_JOINT_FOR_AIM], pointerMode, usingEyeTracking, eyeTrackingTransform, delegate);
                 delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
                 return;
             }
@@ -933,7 +934,8 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
         if (button.type == OpenXRButtonType::Trigger) {
             delegate.SetSelectFactor(mIndex, state->value);
             if (pointerMode == DeviceDelegate::PointerMode::TRACKED_EYE)
-                HandleEyeTrackingScroll(frameState.predictedDisplayTime, state->clicked, pointerTransform, delegate);
+                if (!HandleEyeTrackingScroll(frameState.predictedDisplayTime, state->clicked, pointerTransform, eyeTrackingTransform, delegate))
+                    delegate.SetTransform(mIndex, eyeTrackingTransform);
         }
 
         // Select action
@@ -1069,19 +1071,27 @@ OpenXRInputSource::GetNextHandMeshBuffer() {
     return mHandMeshMSFT.buffer;
 }
 
-void OpenXRInputSource::HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix &pointerTransform, ControllerDelegate &controllerDelegate) {
+bool OpenXRInputSource::HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix &pointerTransform, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate &controllerDelegate) {
+    bool handled { false };
     if (!mTriggerWasClicked && triggerClicked) {
-        mControllerPositionOnGestureStart =  pointerTransform.GetTranslation();
+        mEyeGazeTransformOnPinchStart = eyeTrackingTransform;
         mEyeTrackingPinchStartTime = predictedDisplayTime;
+        handled = true;
     } else if (mTriggerWasClicked && triggerClicked) {
         // Throttle the start of the scroll gesture to avoid scrolling on pinch.
         if (predictedDisplayTime - mEyeTrackingPinchStartTime > kEyeTrackingScrollThreshold) {
             vrb::Vector currentControllerPosition = pointerTransform.GetTranslation();
-            auto delta = currentControllerPosition - mControllerPositionOnGestureStart;
-            controllerDelegate.TranslateTransform(mIndex, delta * 10);
+            auto delta = currentControllerPosition - mControllerPositionOnScrollStart;
+            controllerDelegate.SetTransform(mIndex, mEyeGazeTransformOnPinchStart.Translate(delta * 10));
+        } else {
+            // Keep updating the initial position while throttling to avoid a sudden jump when
+            // scrolling starts.
+            mControllerPositionOnScrollStart =  pointerTransform.GetTranslation();
         }
+        handled = true;
     }
     mTriggerWasClicked = triggerClicked;
+    return handled;
 }
 
 bool OpenXRInputSource::HasPhysicalControllersAvailable() const {

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -47,7 +47,7 @@ private:
     void UpdateHaptics(ControllerDelegate&);
     bool GetHandTrackingInfo(XrTime predictedDisplayTime, XrSpace, const vrb::Matrix& head);
     float GetDistanceBetweenJoints (XrHandJointEXT jointA, XrHandJointEXT jointB);
-    void EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, ControllerDelegate& delegate);
+    void EmulateControllerFromHand(device::RenderMode renderMode, XrTime predictedDisplayTime, const vrb::Matrix& head, const vrb::Matrix& handJointForAim, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate& delegate);
     void PopulateHandJointLocations(device::RenderMode, std::vector<vrb::Matrix>& jointTransforms, std::vector<float>& jointRadii);
 
     XrInstance mInstance { XR_NULL_HANDLE };
@@ -85,7 +85,8 @@ private:
     bool mUsingHandInteractionProfile { false };
     device::DeviceType mDeviceType { device::UnknownType };
     bool mTriggerWasClicked { false };
-    vrb::Vector mControllerPositionOnGestureStart;
+    vrb::Vector mControllerPositionOnScrollStart;
+    vrb::Matrix mEyeGazeTransformOnPinchStart;
     XrTime mEyeTrackingPinchStartTime { 0 };
 
     struct HandMeshMSFT {
@@ -107,13 +108,13 @@ private:
 
     bool mIsHandInteractionSupported { false };
 
-    void HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix& pointerTransform, ControllerDelegate &controllerDelegate);
+    bool HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix& pointerTransform, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate &);
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);
     ~OpenXRInputSource();
 
     XrResult SuggestBindings(SuggestedBindings&) const;
-    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, bool handTrackingEnabled, ControllerDelegate& delegate);
+    void Update(const XrFrameState&, XrSpace, const vrb::Matrix& head, const vrb::Vector& offsets, device::RenderMode, DeviceDelegate::PointerMode pointerMode, bool usingEyeTracking, bool handTrackingEnabled, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate& delegate);
     XrResult UpdateInteractionProfile(ControllerDelegate&);
     std::string ControllerModelName() const;
     OpenXRInputMapping* GetActiveMapping() const { return mActiveMapping; }

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -108,7 +108,7 @@ private:
 
     bool mIsHandInteractionSupported { false };
 
-    bool HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix& pointerTransform, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate &);
+    void HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix& pointerTransform, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate &controllerDelegate);
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);
     ~OpenXRInputSource();


### PR DESCRIPTION
This PR fixes a couple of issues with the current gesture to scroll using eye tracking:
1. it allows users to scroll with both hands, initially it was only tied to the right hand
2. it prevents scrolling by moving the eyes. The scroll gesture should be done with the hand or the controller but not with the gaze. The current code scrolls if user moves their eyes up and down while pinching/clicking and holding.

To fix that we pass a new parameter to the Update() method in the input source carrying the transform for the eye gaze. That transform would be used to set the starting point of the scroll action if there is a scroll or the pointer position otherwise.

Methods like Update(), EmulateControllerFromHands() or HandleEyeTrackingScroll() are suffering from bad design decisions and this PR does not improve the situation. In any case that's a different topic and should be addressed in a separate PR.

Tested in:
* Pico 4E (5.11.1)
* Meta Quest Pro (v71)
* Magic Leap 2

Fixes #1571, fixes #1572