### PR TITLE
Add a move bar widget

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1388,10 +1388,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Keep
     @SuppressWarnings("unused")
     public void resetWindowsPosition() {
-        // Reset the position of the windows when we are not in headlock and window movement is enabled.
-        if (!mSettings.isHeadLockEnabled() && mSettings.isWindowMovementEnabled()) {
-            runOnUiThread(() -> mWindows.resetWindowsPosition());
-        }
+        // Reset the position of the windows when we are not in headlock.
+        if (mSettings.isHeadLockEnabled())
+            return;
+        runOnUiThread(() -> mWindows.resetWindowsPosition());
     }
 
     @Keep

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -391,19 +391,6 @@ public class SettingsStore {
         editor.apply();
     }
 
-    public boolean isWindowMovementEnabled() {
-        return mPrefs.getBoolean(
-                mContext.getString(R.string.settings_key_window_movement), WINDOW_MOVEMENT_DEFAULT);
-    }
-
-    public void setWindowMovementEnabled(boolean isEnabled) {
-        SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putBoolean(mContext.getString(R.string.settings_key_window_movement), isEnabled);
-        editor.apply();
-
-        mSettingsViewModel.setWindowMovementEnabled(isEnabled);
-    }
-
     public boolean isEnvironmentOverrideEnabled() {
         return mPrefs.getBoolean(
                 mContext.getString(R.string.settings_key_environment_override), ENV_OVERRIDE_DEFAULT);

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
@@ -32,7 +32,6 @@ public class SettingsViewModel extends AndroidViewModel {
     private MutableLiveData<String> propsVersionName;
     private MutableLiveData<Map<String, RemoteProperties>> props;
     private MutableLiveData<ObservableBoolean> isWhatsNewVisible;
-    private MutableLiveData<ObservableBoolean> isWindowMovementEnabled;
 
     public SettingsViewModel(@NonNull Application application) {
         super(application);
@@ -44,7 +43,6 @@ public class SettingsViewModel extends AndroidViewModel {
         propsVersionName = new MutableLiveData<>();
         props = new MutableLiveData<>(Collections.emptyMap());
         isWhatsNewVisible = new MutableLiveData<>(new ObservableBoolean(false));
-        isWindowMovementEnabled = new MutableLiveData<>(new ObservableBoolean(false));
 
         propsVersionName.observeForever(props -> isWhatsNewVisible());
         props.observeForever(versionName -> isWhatsNewVisible());
@@ -66,9 +64,6 @@ public class SettingsViewModel extends AndroidViewModel {
 
         String appVersionName = SettingsStore.getInstance(getApplication().getBaseContext()).getRemotePropsVersionName();
         propsVersionName.postValue(appVersionName);
-
-        boolean windowMovementVisible = SettingsStore.getInstance(getApplication().getBaseContext()).isWindowMovementEnabled();
-        isWindowMovementEnabled.postValue(new ObservableBoolean(windowMovementVisible));
     }
 
     private void isWhatsNewVisible() {
@@ -108,14 +103,6 @@ public class SettingsViewModel extends AndroidViewModel {
 
     public MutableLiveData<ObservableBoolean> getIsWebXREnabled() {
         return isWebXREnabled;
-    }
-
-    public void setWindowMovementEnabled(boolean isEnabled) {
-        this.isWindowMovementEnabled.setValue(new ObservableBoolean(isEnabled));
-    }
-
-    public MutableLiveData<ObservableBoolean> isWindowMovementEnabled() {
-        return isWindowMovementEnabled;
     }
 
     public void setPropsVersionName(String appVersionName) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -10,11 +10,14 @@ import static com.igalia.wolvic.db.SitePermission.SITE_PERMISSION_POPUP;
 import static com.igalia.wolvic.db.SitePermission.SITE_PERMISSION_TRACKING;
 import static com.igalia.wolvic.ui.widgets.menus.VideoProjectionMenuWidget.VIDEO_PROJECTION_NONE;
 
+import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
+import android.graphics.PorterDuff;
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import androidx.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -134,6 +137,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
     private WidgetPlacement mBeforeFullscreenPlacement;
     private float mSavedCylinderDensity = 0.0f;
     private Animation mAnimation;
+    private ValueAnimator mMoveBarAnimator;
 
     private class MoveTouchListener implements OnTouchListener {
         @Override
@@ -326,7 +330,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             }
         });
 
-        mBinding.navigationBarNavigation.moveButton.setOnTouchListener(new MoveTouchListener());
+        mBinding.navigationBarNavigation.moveBar.setOnTouchListener(new MoveTouchListener());
         mBinding.navigationBarFullscreen.fullScreenMoveButton.setOnTouchListener(new MoveTouchListener());
 
         mBinding.navigationBarNavigation.menuButton.setOnClickListener(view -> {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -1388,17 +1388,18 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             for (WindowWidget win: getCurrentWindows()) {
                 setWindowVisible(win, win == mFullscreenWindow);
             }
-            updateMaxWindowScales();
-            updateViews();
-        } else if (mFullscreenWindow != null) {
+        } else {
+            if (mFullscreenWindow == null)
+                return;
             aWindow.restoreBeforeFullscreenPlacement();
             mFullscreenWindow = null;
             for (WindowWidget win : getCurrentWindows()) {
                 setWindowVisible(win, true);
             }
-            updateMaxWindowScales();
-            updateViews();
         }
+        updateMaxWindowScales();
+        updateCurvedMode(true);
+
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -107,9 +107,6 @@ class DisplayOptionsView extends SettingsView {
         mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
         setHeadLock(SettingsStore.getInstance(getContext()).isHeadLockEnabled(), false);
 
-        mBinding.windowMovementSwitch.setOnCheckedChangeListener(mWindowMovementListener);
-        setWindowMovement(SettingsStore.getInstance(getContext()).isWindowMovementEnabled(), false);
-
         mDefaultHomepageUrl = getContext().getString(R.string.HOMEPAGE_URL);
 
         mBinding.homepageEdit.setHint1(getContext().getString(R.string.homepage_hint, getContext().getString(R.string.app_name)));
@@ -203,10 +200,6 @@ class DisplayOptionsView extends SettingsView {
         setHeadLock(value, true);
     };
 
-    private SwitchSetting.OnCheckedChangeListener mWindowMovementListener = (compoundButton, enabled, apply) -> {
-        setWindowMovement(enabled, true);
-    };
-
     private OnClickListener mHomepageListener = (view) -> {
         if (!mBinding.homepageEdit.getFirstText().isEmpty()) {
             setHomepage(mBinding.homepageEdit.getFirstText());
@@ -284,7 +277,6 @@ class DisplayOptionsView extends SettingsView {
         setSoundEffect(SettingsStore.AUDIO_ENABLED, true);
         setLatinAutoComplete(SettingsStore.LATIN_AUTO_COMPLETE_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
-        setWindowMovement(SettingsStore.WINDOW_MOVEMENT_DEFAULT, true);
         setWindowDistance(SettingsStore.WINDOW_DISTANCE_DEFAULT, true);
 
         if (mBinding.startWithPassthroughSwitch.isChecked() != SettingsStore.shouldStartWithPassthrougEnabled()) {
@@ -360,12 +352,6 @@ class DisplayOptionsView extends SettingsView {
         if (doApply) {
             settingsStore.setHeadLockEnabled(value);
         }
-
-        if (value && settingsStore.isWindowMovementEnabled()) {
-            // Disable window movement if head lock is enabled,
-            // otherwise the windows might be moved out of the user's reach.
-            setWindowMovement(false, true);
-        }
     }
 
     private void setSoundEffect(boolean value, boolean doApply) {
@@ -376,23 +362,6 @@ class DisplayOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setAudioEnabled(value);
             AudioEngine.fromContext(getContext()).setEnabled(value);
-        }
-    }
-
-    private void setWindowMovement(boolean value, boolean doApply) {
-        mBinding.windowMovementSwitch.setOnCheckedChangeListener(null);
-        mBinding.windowMovementSwitch.setValue(value, false);
-        mBinding.windowMovementSwitch.setOnCheckedChangeListener(mWindowMovementListener);
-
-        SettingsStore settingsStore = SettingsStore.getInstance(getContext());
-        if (doApply) {
-            settingsStore.setWindowMovementEnabled(value);
-        }
-
-        if (value && settingsStore.isHeadLockEnabled()) {
-            // Disable head lock if window movement is enabled,
-            // otherwise the windows might be moved out of the user's reach.
-            setHeadLock(false, true);
         }
     }
 

--- a/app/src/main/res/drawable/rounded_line.xml
+++ b/app/src/main/res/drawable/rounded_line.xml
@@ -4,8 +4,6 @@
             <solid android:color="@color/ocean" />
             <corners android:radius="5dp" />
             <size android:height="5dp" />
-            <!-- 50% opacity @color/asphalt -->
-
         </shape>
     </item>
     <item android:state_hovered="true">
@@ -13,7 +11,6 @@
             <solid android:color="@color/azure" />
             <corners android:radius="5dp" />
             <size android:height="5dp" />
-
         </shape>
     </item>
     <item>
@@ -21,7 +18,6 @@
             <solid android:color="@color/fog" />
             <corners android:radius="5dp" />
             <size android:height="5dp" />
-
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/rounded_line.xml
+++ b/app/src/main/res/drawable/rounded_line.xml
@@ -1,0 +1,27 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="@color/ocean" />
+            <corners android:radius="5dp" />
+            <size android:height="5dp" />
+            <!-- 50% opacity @color/asphalt -->
+
+        </shape>
+    </item>
+    <item android:state_hovered="true">
+        <shape>
+            <solid android:color="@color/azure" />
+            <corners android:radius="5dp" />
+            <size android:height="5dp" />
+
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@color/fog" />
+            <corners android:radius="5dp" />
+            <size android:height="5dp" />
+
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/navigation_bar_fullscreen.xml
+++ b/app/src/main/res/layout/navigation_bar_fullscreen.xml
@@ -51,7 +51,7 @@
                 android:src="@drawable/ic_icon_move"
                 android:tooltipText="@string/move_tooltip"
                 app:privateMode="@{viewmodel.isPrivateSession}"
-                app:visibleGone="@{settingsmodel.isWindowMovementEnabled &amp;&amp; viewmodel.isCurved}" />
+                app:visibleGone="@{viewmodel.isCurved}" />
 
             <com.igalia.wolvic.ui.views.UIButton
                 android:id="@+id/brightnessButton"

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -170,6 +170,7 @@
                 android:layout_height="8dp"
                 android:layout_gravity="center"
                 android:background="@drawable/rounded_line"
+                android:duplicateParentState="true"
                 android:radius="4dp" />
         </FrameLayout>
 

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -11,8 +11,16 @@
             name="settingsmodel"
             type="com.igalia.wolvic.ui.viewmodel.SettingsViewModel" />
     </data>
+
     <LinearLayout
         android:id="@+id/navigationBarContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="0dp">
+
+    <!-- Navigation bar -->
+    <LinearLayout
         style="?attr/navigationBarStyle"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -136,16 +144,6 @@
         </RelativeLayout>
 
         <com.igalia.wolvic.ui.views.UIButton
-            android:id="@+id/moveButton"
-            style="?attr/navigationBarButtonStyle"
-            android:layout_marginStart="10dp"
-            android:layout_weight="0"
-            android:src="@drawable/ic_icon_move"
-            android:tooltipText="@string/move_tooltip"
-            app:privateMode="@{viewmodel.isPrivateSession}"
-            app:visibleGone="@{settingsmodel.isWindowMovementEnabled &amp;&amp; viewmodel.isCurved}" />
-
-        <com.igalia.wolvic.ui.views.UIButton
             android:id="@+id/menuButton"
             style="?attr/navigationBarButtonStyle"
             android:layout_marginStart="10dp"
@@ -153,5 +151,27 @@
             android:src="@drawable/ic_icon_hamburger_menu"
             android:tooltipText="@string/hamburger_menu_tooltip"
             app:privateMode="@{viewmodel.isPrivateSession}"/>
+    </LinearLayout>
+
+    <!-- Horizontal Divider -->
+        <FrameLayout
+            android:clickable="true"
+            android:id="@+id/moveBar"
+            android:radius="4dp"
+            android:layout_margin="10dp"
+            android:layout_width="128dp"
+            android:layout_height="32dp"
+            android:tooltipText="@string/move_tooltip"
+            android:layout_gravity="center_horizontal"
+            app:visibleGone="@{viewmodel.isCurved}">
+
+            <View
+                android:layout_width="@dimen/move_bar_width"
+                android:layout_height="8dp"
+                android:layout_gravity="center"
+                android:background="@drawable/rounded_line"
+                android:radius="4dp" />
+        </FrameLayout>
+
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -149,12 +149,6 @@
                     android:layout_height="wrap_content"
                     app:description="@string/display_options_head_lock" />
 
-                <com.igalia.wolvic.ui.views.settings.SwitchSetting
-                    android:id="@+id/windowMovementSwitch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/display_options_windows_can_move" />
-
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1679,7 +1679,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n
 \nVIGTIGT: Medmindre du bruger Sync, vil den nye Wolvic-app ikke have dine bogmærker og faner.</string>
     <string name="developer_options_center_windows">Centrer vinduer vertikalt</string>
-    <string name="display_options_windows_can_move">Træk for at flytte vinduer</string>
     <string name="controller_options_haptic_feedback">Haptisk feedback</string>
     <string name="security_options_permission_fine_location_warning">Wolvic kan kun få din omtrentlige placering. Dette kan ændres i systemindstillingerne.</string>
     <string name="voice_input_start">Hvad vil du gerne have input til?</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -444,10 +444,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">Start with Passthrough Mode</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">Drag to move windows</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Use Sound Effects</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1789,7 +1789,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="display_options_start_with_passthrough">Usar el modo Passthrough al iniciar</string>
     <string name="tray_wifi_unavailable_ssid">SSID no disponible</string>
     <string name="voice_input_start">¿Qué te gustaría introducir?</string>
-    <string name="display_options_windows_can_move">Las ventanas se pueden mover</string>
     <string name="display_options_latin_auto_complete">Autocompletado con el teclado latino</string>
     <string name="display_options_head_lock">Activar Head Lock</string>
     <string name="controller_options_haptic_feedback">Feedback táctil</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1334,10 +1334,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">Iniciar en modo Passthrough</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">Las ventanas pueden moverse</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Usar efectos sonoros</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1563,7 +1563,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="developer_options_ua_vr">VR</string>
     <string name="developer_options_center_windows">Keskitä ikkunat pystysuoraan</string>
     <string name="display_options_head_lock">Ota päälukko käyttöön</string>
-    <string name="display_options_windows_can_move">Siirrä ikkunaa raahamalla</string>
     <string name="display_options_sound_effect">Käytä äänitehosteita</string>
     <string name="display_options_latin_auto_complete">Latinalaisen näppäimistön automaattinen täydennys</string>
     <string name="display_options_windows_distance">Ikkunan etäisyys</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1805,7 +1805,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="experimental_features">Fonctionnalités expérimentales</string>
     <string name="controller_options_haptic_feedback">Retour haptique</string>
     <string name="developer_options_center_windows">Centrer les fenêtres verticalement</string>
-    <string name="display_options_windows_can_move">Glisser pour déplacer les fenêtres</string>
     <string name="fxa_account_options_device_name">Nom de l\'appareil</string>
     <string name="device_name">%1$s sur %2$s</string>
     <string name="permission_rationale_title">Permissions supplémentaires</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -332,7 +332,6 @@
     <string name="history_context_add_bookmarks">Engadir aos marcadores</string>
     <string name="history_context_remove_bookmarks">Eliminar dos marcadores</string>
     <string name="download_context_delete">Borrar</string>
-    <string name="display_options_windows_can_move">As xanelas poden moverse</string>
     <string name="display_options_sound_effect">Usar efectos de son</string>
     <string name="display_options_head_lock">Activar Head Lock</string>
     <string name="display_options_windows_distance">Distancia das xanelas</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1688,7 +1688,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n\t•Wolvicの一部の機能はウェブ情報サービスを利用しています。そのサービスの信憑性やエラーの有無は保証できません。この機能に関する詳細（ウェブ情報サービスを利用する機能を不有効にする方法なども含み）は以下の利用規約に記述されています。</string>
     <string name="terms_service_subtitle_2">Wolvicウェブ情報サービス</string>
     <string name="developer_options_center_windows">ウィンドウを上下中央揃えにする</string>
-    <string name="display_options_windows_can_move">ウィンドウのドラッグを有効にする</string>
     <string name="display_options_sound_effect">効果音を使う</string>
     <string name="display_options_latin_auto_complete">ラテン文字キーボード入力の自動補完</string>
     <string name="display_options_head_lock">ヘッドロックを有効にする</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1796,7 +1796,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="video_mode_3d_top_bottom">3D 상하 화면</string>
     <string name="clear_user_data_dialog_text">%1$s이 초기화 됩니다. 동기화하지 않은 경우, 저장된 로그인 정보, 방문 기록과 북마크를 포함한 모든 데이터가 완전히 삭제됩니다. %1$s은 초기화가 완료된 후 자동으로 종료됩니다. 계속하시겠습니까?</string>
     <string name="security_options_use_system_root_ca">시스템에서 신뢰할 수 있는 루트 인증서 사용</string>
-    <string name="display_options_windows_can_move">드래그로 창 이동하기</string>
     <string name="display_options_latin_auto_complete">라틴어 키보드 입력 시 자동 완성</string>
     <string name="display_options_windows_distance">창 간 거리</string>
     <string name="controller_options_haptic_feedback">햅틱 피드백</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -768,7 +768,6 @@
     <string name="device_name">%1$s em %2$s</string>
     <string name="move_tooltip">Mover</string>
     <string name="developer_options_center_windows">Centralizar Janelas Verticalmente</string>
-    <string name="display_options_windows_can_move">Arraste para mover janelas</string>
     <string name="display_options_sound_effect">Usar efeitos sonoros</string>
     <string name="display_options_latin_auto_complete">Teclado em Latim com Autocompletar</string>
     <string name="display_options_head_lock">Habilitar bloqueio de cabeça</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -433,7 +433,6 @@
     <string name="developer_options_msaa_disabled">Desativado</string>
     <string name="settings_accounts_sign_out">Sair</string>
     <string name="developer_options_center_windows">Centralizar as Janelas Verticalmente</string>
-    <string name="display_options_windows_can_move">Arrastar para mover janelas</string>
     <string name="display_options_sound_effect">Usar efeitos sonoros</string>
     <string name="display_options_windows_distance">Distância das janelas</string>
     <string name="experimental_features">Funcionalidades experimentais</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1667,7 +1667,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_addon_install_blocked">Установка локального дополнения заблокирована</string>
     <string name="voice_service_metkai">MeetKai</string>
     <string name="developer_options_center_windows">Центрировать окна по вертикали</string>
-    <string name="display_options_windows_can_move">Передвигать окна перетаскиванием</string>
     <string name="display_options_sound_effect">Использовать звуковые эффекты</string>
     <string name="display_options_start_with_passthrough">Начинать в режиме Passthrough</string>
     <string name="display_options_latin_auto_complete">Автодополнение слов для латинской клавиатуры</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -1804,7 +1804,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="controller_options_haptic_feedback">Haptisk feedback</string>
     <string name="fxa_account_options_device_name">Enhetsnamn</string>
     <string name="move_tooltip">Flytta</string>
-    <string name="display_options_windows_can_move">Dra för att flytta fönster</string>
     <string name="display_options_sound_effect">Använd ljudeffekter</string>
     <string name="display_options_windows_distance">Fönster distans</string>
     <string name="display_options_latin_auto_complete">Latinsk tangentbordsinmatning Automatisk komplettering</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -778,7 +778,6 @@
     <string name="fxa_account_options_device_name">Найменування пристрою</string>
     <string name="experimental_features">Експериментальні можливості</string>
     <string name="move_tooltip">Перемістити</string>
-    <string name="display_options_windows_can_move">Перетягування для переміщення вікон</string>
     <string name="display_options_sound_effect">Використовувати звукові ефекти</string>
     <string name="device_name">%1$s на %2$s</string>
     <string name="hamburger_menu_zoom">Масштабування</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -346,9 +346,6 @@
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">启动时使用直通模式</string>
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">拖拽移动窗口</string>
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">使用音效</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -446,10 +446,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">啟動時使用直通模式</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">拖拽移動視窗</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">使用音效</string>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -16,10 +16,12 @@
 
     <!-- Navigation bar -->
     <dimen name="navigation_bar_width">720dp</dimen>
-    <dimen name="navigation_bar_height">44dp</dimen>
+    <dimen name="navigation_bar_height">74dp</dimen>
     <dimen name="url_bar_item_width">28dp</dimen>
     <dimen name="url_bar_first_item_width">36dp</dimen>
     <dimen name="url_bar_last_item_width">36dp</dimen>
+    <dimen name="move_bar_width">60dp</dimen>
+    <dimen name="move_bar_hover_width">80dp</dimen>
 
     <!-- Title bar -->
     <dimen name="title_bar_width">300dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,10 +499,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">Start with Passthrough Mode</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">Drag to move windows</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Use Sound Effects</string>


### PR DESCRIPTION
This widget replaces the experimental move windows button that could be enabled from the Display Settings. That button was shown in the navigation bar and was a bit weird to use.

This PR replaces it with a thing semi-transparent bar that when dragged moves the window in the horizontal direction as the old button used to do. That bar is unconditionally shown when in curved mode.