### PR TITLE
[META] Add screen orientation landscape for VersionCheckActivity

### DIFF
--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -44,6 +44,11 @@
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>
         <activity
+            android:name=".VersionCheckActivity"
+            android:screenOrientation="landscape"
+            android:exported="true">
+        </activity>
+        <activity
             android:name=".VRBrowserActivity"
             android:launchMode="singleTask"
             android:screenOrientation="landscape"


### PR DESCRIPTION
Meta requires the screen orientation is set to landscape in the Activity that serves as entry point for the app.

In our case, this is VersionCheckActivity.