### PR TITLE
Reimplement FB passthrough layer

### DIFF
--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -102,7 +102,6 @@ private:
 #if defined(OCULUSVR) && defined(STORE_BUILD)
   void ProcessOVRPlatformEvents();
 #endif
-  void resetPassthroughLayerIfNeeded();
   State& m;
   BrowserWorld() = delete;
   VRB_NO_DEFAULTS(BrowserWorld)

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -107,7 +107,7 @@ public:
   virtual VRLayerProjectionPtr CreateLayerProjection(VRLayerSurface::SurfaceType aSurfaceType) { return nullptr; }
   virtual VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) { return nullptr; }
   virtual VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) { return nullptr; }
-  virtual VRLayerPassthroughPtr CreateLayerPassthrough() { return nullptr; }
+  virtual void CreateLayerPassthrough() { }
   virtual void DeleteLayer(const VRLayerPtr& aLayer) {};
   virtual bool IsControllerLightEnabled() const { return true; }
   virtual vrb::LoadTask GetControllerModelTask(int32_t index) { return nullptr; } ;
@@ -123,7 +123,7 @@ public:
   };
   void SetReorientClient(ReorientClient* client) { mReorientClient = client; }
   virtual bool IsPassthroughEnabled() const { return mIsPassthroughEnabled; }
-  void TogglePassthroughEnabled() { mIsPassthroughEnabled = !mIsPassthroughEnabled; }
+  virtual void TogglePassthroughEnabled() { mIsPassthroughEnabled = !mIsPassthroughEnabled; }
   virtual bool usesPassthroughCompositorLayer() const { return false; }
   virtual int32_t GetHandTrackingJointIndex(const HandTrackingJoints aJoint) { return -1; };
   virtual void UpdateHandMesh(const uint32_t aControllerIndex, const std::vector<vrb::Matrix>& handJointTransforms,

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -58,7 +58,7 @@ public:
   VRLayerCylinderPtr CreateLayerCylinder(const VRLayerSurfacePtr& aMoveLayer) override;
   VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) override;
   VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) override;
-  VRLayerPassthroughPtr CreateLayerPassthrough() override;
+  void CreateLayerPassthrough() override;
   bool usesPassthroughCompositorLayer() const override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;
   int32_t GetHandTrackingJointIndex(const HandTrackingJoints aJoint) override;
@@ -70,6 +70,7 @@ public:
   bool IsPassthroughEnabled() const override;
   bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) override;
   void SetHandTrackingEnabled(bool value) override;
+  void TogglePassthroughEnabled() override;
   // Custom methods for NativeActivity render loop based devices.
   void BeginXRSession();
   void EnterVR(const crow::BrowserEGLContext& aEGLContext);
@@ -89,6 +90,7 @@ private:
   State& m;
   VRB_NO_DEFAULTS(DeviceDelegateOpenXR)
   void updateEyeGaze();
+  void UpdatePassthrough();
 };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRExtensions.cpp
+++ b/app/src/openxr/cpp/OpenXRExtensions.cpp
@@ -19,6 +19,8 @@ PFN_xrCreatePassthroughFB OpenXRExtensions::sXrCreatePassthroughFB = nullptr;
 PFN_xrDestroyPassthroughFB OpenXRExtensions::sXrDestroyPassthroughFB = nullptr;
 PFN_xrCreatePassthroughLayerFB OpenXRExtensions::sXrCreatePassthroughLayerFB = nullptr;
 PFN_xrDestroyPassthroughLayerFB OpenXRExtensions::sXrDestroyPassthroughLayerFB = nullptr;
+PFN_xrPassthroughLayerResumeFB OpenXRExtensions::sXrPassthroughLayerResumeFB = nullptr;
+PFN_xrPassthroughLayerPauseFB OpenXRExtensions::sXrPassthroughLayerPauseFB = nullptr;
 PFN_xrCreateHandMeshSpaceMSFT OpenXRExtensions::sXrCreateHandMeshSpaceMSFT = nullptr;
 PFN_xrUpdateHandMeshMSFT OpenXRExtensions::sXrUpdateHandMeshMSFT = nullptr;
 PFN_xrCreateKeyboardSpaceFB OpenXRExtensions::xrCreateKeyboardSpaceFB = nullptr;
