### PR TITLE
Add Quest3S support

### DIFF
--- a/app/src/main/cpp/DeviceUtils.cpp
+++ b/app/src/main/cpp/DeviceUtils.cpp
@@ -133,6 +133,8 @@ device::DeviceType DeviceUtils::GetDeviceTypeFromSystem(bool is6DoF) {
         deviceNamesMap.emplace("Quest", device::OculusQuest);
         deviceNamesMap.emplace("Quest 2", device::OculusQuest2);
         deviceNamesMap.emplace("Quest 3", device::MetaQuest3);
+        // So far no need to differentiate between Quest 3 and Quest 3S
+        deviceNamesMap.emplace("Quest 3S", device::MetaQuest3);
         // So far no need to differentiate between Pico4 and Pico4E
         deviceNamesMap.emplace("A8110", device::Pico4x);
         deviceNamesMap.emplace("A9210", device::Pico4U);


### PR DESCRIPTION
We can reuse the Quest3 infra because the controllers are almost the same (if not identical) so there is no need to add a new device type, controller 3D models, etc...

Fixes #1611

(haven't actually tried on a device but quite confident it works)