### PR TITLE
Revert "Synthesize FCP for cached pages"

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -12,6 +12,9 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import androidx.preference.PreferenceManager;
+
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.Surface;
 import android.view.inputmethod.CursorAnchorInfo;
@@ -1364,6 +1367,13 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
                 for (WSession.ContentDelegate listener : mContentListeners) {
                     listener.onFirstContentfulPaint(aSession);
                 }
+            } else if (!mState.mIsLoading) {
+                new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                    // onFirstContentfulPaint is not emitted sometimes when loading a page from
+                    // the cache. This is a workaround to ensure that the event is emitted.
+                    if (!mFirstContentfulPaint)
+                        onFirstContentfulPaint(aSession);
+                }, 500);
             }
         }
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -277,9 +277,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
             return;
         if (mState.mIsLoading) {
             aListener.onPageStart(mState.mSession, mState.mUri);
-            aListener.onProgressChange(mState.mSession, 0);
         } else {
-            aListener.onProgressChange(mState.mSession, 100);
             aListener.onPageStop(mState.mSession, true);
         }
 
@@ -1273,16 +1271,6 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
         for (WSession.ProgressDelegate listener : mProgressListeners) {
             listener.onPageStop(aSession, b);
-        }
-    }
-
-    @Override
-    public void onProgressChange(@NonNull WSession aSession, int progress) {
-        if (mState.mSession != aSession) {
-            return;
-        }
-        for (WSession.ProgressDelegate listener : mProgressListeners) {
-            listener.onProgressChange(aSession, progress);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1941,14 +1941,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.setIsLoading(false);
     }
 
-    @Override
-    public void onProgressChange(@NonNull WSession aSession, int progress) {
-        // Pages that are completely loaded from cache don't trigger onFirstContentfulPaint so we
-        // force it here to the get page properly rendered.
-        if (!mAfterFirstPaint)
-            mSession.onFirstContentfulPaint(aSession);
-    }
-
     public void captureImage() {
         mSession.captureBitmap();
     }


### PR DESCRIPTION
This reverts commit aae801484e40c68b9c4e1989b29ea2e3c8059476.

This workaround was added after the update to Gecko 121. The issues with first contentful paint are not here anymore so we can remove it and avoid synthesizing FCP events at the wrong time which were causing issues when taking screenshots of the web contents.

When those generated FCPs were issued, the Gecko compositor was not in a ready state to generate a screenshot and thus an exception was generated. Gecko was not handling it properly so it was affecting subsequent JNI calls causing crashes and hangs in Gecko.

Fixes #1638