### PR TITLE
Sync UI with pinch gesture detection

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -217,6 +217,7 @@ struct BrowserWorld::State {
   bool isApplicationEntitled = false;
 #endif
   TrackedKeyboardRendererPtr trackedKeyboardRenderer;
+  float selectThreshold;
 
   State() : paused(true), glInitialized(false), modelsLoaded(false), env(nullptr), cylinderDensity(0.0f), nearClip(0.1f),
             farClip(300.0f), activity(nullptr), windowsInitialized(false), exitImmersiveRequested(false), loaderDelay(0) {
@@ -531,7 +532,7 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
 
         const float scale = (hitPoint - device->GetHeadTransform().MultiplyPosition(vrb::Vector(0.0f, 0.0f, 0.0f))).Magnitude();
         controller.pointer->SetScale(scale + kPointerSize - controller.selectFactor * kPointerSize);
-        if (controller.selectFactor >= 1.0f)
+        if (controller.selectFactor >= selectThreshold)
           controller.pointer->SetPointerColor(kPointerColorSelected);
         else
           controller.pointer->SetPointerColor(VRBrowser::GetPointerColor());
@@ -936,6 +937,7 @@ BrowserWorld::RegisterDeviceDelegate(DeviceDelegatePtr aDelegate) {
     m.device->SetControllerDelegate(delegate);
     m.device->SetReorientClient(this);
     m.gestures = m.device->GetGestureDelegate();
+    m.selectThreshold = m.device->GetSelectThreshold();
   } else if (previousDevice) {
     m.leftCamera = m.rightCamera = nullptr;
     m.controllers->Reset();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -138,6 +138,7 @@ public:
   virtual void SetImmersiveBlendMode(device::BlendMode) {};
   virtual bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) { return false; };
   virtual void SetHandTrackingEnabled(bool value) {};
+  virtual float GetSelectThreshold() { return 1.f; };
 
 protected:
   DeviceDelegate() {}

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1752,4 +1752,8 @@ void DeviceDelegateOpenXR::SetHandTrackingEnabled(bool value) {
   m.handTrackingEnabled = value;
 }
 
+float DeviceDelegateOpenXR::GetSelectThreshold() {
+  return kClickThreshold;
+}
+
 } // namespace crow

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -79,6 +79,7 @@ public:
   bool ExitApp();
   bool ShouldExitRenderLoop() const;
   void SetImmersiveBlendMode(device::BlendMode) override;
+  float GetSelectThreshold() override;
 
 protected:
   struct State;

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -14,6 +14,10 @@
 
 namespace crow {
 
+// Threshold to consider a trigger value as a click
+// Used when devices don't map the click value for triggers;
+const float kClickThreshold = 0.91f;
+
 #if defined(HVR)
   const vrb::Vector kAverageHeight(0.0f, 1.6f, 0.0f);
 #else

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -10,10 +10,6 @@
 
 namespace crow {
 
-// Threshold to consider a trigger value as a click
-// Used when devices don't map the click value for triggers;
-const float kClickThreshold = 0.91f;
-
 // When doing scrolling with eye tracking we wait until this threshold is reached to start scrolling.
 // Otherwise single (slow) clicks would easily trigger scrolling.
 const XrDuration kEyeTrackingScrollThreshold = 250000000;


### PR DESCRIPTION
When using hand tracking in some systems the pointer was not getting azure (signal of pinching) until the fingers were actually in contact. However for the pinch to happen, there is no need to touch them, once they are close enough we consider them performing the pinch gesture.

The problem was that the code detecting the gesture and the code changing the color of the pointer were not using the same activation thresholds. Actually the color of the pointer was only changed when the pinch gesture was returning 1.0, i.e, fingers touching.