### PR TITLE
[OpenXR] Do not crash if FB keyboard extension does not work

### DIFF
--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -227,7 +227,8 @@ void OpenXRInput::UpdateTrackedKeyboard(const XrFrameState& frameState, XrSpace 
     .flags = XR_KEYBOARD_TRACKING_QUERY_LOCAL_BIT_FB,
   };
   XrKeyboardTrackingDescriptionFB kbdDesc;
-  CHECK_XRCMD(OpenXRExtensions::xrQuerySystemTrackedKeyboardFB(mSession, &queryInfo, &kbdDesc));
+  if (XR_FAILED(OpenXRExtensions::xrQuerySystemTrackedKeyboardFB(mSession, &queryInfo, &kbdDesc)))
+    return;
 
   // Check if existing keyboard disappeared or changed, and clear up its state if so
   if ((kbdDesc.flags & XR_KEYBOARD_TRACKING_EXISTS_BIT_FB) == 0 ||


### PR DESCRIPTION
The XR_FB_keyboard_tracking extension is deprecated and won't work starting on MetaOS v72. We should replace it by others like XR_META_dynamic_object_tracker for example.

In the meantime we should bailout instead of asserting to avoid a crash that should not happen anyway.