### PR TITLE
Migrate some gradle configs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -613,6 +613,7 @@ android {
         viewBinding true
         prefab true // enable prefab support for various SDK AAR
         dataBinding true
+        buildConfig true
     }
 
     lint {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath "org.mozilla.telemetry:glean-gradle-plugin:56.1.0"
         classpath "com.android.tools.build:gradle:$versions.android_gradle_plugin"
-        classpath 'com.android.tools:r8:8.5.35'
+        classpath 'com.android.tools:r8:8.7.14'
         classpath "$deps.kotlin.plugin"
         classpath 'com.huawei.agconnect:agcp:1.9.1.301'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,5 @@ android.injected.testOnly=false
 android.useAndroidX=true
 android.enableJetifier=true
 
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
This commit fixes 2 issues
* R8 version was different to the one configured in the plugin
* android.defaults.buildfeatures.buildconfig is deprecated and to be removed in gradle 9.0

For the former we just need to upgrade the version. For the latter it's a matter of moving the configuration option from gradle properties to the app module build.gradle.