### PR TITLE
[META] Add eye_tracking feature to manifest

### DIFF
--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -4,6 +4,7 @@
     android:installLocation="auto">
     <uses-feature android:glEsVersion="0x00030001"/>
     <uses-feature android:name="android.hardware.vr.headtracking" android:version="1" android:required="${headtrackingRequired}" />
+    <uses-feature android:name="oculus.software.eye_tracking" />
     <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
     <uses-permission android:name="${permissionToRemove}" tools:node="remove" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove"/>


### PR DESCRIPTION
Since we are declaring the eye tracking permission, Meta also requires that we add the eye tracking feature in the manifest.