### PR TITLE
Better tracking of the specific window content type

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -82,7 +82,6 @@ import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 import com.igalia.wolvic.ui.widgets.WindowWidget;
 import com.igalia.wolvic.ui.widgets.Windows;
 import com.igalia.wolvic.ui.widgets.dialogs.CrashDialogWidget;
-import com.igalia.wolvic.ui.widgets.dialogs.DeprecatedVersionDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.LegalDocumentDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.PromptDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.SendTabDialogWidget;
@@ -1104,7 +1103,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             // We shouldn't divide the scale factor when we pass the motion event to the web engine
             if (widget instanceof WindowWidget) {
                 WindowWidget windowWidget = (WindowWidget) widget;
-                if (!windowWidget.isLibraryVisible()) {
+                if (!windowWidget.isNativeContentVisible()) {
                     scale = 1.0f;
                 }
             }

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
@@ -37,7 +37,7 @@ public class LibraryPanel extends FrameLayout {
     private AddonsView mAddonsView;
     private SystemNotificationsView mSystemNotificationsView;
     private LibraryView mCurrentView;
-    private @Windows.PanelType int mCurrentPanel;
+    private Windows.ContentType mCurrentPanel;
 
     public LibraryPanel(@NonNull Context context) {
         super(context);
@@ -64,7 +64,7 @@ public class LibraryPanel extends FrameLayout {
         mDownloadsView = new DownloadsView(getContext(), this);
         mAddonsView = new AddonsView(getContext(), this);
         mSystemNotificationsView = new SystemNotificationsView(getContext(), this);
-        mCurrentPanel = Windows.BOOKMARKS;
+        mCurrentPanel = Windows.ContentType.BOOKMARKS;
 
         updateUI();
     }
@@ -177,27 +177,27 @@ public class LibraryPanel extends FrameLayout {
         mSystemNotificationsView.onDestroy();
     }
 
-    public @Windows.PanelType int getSelectedPanelType() {
+    public Windows.ContentType getSelectedPanelType() {
         if (mCurrentView == mBookmarksView) {
-            return Windows.BOOKMARKS;
+            return Windows.ContentType.BOOKMARKS;
 
         } else if (mCurrentView == mWebAppsView) {
-            return Windows.WEB_APPS;
+            return Windows.ContentType.WEB_APPS;
 
         } else if (mCurrentView == mHistoryView) {
-            return Windows.HISTORY;
+            return Windows.ContentType.HISTORY;
 
         } else if (mCurrentView == mDownloadsView) {
-            return Windows.DOWNLOADS;
+            return Windows.ContentType.DOWNLOADS;
 
         } else if (mCurrentView == mAddonsView) {
-            return Windows.ADDONS;
+            return Windows.ContentType.ADDONS;
 
         } else if (mCurrentView == mSystemNotificationsView) {
-            return Windows.NOTIFICATIONS;
+            return Windows.ContentType.NOTIFICATIONS;
 
         } else {
-            return Windows.NONE;
+            return Windows.ContentType.WEB_CONTENT;
         }
     }
 
@@ -241,30 +241,30 @@ public class LibraryPanel extends FrameLayout {
         mBinding.searchBar.setVisibility(mCurrentView.supportsSearch() ? View.VISIBLE : View.INVISIBLE);
     }
 
-    public void selectPanel(@Windows.PanelType int panelType) {
+    public void selectPanel(Windows.ContentType panelType) {
         mCurrentPanel = panelType;
 
-        if (panelType == Windows.NONE) {
+        if (panelType == Windows.ContentType.WEB_CONTENT) {
             panelType = getSelectedPanelType();
         }
         switch (panelType) {
-            case Windows.NONE:
-            case Windows.BOOKMARKS:
+            case WEB_CONTENT:
+            case BOOKMARKS:
                 selectTab(mBinding.bookmarks);
                 break;
-            case Windows.WEB_APPS:
+            case WEB_APPS:
                 selectTab(mBinding.webApps);
                 break;
-            case Windows.HISTORY:
+            case HISTORY:
                 selectTab(mBinding.history);
                 break;
-            case Windows.DOWNLOADS:
+            case DOWNLOADS:
                 selectTab(mBinding.downloads);
                 break;
-            case Windows.ADDONS:
+            case ADDONS:
                 selectTab(mBinding.addons);
                 break;
-            case Windows.NOTIFICATIONS:
+            case NOTIFICATIONS:
                 selectTab(mBinding.notifications);
                 break;
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -15,11 +15,9 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.net.Uri;
 import androidx.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -1379,12 +1377,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             public void onAddons() {
                 hideMenu();
 
-                if (!mAttachedWindow.isLibraryVisible()) {
-                    mAttachedWindow.switchPanel(Windows.ADDONS);
-
-                } else if (mAttachedWindow.getSelectedPanel() != Windows.ADDONS) {
-                    mAttachedWindow.showPanel(Windows.ADDONS);
-                }
+                mAttachedWindow.showPanel(Windows.ContentType.ADDONS);
             }
 
             @Override
@@ -1460,7 +1453,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
         mBlockedCount++;
         final int currentCount = mBlockedCount;
         postDelayed(() -> {
-            if (currentCount == mBlockedCount && !mViewModel.getIsLibraryVisible().getValue().get()) {
+            if (currentCount == mBlockedCount && !mViewModel.getIsNativeContentVisible().getValue().get()) {
                 showNotification(POPUP_NOTIFICATION_ID,
                         mBinding.navigationBarNavigation.urlBar.getPopUpButton(),
                         NotificationManager.Notification.TOP,

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -35,7 +35,6 @@ import androidx.databinding.ObservableBoolean;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
-import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.VRBrowserApplication;
@@ -578,7 +577,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
         mWidgetPlacement.parentHandle = -1;
 
         if (mViewModel != null) {
-            mViewModel.getIsLibraryVisible().removeObserver(mIsLibraryVisible);
+            mViewModel.getIsNativeContentVisible().removeObserver(mIsNativeContentVisible);
             mViewModel.getIsPrivateSession().removeObserver(mIsPrivateSession);
             mViewModel = null;
         }
@@ -601,7 +600,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
                 (VRBrowserActivity)getContext(),
                 ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
                 .get(String.valueOf(mAttachedWindow.hashCode()), WindowViewModel.class);
-        mViewModel.getIsLibraryVisible().observe((VRBrowserActivity)getContext(), mIsLibraryVisible);
+        mViewModel.getIsNativeContentVisible().observe((VRBrowserActivity)getContext(), mIsNativeContentVisible);
         mViewModel.getIsPrivateSession().observe((VRBrowserActivity)getContext(), mIsPrivateSession);
 
         mBinding.setViewmodel(mViewModel);
@@ -611,7 +610,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
         mIsWindowAttached = true;
     }
 
-    private Observer<ObservableBoolean> mIsLibraryVisible = aBoolean -> {
+    private Observer<ObservableBoolean> mIsNativeContentVisible = aBoolean -> {
         if (mBinding.libraryButton.isHovered()) {
             return;
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
@@ -202,7 +202,7 @@ public class HamburgerMenuWidget extends UIWidget implements
                         }).build());
 
                 String url = activeSession.getCurrentUri();
-                boolean showAddons = (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) && !mWidgetManager.getFocusedWindow().isLibraryVisible();
+                boolean showAddons = (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) && !mWidgetManager.getFocusedWindow().isNativeContentVisible();
                 final SessionState tab = ComponentsAdapter.get().getSessionStateForSession(activeSession);
                 if (tab != null && showAddons) {
                     final List<WebExtensionState> extensions = ComponentsAdapter.get().getSortedEnabledExtensions();

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -208,6 +208,26 @@ public class UrlUtils {
         return url.equalsIgnoreCase(ABOUT_ADDONS);
     }
 
+    public static final String ABOUT_WEBAPPS = "about://webapps";
+
+    public static boolean isWebAppsUrl(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+
+        return url.equalsIgnoreCase(ABOUT_WEBAPPS);
+    }
+
+    public static final String ABOUT_NOTIFICATIONS = "about://notifications";
+
+    public static boolean isNotificationsUrl(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+
+        return url.equalsIgnoreCase(ABOUT_NOTIFICATIONS);
+    }
+
     public static final String WEB_EXTENSION_URL = "moz-extension://";
 
     public static boolean isWebExtensionUrl(@Nullable String url) {
@@ -225,7 +245,8 @@ public class UrlUtils {
     }
 
     public static boolean isAboutPage(@Nullable String url) {
-        return isHistoryUrl(url) || isBookmarksUrl(url) || isDownloadsUrl(url) || isAddonsUrl(url) || isPrivateUrl(url);
+        return isHistoryUrl(url) || isBookmarksUrl(url) || isDownloadsUrl(url) || isAddonsUrl(url) ||
+                isWebAppsUrl(url) || isNotificationsUrl(url) || isPrivateUrl(url);
     }
 
     public static boolean isContentFeed(Context aContext, @Nullable String url) {

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -228,8 +228,8 @@
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/microphoneButton"
                     style="@style/urlBarIconTheme"
-                    android:layout_width="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
-                    android:background="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
+                    android:layout_width="@{(viewmodel.isNativeContentVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
+                    android:background="@{(viewmodel.isNativeContentVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
                     android:src="@drawable/ic_icon_microphone"
                     android:tint="@color/fog"
                     android:tooltipText="@string/voice_search_tooltip"
@@ -239,13 +239,13 @@
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/webAppButton"
                     style="@style/urlBarIconTheme"
-                    android:layout_width="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
-                    android:background="@{(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
+                    android:layout_width="@{(viewmodel.isNativeContentVisible || viewmodel.isUrlEmpty) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
+                    android:background="@{(viewmodel.isNativeContentVisible || viewmodel.isUrlEmpty) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
                     android:src="@drawable/ic_web_app_registration"
                     android:tint="@color/fog"
                     android:tooltipText="@string/hamburger_menu_save_web_app"
                     app:privateMode="@{viewmodel.isPrivateSession}"
-                    app:visibleGone="@{viewmodel.isWebApp &amp;&amp; !(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}" />
+                    app:visibleGone="@{viewmodel.isWebApp &amp;&amp; !(viewmodel.isNativeContentVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}" />
 
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/bookmarkButton"
@@ -254,7 +254,7 @@
                     android:tint="@color/fog"
                     android:tooltipText="@{viewmodel.isBookmarked ? @string/remove_bookmark_tooltip : @string/bookmark_tooltip}"
                     app:privateMode="@{viewmodel.isPrivateSession}"
-                    app:visibleGone="@{!(viewmodel.isLibraryVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}"
+                    app:visibleGone="@{!(viewmodel.isNativeContentVisible || viewmodel.isUrlEmpty) &amp;&amp; !viewmodel.isFocused}"
                     tools:src="@drawable/ic_icon_bookmarked" />
 
                 <com.igalia.wolvic.ui.views.UIButton

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -189,13 +189,13 @@
                 <com.igalia.wolvic.ui.views.UIButton
                     android:id="@+id/libraryButton"
                     style="@style/trayButtonMiddleTheme"
-                    android:tooltipText="@{viewmodel.isLibraryVisible ? @string/close_library_tooltip : @string/open_library_tooltip}"
+                    android:tooltipText="@{viewmodel.isNativeContentVisible ? @string/close_library_tooltip : @string/open_library_tooltip}"
                     app:tooltipDensity="@dimen/tray_tooltip_density"
                     app:tooltipPosition="bottom"
                     app:tooltipLayout="@layout/tooltip_tray"
                     android:src="@drawable/ic_icon_library"
                     app:clipDrawable="@drawable/ic_icon_library_clip"
-                    app:activeMode="@{viewmodel.isLibraryVisible}"/>
+                    app:activeMode="@{viewmodel.isNativeContentVisible}"/>
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="12dp"
                     android:layout_height="12dp"


### PR DESCRIPTION
Replace the integer constants for the library sections in `WindowWidget` with an enum that also includes the `about:` URL for each one.

`WindowViewModel.currentContentType` keeps track of the specific content being shown in the window at each moment, which will make it easier to implement the native UI New Tab page and reorganise the library.

`WindowViewModel.isNativeContentVisible` depends on the previous field and provides a boolean value so the current bindings keep working.

This PR should not cause any major behaviour changes.