### PR TITLE
Enable full screen mode for 2D browsing

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1348,6 +1348,11 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             }
 
             @Override
+            public void onFullScreen() {
+                mAttachedWindow.setIsFullScreen(true);
+            }
+
+            @Override
             public void onPassthrough() {
                 mWidgetManager.togglePassthrough();
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
@@ -55,6 +55,7 @@ public class HamburgerMenuWidget extends UIWidget implements
         void onPageZoomIn();
         void onPageZoomOut();
         int getCurrentZoomLevel();
+        void onFullScreen();
     }
 
     public static final int SWITCH_ITEM_ID = 0;
@@ -189,6 +190,18 @@ public class HamburgerMenuWidget extends UIWidget implements
 
         // In kiosk mode, only resize, find in page and passthrough are available.
         if (!mWidgetManager.getFocusedWindow().isKioskMode()) {
+            mItems.add(new HamburgerMenuAdapter.MenuItem.Builder(
+                    HamburgerMenuAdapter.MenuItem.TYPE_DEFAULT,
+                    (menuItem) -> {
+                        if (mDelegate != null) {
+                            mDelegate.onFullScreen();
+                        }
+                        return null;
+                    })
+                    .withTitle(getContext().getString(R.string.hamburger_menu_fullscreen))
+                    .withIcon(R.drawable.fullscreen_button)
+                    .build());
+
             final Session activeSession = SessionStore.get().getActiveSession();
 
             if (!BuildConfig.FLAVOR_backend.equals("chromium")) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2074,6 +2074,10 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
          it saves the Web App provided by the current page -->
     <string name="hamburger_menu_save_web_app">Save Web app…</string>
 
+    <!-- This string is displayed inside the Hamburger menu at the right of the navigation bar. When clicked
+         it put the current window in fullscreen mode -->
+    <string name="hamburger_menu_fullscreen">Fullscreen</string>
+
     <!-- This string is displayed in the tooltip that is displayed when the user hovers the hamburger menu icon -->
     <string name="hamburger_menu_tooltip">Menu</string>
 


### PR DESCRIPTION
Fixes #1494

Add a "Fullscreen" item in the hamburger menu to set the current window in the fullscreen mode. This item will not be available in kiosk mode.