### PR TITLE
Do not execute blocking operations in the main thread in Downloads

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -64,6 +64,10 @@ public class DownloadsManager {
         mDiskExecutor = ((VRBrowserApplication) mContext.getApplicationContext()).getExecutors().diskIO();
     }
 
+    private void removeDownloadOnDiskIO(long id) {
+        mDiskExecutor.execute(() -> { mDownloadManager.remove(id); });
+    }
+
     public void init() {
         IntentFilter filter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -75,7 +79,7 @@ public class DownloadsManager {
         downloads.forEach(download -> {
             File downloadedFile = download.getOutputFile();
             if (mDownloadManager != null && (downloadedFile == null || !downloadedFile.exists())) {
-                mDownloadManager.remove(download.getId());
+                removeDownloadOnDiskIO(download.getId());
             }
         });
     }
@@ -235,19 +239,19 @@ public class DownloadsManager {
                     File newFile = new File(file.getAbsolutePath().concat(".bak"));
                     file.renameTo(newFile);
                     if (mDownloadManager != null) {
-                        mDownloadManager.remove(downloadId);
+                        removeDownloadOnDiskIO(downloadId);
                     }
                     newFile.renameTo(file);
 
                 } else {
                     if (mDownloadManager != null) {
-                        mDownloadManager.remove(downloadId);
+                        removeDownloadOnDiskIO(downloadId);
                     }
                 }
 
             } else {
                 if (mDownloadManager != null) {
-                    mDownloadManager.remove(downloadId);
+                    removeDownloadOnDiskIO(downloadId);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes 2 strict mode policy violations in the downloads manager code
* querying the list of downloads might involve on disk sql operations
* removing downloads might involve on disk read/write operations

We should not perform blocking operations in the main thread. Use an executor do run them in a separate disk IO thread.

This PR sits on top of #1632 and #1635 