### PR TITLE
Use StrictMode for debug builds

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
@@ -9,6 +9,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.os.StrictMode;
 
 import androidx.annotation.NonNull;
 
@@ -89,6 +90,23 @@ public class VRBrowserApplication extends Application implements AppServicesProv
         //  see https://github.com/Igalia/wolvic/issues/797
         getApplicationContext().getResources().updateConfiguration(newConfig, getBaseContext().getResources().getDisplayMetrics());
         super.onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // TODO: eventually add .penaltyDeath() to the policies once we have fixed all the issues.
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .build());
+
+            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .build());
+        }
     }
 
     public Services getServices() {


### PR DESCRIPTION
StrictMode is most commonly used to catch accidental disk or network access on the application's main thread, where UI operations are received and animations take place. Keeping disk and network operations off the main thread makes for much smoother, more responsive applications[1].

[1] https://developer.android.com/reference/android/os/StrictMode