### PR TITLE
Use different props file for Chromium and Gecko

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,13 +179,11 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig getUseDebugSigningOnRelease() ? debug.signingConfig : release.signingConfig
-            buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props.json"'
             buildConfigField "String", "MK_API_KEY", "\"${getMKApiKey()}\""
         }
         debug {
             applicationIdSuffix getDevApplicationIdSuffix()
             pseudoLocalesEnabled true
-            buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props.json"'
             buildConfigField "String", "MK_API_KEY", "\"\""
         }
     }
@@ -359,6 +357,7 @@ android {
                     arguments "-DGECKO=ON"
                 }
             }
+            buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props.json"'
         }
 
         chromium {
@@ -371,6 +370,7 @@ android {
                 }
             }
             buildConfigField "Boolean", "ENABLE_PAGE_ZOOM", "true"
+            buildConfigField 'String', 'PROPS_ENDPOINT', '"https://igalia.github.io/wolvic/props-chromium.json"'
         }
 
         webkit {


### PR DESCRIPTION
The props files are used to store things like the external environments or the autocomplete dictionaries. They're indexed by version number. As Gecko and Chromium backend have temporarily different version numbers, we need to handle them separatedely.