### PR TITLE
Use the widget name from widget placement

### DIFF
--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -70,7 +70,7 @@ struct Widget::State {
   void Initialize(const int aHandle, const WidgetPlacementPtr& aPlacement, const int32_t aTextureWidth, const int32_t aTextureHeight,
                   const QuadPtr& aQuad, const CylinderPtr& aCylinder) {
     handle = (uint32_t)aHandle;
-    name = "crow::Widget-" + std::to_string(handle);
+    name = aPlacement->name + '_' + std::to_string(handle);
     vrb::RenderContextPtr render = context.lock();
     if (!render) {
       return;


### PR DESCRIPTION
The WidgetPlacement structure contains the name of the widget. When building the name for the native widgets we were using a combination of "Widget-" prefix + the widget handle. That was not useful at all for debugging as it was not possible to differentiate between widgets by name.

Instead it's much better to use the widget name that is passed in WidgetPlacement. That way we can identify whether a widget is a TrayWidget, a WindowWidget... We keep the widget handle in the name as it's useful to differentiate widgets that may have multiple instances (like Windows for example).