### PR TITLE
Bump R8 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath "org.mozilla.telemetry:glean-gradle-plugin:56.1.0"
         classpath "com.android.tools.build:gradle:$versions.android_gradle_plugin"
-        classpath 'com.android.tools:r8:8.7.14'
+        classpath 'com.android.tools:r8:8.7.18'
         classpath "$deps.kotlin.plugin"
         classpath 'com.huawei.agconnect:agcp:1.9.1.301'
 


### PR DESCRIPTION
We should at least match the version of AGP which was recently updated. The build was issuing a warning alerting about potential side effects of having different versioning.