### PR TITLE
Add noCompress for 'dat' resources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -621,6 +621,9 @@ android {
     }
     androidResources {
         noCompress 'pak'
+        noCompress 'ja'
+        noCompress 'dat'
+        noCompress 'bin'
     }
 
 }


### PR DESCRIPTION
In 63e622fe4 we have replaced the 'aaptOptions' directive with 'androidResources', but we also removed 'noCompress' entries for *.dat, *.ja and *.bin extensions.

The Chromium backend APK should contains a filed called 'icudtl.dat' that Wolvic is not able to load because it's compressed, due to the lack of the noCompress entry for that extension.

Fixes  #1622 