### PR TITLE
Implement the onWebAppManifest abstract method

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsDelegate.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsDelegate.java
@@ -76,6 +76,9 @@ public class TabWebContentsDelegate extends WolvicWebContentsDelegate {
         }
     }
 
+    @Override
+    public void onWebAppManifest(WebContents webContents, @NonNull String manifest) {}
+
     public class OnNewSessionCallback implements WSession.NavigationDelegate.OnNewSessionCallback {
         public OnNewSessionCallback(RuntimeImpl runtime, WebContents webContents) {
             mRuntime = runtime;


### PR DESCRIPTION
The WolvicWebContenstDelegate abstrac class defines the onWebAppManifest method that our TabWebContenstDelegate must implement.

This is a dummy implementation, just to fix the build error caused by the PR#135 [1]

[1] https://github.com/Igalia/wolvic-chromium/pull/135