### PR TITLE
Move intent filters to VersionCheckActivity

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VersionCheckActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VersionCheckActivity.java
@@ -3,15 +3,8 @@ package com.igalia.wolvic;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
-
-import com.igalia.wolvic.utils.SystemUtils;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.Properties;
 
 public class VersionCheckActivity extends Activity {
     private boolean browserActivityStarted = false;
@@ -24,11 +17,16 @@ public class VersionCheckActivity extends Activity {
         if (platformSystemCheck.isOSVersionCompatible()) {
             Intent receivedIntent = getIntent();
             Bundle extras = receivedIntent.getExtras();
+            Uri data = receivedIntent.getData();
 
             // Start VRBrowserActivity if OS version is compatible
             Intent intent = new Intent(this, VRBrowserActivity.class);
-            if (extras != null)
+            if (extras != null) {
                 intent.putExtras(extras);
+            }
+            if (data != null) {
+                intent.setData(data);
+            }
 
             startActivity(intent);
             browserActivityStarted = true;

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,18 +39,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="com.oculus.intent.category.2D" />
             </intent-filter>
-        </activity>
-        <activity
-            android:name="com.igalia.wolvic.VRBrowserActivity"
-            android:launchMode="singleInstance"
-            android:exported="false"
-            android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
-            android:windowSoftInputMode="stateAlwaysHidden">
-            <!-- Declares Wolvic as a browser app -->
+            <!-- Declares Wolvic as a browser app that can open Web URLs -->
             <intent-filter>
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
-
+                <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="https" />
                 <data android:scheme="http" />
             </intent-filter>
@@ -58,6 +51,7 @@
             <intent-filter>
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+                <action android:name="android.intent.action.VIEW" />
                 <data
                     android:scheme="wolvic"
                     android:host="com.igalia.wolvic" />
@@ -68,6 +62,12 @@
                 <data android:mimeType="text/plain"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.igalia.wolvic.VRBrowserActivity"
+            android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
+            android:exported="false"
+            android:launchMode="singleInstance"
+            android:windowSoftInputMode="stateAlwaysHidden" />
         <service
             android:name="com.igalia.wolvic.crashreporting.CrashReporterService"
             android:exported="false"


### PR DESCRIPTION
`VersionCheckActivity` is the entry point of our application and the only Activity that we export, so it needs to use the intent filters that were previously associated to `VRBrowserActivity`.

These filters declare Wolvic as an application capable of viewing the Web URLs `http://` and `https://` as well as the special custom `wolvic://` links.

`VersionCheckActivity`  also needs to propagate the data received in the original Intent.

See also:
- https://developer.android.com/guide/components/intents-filters 
- https://developer.android.com/training/app-links/deep-linking