### PR TITLE
Write window state to disk on diskIO thread

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -225,7 +225,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         restoreWindows();
     }
 
-    public void saveState() {
+    private void saveStateOnDiskIO() {
         File file = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME);
         try (Writer writer = new FileWriter(file)) {
             WindowsState state = new WindowsState();
@@ -255,6 +255,16 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             Log.e(LOGTAG, "Error saving windows state: " + e.getLocalizedMessage());
             file.delete();
         }
+    }
+
+    public void saveState() {
+        Executor diskIOExecutor = ((VRBrowserApplication)mContext.getApplicationContext()).getExecutors().diskIO();
+        diskIOExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                saveStateOnDiskIO();
+            }
+        });
     }
 
     private WindowsState restoreState() {


### PR DESCRIPTION
The saveState() method from Windows class was writing its state in the main thread. This kind of blocking operations should not be done in the main thread. This was detected using strict mode.