@@ -120,6 +122,10 @@ void OpenXRExtensions::LoadExtensions(XrInstance instance) {
                                           reinterpret_cast<PFN_xrVoidFunction *>(&sXrCreatePassthroughLayerFB)));
         CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrDestroyPassthroughLayerFB",
                                           reinterpret_cast<PFN_xrVoidFunction *>(&sXrDestroyPassthroughLayerFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrPassthroughLayerResumeFB",
+                                          reinterpret_cast<PFN_xrVoidFunction *>(&sXrPassthroughLayerResumeFB)));
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrPassthroughLayerPauseFB",
+                                            reinterpret_cast<PFN_xrVoidFunction *>(&sXrPassthroughLayerPauseFB)));
     }
 
     if (IsExtensionSupported(XR_FB_KEYBOARD_TRACKING_EXTENSION_NAME)) {

--- a/app/src/openxr/cpp/OpenXRExtensions.h
+++ b/app/src/openxr/cpp/OpenXRExtensions.h
@@ -33,6 +33,8 @@ namespace crow {
     static PFN_xrDestroyPassthroughFB sXrDestroyPassthroughFB;
     static PFN_xrCreatePassthroughLayerFB sXrCreatePassthroughLayerFB;
     static PFN_xrDestroyPassthroughLayerFB sXrDestroyPassthroughLayerFB;
+    static PFN_xrPassthroughLayerResumeFB sXrPassthroughLayerResumeFB;
+    static PFN_xrPassthroughLayerPauseFB sXrPassthroughLayerPauseFB;
 
     static PFN_xrCreateHandMeshSpaceMSFT sXrCreateHandMeshSpaceMSFT;
     static PFN_xrUpdateHandMeshMSFT sXrUpdateHandMeshMSFT;

--- a/app/src/openxr/cpp/OpenXRLayers.cpp
+++ b/app/src/openxr/cpp/OpenXRLayers.cpp
@@ -244,46 +244,36 @@ OpenXRLayerEquirect::Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwap
 // OpenXRLayerPassthrough;
 
 OpenXRLayerPassthroughPtr
-OpenXRLayerPassthrough::Create(const VRLayerPassthroughPtr& aLayer, XrPassthroughFB passthroughInstance) {
+OpenXRLayerPassthrough::Create(XrPassthroughFB passthroughInstance) {
   auto result = std::make_shared<OpenXRLayerPassthrough>();
-  result->layer = aLayer;
   result->mPassthroughInstance = passthroughInstance;
 
   return result;
 }
 
 void
-OpenXRLayerPassthrough::Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) {
+OpenXRLayerPassthrough::Init(XrSession session) {
   XrPassthroughLayerCreateInfoFB layerCreateInfo = {
     .type = XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB,
     .passthrough = mPassthroughInstance,
-    .flags = XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
     .purpose = XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB
   };
   CHECK_XRCMD(OpenXRExtensions::sXrCreatePassthroughLayerFB(session, &layerCreateInfo, &mPassthroughLayerHandle));
-  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Init(aEnv, session, aContext);
-}
-
-void
-OpenXRLayerPassthrough::Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) {
   xrCompositionLayer = {
-          .type = XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB,
-          .next = XR_NULL_HANDLE,
-          .flags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT,
-          .space = XR_NULL_HANDLE,
-          .layerHandle = mPassthroughLayerHandle,
+    .type = XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB,
+    .next = XR_NULL_HANDLE,
+    .flags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT,
+    .space = XR_NULL_HANDLE,
+    .layerHandle = mPassthroughLayerHandle,
   };
-  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Update(aSpace, aReorientPose, aClearSwapChain);
 }
 
-void
-OpenXRLayerPassthrough::Destroy() {
+OpenXRLayerPassthrough::~OpenXRLayerPassthrough() {
   if (mPassthroughLayerHandle == XR_NULL_HANDLE)
     return;
 
   CHECK_XRCMD(OpenXRExtensions::sXrDestroyPassthroughLayerFB(mPassthroughLayerHandle));
   mPassthroughLayerHandle = XR_NULL_HANDLE;
-  OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB>::Destroy();
 }
 
 }

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -93,16 +93,13 @@ public:
     }
 
     for (uint i = 0; i < numXRLayers; ++i) {
-      // We have to explicitly cast to XrCompositionLayerBaseHeader because the
-      // XrCompositionLayerPassthroughFB structure used "flags" instead of "layerFlags". It's still
-      // a XrCompositionLayerBaseHeader though because the structs are binary compatible.
-      XrCompositionLayerBaseHeader* xrLayer = (XrCompositionLayerBaseHeader*) &xrLayers[i];
-      xrLayer->layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
-      xrLayer->space = aSpace;
-      xrLayer->next = XR_NULL_HANDLE;
+      auto& xrLayer = xrLayers[i];
+      xrLayer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+      xrLayer.space = aSpace;
+      xrLayer.next = XR_NULL_HANDLE;
 
       if (mCompositionLayerColorScaleBias != XR_NULL_HANDLE)
-        PushNextXrStructureInChain((XrBaseInStructure&)*xrLayer, (XrBaseInStructure&)*mCompositionLayerColorScaleBias);
+        PushNextXrStructureInChain((XrBaseInStructure&)xrLayer, (XrBaseInStructure&)*mCompositionLayerColorScaleBias);
     }
   }
 
