### PR TITLE
Check storage permissions before installing local addons

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
@@ -5,6 +5,7 @@
 
 package com.igalia.wolvic.ui.views.library;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.PointF;
@@ -162,24 +163,32 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
 
             if (item.getMediaType().equals(UrlUtils.EXTENSION_MIME_TYPE)) {
                 if (SettingsStore.getInstance(getContext()).isLocalAddonAllowed()) {
-                    mWidgetManager.getFocusedWindow().showConfirmPrompt(
-                            getContext().getString(R.string.download_addon_install),
-                            item.getFilename(),
-                            new String[]{
-                                    getContext().getString(R.string.download_addon_install_cancel),
-                                    getContext().getString(R.string.download_addon_install_confirm_install),
-                            },
-                            (index, isChecked) -> {
-                                if (index == PromptDialogWidget.POSITIVE) {
-                                    LocalExtension.install(
-                                            SessionStore.get().getWebExtensionRuntime(),
-                                            UUID.randomUUID().toString(),
-                                            item.getOutputFileUriAsString(),
-                                            ((VRBrowserActivity) getContext()).getServicesProvider().getAddons()
-                                    );
+                    if (mWidgetManager.isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                        mWidgetManager.getFocusedWindow().showConfirmPrompt(
+                                getContext().getString(R.string.download_addon_install),
+                                item.getFilename(),
+                                new String[]{
+                                        getContext().getString(R.string.download_addon_install_cancel),
+                                        getContext().getString(R.string.download_addon_install_confirm_install),
+                                },
+                                (index, isChecked) -> {
+                                    if (index == PromptDialogWidget.POSITIVE) {
+                                        LocalExtension.install(
+                                                SessionStore.get().getWebExtensionRuntime(),
+                                                UUID.randomUUID().toString(),
+                                                item.getOutputFileUriAsString(),
+                                                ((VRBrowserActivity) getContext()).getServicesProvider().getAddons()
+                                        );
+                                    }
                                 }
-                            }
-                    );
+                        );
+                        } else {
+                            mWidgetManager.getFocusedWindow().showAlert(
+                                    getContext().getString(R.string.download_addon_install_blocked),
+                                    getContext().getString(R.string.download_addon_install_blocked_permissions_body),
+                                    null
+                            );
+                        }
                 } else {
                     mWidgetManager.getFocusedWindow().showAlert(
                             getContext().getString(R.string.download_addon_install_blocked),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2323,6 +2323,9 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <!-- This string is displayed in the body of the error dialog shown when downloaded addon installation is blocked. -->
     <string name="download_addon_install_blocked_body">Allow local addon installation in Developer Options to proceed.</string>
 
+    <!-- This string is displayed in the body of the error dialog shown when downloaded addon installation is blocked. -->
+    <string name="download_addon_install_blocked_permissions_body">Allow storage permissions in Privacy Options to proceed.</string>
+
     <!-- This string is shown in the body of the error dialog displayed when the user is trying to download an environment in the external storage
     but hasn't granted the permission. -->
     <string name="environment_download_permission_error_body">Permission to write the external storage is required to download the environment.</string>


### PR DESCRIPTION
Addons can be installed from locally downloadable XPI files with the correct MIME type. Installing those local files require android storage permissions. Those permissions were not checked when installing (and are not granted by default) so local installations used to silently fail in those cases.

From now on a dialog is shown in case the permission is not granted.