### PR TITLE
Use scheduleWithFixedDelay for download updated

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -99,7 +99,7 @@ public class DownloadsManager {
             // Already scheduled
             return;
         }
-        mFuture = mExecutor.scheduleAtFixedRate(mDownloadUpdateTask, 0, REFRESH_INTERVAL, TimeUnit.MILLISECONDS);
+        mFuture = mExecutor.scheduleWithFixedDelay(mDownloadUpdateTask, 0, REFRESH_INTERVAL, TimeUnit.MILLISECONDS);
     }
 
     private void stopUpdates() {


### PR DESCRIPTION
Replace scheduleAtFixedRate with scheduleWithFixedDelay.

The method scheduleAtFixedRate is strongly discouraged because it can lead to tasks unexpectedly executing many times in quick succession in some circumstances.