@@ -418,17 +415,15 @@ public:
 class OpenXRLayerPassthrough;
 typedef std::shared_ptr<OpenXRLayerPassthrough> OpenXRLayerPassthroughPtr;
 
-class OpenXRLayerPassthrough : public OpenXRLayerBase<VRLayerPassthroughPtr, XrCompositionLayerPassthroughFB> {
+class OpenXRLayerPassthrough {
   public:
     XrCompositionLayerPassthroughFB xrCompositionLayer;
 
-    static OpenXRLayerPassthroughPtr
-    Create(const VRLayerPassthroughPtr& aLayer, XrPassthroughFB);
-    void Init(JNIEnv *aEnv, XrSession session, vrb::RenderContextPtr &aContext) override;
-    void Update(XrSpace aSpace, const XrPosef &aReorientPose, XrSwapchain aClearSwapChain) override;
-    void Destroy() override;
-    bool IsDrawRequested() const override { return layer->IsDrawRequested(); };
+    static OpenXRLayerPassthroughPtr Create(XrPassthroughFB);
+    void Init(XrSession session);
     bool IsValid() const { return mPassthroughLayerHandle != XR_NULL_HANDLE; }
+    XrPassthroughLayerFB GetPassthroughLayerHandle() const { return mPassthroughLayerHandle; }
+    ~OpenXRLayerPassthrough();
 
 private:
     XrPassthroughFB mPassthroughInstance;

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -92,8 +92,7 @@ public:
         mCompositionLayerColorScaleBiasStruct.colorScale = {tintColor.Red(), tintColor.Green(), tintColor.Blue(), tintColor.Alpha()};
     }
 
-    for (uint i = 0; i < numXRLayers; ++i) {
-      auto& xrLayer = xrLayers[i];
+    for (auto& xrLayer : xrLayers) {
       xrLayer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
       xrLayer.space = aSpace;
       xrLayer.next = XR_NULL_HANDLE;

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.cpp
@@ -8,7 +8,7 @@
 namespace crow {
 
 OpenXRLayerPassthroughPtr
-OpenXRPassthroughStrategy::createLayerIfSupported(VRLayerPassthroughPtr) const {
+OpenXRPassthroughStrategy::createLayerIfSupported() const {
     VRB_ERROR("asking to create a layer for passthrough when it isn't actually supported");
     return nullptr;
 };
@@ -66,8 +66,8 @@ OpenXRPassthroughStrategyFBExtension::isReady() const {
 }
 
 OpenXRLayerPassthroughPtr
-OpenXRPassthroughStrategyFBExtension::createLayerIfSupported(VRLayerPassthroughPtr vrLayer) const {
-    return OpenXRLayerPassthrough::Create(vrLayer, passthroughHandle);
+OpenXRPassthroughStrategyFBExtension::createLayerIfSupported() const {
+    return OpenXRLayerPassthrough::Create(passthroughHandle);
 }
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
+++ b/app/src/openxr/cpp/OpenXRPassthroughStrategy.h
@@ -18,7 +18,7 @@ virtual bool usesCompositorLayer() const { return false; }
 virtual HandleEventResult handleEvent(const XrEventDataBaseHeader&) { return HandleEventResult::NoError; };
 virtual ~OpenXRPassthroughStrategy() = default;
 virtual bool isReady() const { return mIsInErrorState; };
-virtual OpenXRLayerPassthroughPtr createLayerIfSupported(VRLayerPassthroughPtr) const;
+virtual OpenXRLayerPassthroughPtr createLayerIfSupported() const;
 protected:
 bool mIsInErrorState { false };
 };
@@ -34,7 +34,7 @@ void initializePassthrough(XrSession) override;
 bool usesCompositorLayer() const override { return true; }
 HandleEventResult handleEvent(const XrEventDataBaseHeader&) override;
 bool isReady() const override;
-OpenXRLayerPassthroughPtr createLayerIfSupported(VRLayerPassthroughPtr) const override;
+OpenXRLayerPassthroughPtr createLayerIfSupported() const override;
 
 XrPassthroughFB passthroughHandle { XR_NULL_HANDLE };
 };


### PR DESCRIPTION
The current code enables FB passthrough and the passthrough layer on start if supported by the runtime. Instead of doing that, we can create both the passthrough handler and the passthrough layer and activate them on deman. This will be done for WebXR AR experiences and also when activating passthrough in the 3 dots menu.

Apart from that we've removed a lot of the boilerplate that was not really needed. The code used to threat the passthrough layer as any other compositor layer that had to be integrated into the VRB scenegraph. The passthrough layer is a compositor layer that has nothing to do with Wolvic's scenegraph, and thus, does not need to be wrapped by a VRLayer nor added as a node.

There should not be any visual changes from the user POV. However it would allow us to to have things like issue #1351 in the future.