### PR TITLE
Do not hide the hands with no aim and no gesture

### DIFF
--- a/app/src/openxr/cpp/OpenXRGestureManager.cpp
+++ b/app/src/openxr/cpp/OpenXRGestureManager.cpp
@@ -101,10 +101,7 @@ OpenXRGestureManagerFBHandTrackingAim::aimPose(const XrTime predictedDisplayTime
 
 bool
 OpenXRGestureManagerFBHandTrackingAim::systemGestureDetected(const vrb::Matrix& hand, const vrb::Matrix& head) const {
-#ifdef PICOXR
-    // Pico does not correctly implement the SYSTEM_GESTURE_BIT_FB flags.
-    return handFacesHead(hand, head) && !hasAim();
-#elif LYNX
+#if LYNX
     // Lynx does not correctly implement the SYSTEM_GESTURE_BIT_FB and XR_HAND_TRACKING_AIM_VALID_BIT_FB flags (it's always active)
     return handFacesHead(hand, head);
 #else

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -648,11 +648,6 @@ void OpenXRInputSource::EmulateControllerFromHand(device::RenderMode renderMode,
     bool hasAim = mGestureManager->hasAim();
     bool systemGestureDetected = mGestureManager->systemGestureDetected(handJointForAim, head);
 
-    if (!hasAim && !systemGestureDetected && !usingEyeTracking) {
-        delegate.SetEnabled(mIndex, false);
-        return;
-    }
-
     // We should handle the gesture whenever the system does not handle it.
     bool isHandActionEnabled = systemGestureDetected && (!systemTakesOverWhenHandsFacingHead || mHandeness == Left);
     delegate.SetAimEnabled(mIndex, hasAim && pointerMode == DeviceDelegate::PointerMode::TRACKED_POINTER);


### PR DESCRIPTION
There was an early return disabling the hand controller whenever we had no aim and no system gesture was detected. The rationale was that if we have no aim then we must be doing a system gesture.

However that's a false assumption. When the hand is in the process of rotating there is an angle in which there is no aim but also there is no system gesture (the hand is not facing the head). Removing that condition makes the hand not to vanish.

Apart from that we have verified that Pico fixed the bug in the runtime that was preventing the FB aim extension from correctly detecting system gestures. We can safely use it now.

Fixes #1584 