### PR TITLE
Move Bookmarks and Downloads to the tray 

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -1291,7 +1291,16 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
     }
 
     @Override
-    public void onLibraryClicked() {
+    public void onBookmarksClicked() {
+        onLibraryClicked();
+    }
+
+    @Override
+    public void onDownloadsClicked() {
+        onLibraryClicked();
+    }
+
+    private void onLibraryClicked() {
         if (mAttachedWindow.isResizing()) {
             exitResizeMode(ResizeAction.RESTORE_SIZE);
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayListener.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayListener.java
@@ -4,5 +4,6 @@ public interface TrayListener {
     default void onPrivateBrowsingClicked() {}
     default void onAddWindowClicked() {}
     default void onTabsClicked() {}
-    default void onLibraryClicked() {}
+    default void onBookmarksClicked() {}
+    default void onDownloadsClicked() {}
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -489,6 +489,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return mViewModel.getIsNativeContentVisible().getValue().get();
     }
 
+    public Windows.ContentType getCurrentContentType() {
+        return mViewModel.getCurrentContentType().getValue();
+    }
+
     public int getWindowWidth() {
         return mWidgetPlacement.width;
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -1201,15 +1201,20 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     @Override
-    public void onLibraryClicked() {
-        if (mFocusedWindow.isNativeContentVisible()) {
+    public void onBookmarksClicked() {
+        if (mFocusedWindow.getCurrentContentType() == ContentType.BOOKMARKS) {
             mFocusedWindow.hidePanel();
-
-        } else if (mDownloadsManager.isDownloading()) {
-            mFocusedWindow.showPanel(ContentType.DOWNLOADS);
-
         } else {
             mFocusedWindow.showPanel(ContentType.BOOKMARKS);
+        }
+    }
+
+    @Override
+    public void onDownloadsClicked() {
+        if (mFocusedWindow.getCurrentContentType() == ContentType.DOWNLOADS) {
+            mFocusedWindow.hidePanel();
+        } else {
+            mFocusedWindow.showPanel(ContentType.DOWNLOADS);
         }
     }
 

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tool="http://schemas.android.com/tools">
     <data>
+        <import type="com.igalia.wolvic.ui.widgets.Windows.ContentType"/>
         <variable
             name="viewmodel"
             type="com.igalia.wolvic.ui.viewmodel.WindowViewModel" />
@@ -14,7 +15,7 @@
     <RelativeLayout
         android:layout_width="@dimen/tray_width"
         android:layout_height="@dimen/tray_height"
-        android:gravity="top|center_horizontal">
+        android:gravity="center">
 
         <RelativeLayout
             android:id="@+id/status_bar"
@@ -183,19 +184,30 @@
                 android:src="@{viewmodel.isPrivateSession ? @drawable/ic_icon_tray_private_browsing_on_v2 : @drawable/ic_icon_tray_private_browsing_v2}"
                 app:privateMode="@{viewmodel.isPrivateSession}"/>
 
+            <com.igalia.wolvic.ui.views.UIButton
+                android:id="@+id/bookmarksButton"
+                style="@style/trayButtonMiddleTheme"
+                android:src="@drawable/ic_icon_bookmark"
+                android:tooltipText="@{viewmodel.currentContentType == ContentType.BOOKMARKS ? @string/close_library_tooltip : @string/open_library_tooltip}"
+                app:activeMode="@{viewmodel.currentContentType == ContentType.BOOKMARKS}"
+                app:clipDrawable="@drawable/ic_icon_library_clip"
+                app:tooltipDensity="@dimen/tray_tooltip_density"
+                app:tooltipLayout="@layout/tooltip_tray"
+                app:tooltipPosition="bottom" />
+
             <RelativeLayout
                 android:layout_width="40dp"
                 android:layout_height="40dp">
                 <com.igalia.wolvic.ui.views.UIButton
-                    android:id="@+id/libraryButton"
+                    android:id="@+id/downloadsButton"
                     style="@style/trayButtonMiddleTheme"
-                    android:tooltipText="@{viewmodel.isNativeContentVisible ? @string/close_library_tooltip : @string/open_library_tooltip}"
+                    android:tooltipText="@{viewmodel.currentContentType == ContentType.DOWNLOADS ? @string/close_library_tooltip : @string/open_library_tooltip}"
                     app:tooltipDensity="@dimen/tray_tooltip_density"
                     app:tooltipPosition="bottom"
                     app:tooltipLayout="@layout/tooltip_tray"
-                    android:src="@drawable/ic_icon_library"
+                    android:src="@drawable/ic_icon_downloads"
                     app:clipDrawable="@drawable/ic_icon_library_clip"
-                    app:activeMode="@{viewmodel.isNativeContentVisible}"/>
+                    app:activeMode="@{viewmodel.currentContentType == ContentType.DOWNLOADS}"/>
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="12dp"
                     android:layout_height="12dp"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -131,8 +131,8 @@
     <!-- Tray -->
     <item name="tray_world_y" format="float" type="dimen">0.25</item>
     <item name="tray_world_z" format="float" type="dimen">-2.5</item>
-    <item name="tray_world_width" format="float" type="dimen">1.2</item>
-    <dimen name="tray_width">204dp</dimen>
+    <item name="tray_world_width" format="float" type="dimen">1.4</item>
+    <dimen name="tray_width">244dp</dimen>
     <dimen name="tray_height">66dp</dimen>
     <!-- The density of the tray tooltips is the default one. -->
     <item name="tray_tooltip_density" format="float" type="dimen">1.0</item>


### PR DESCRIPTION
For convenience, replace the Library button with separate buttons for the Bookmarks and Downloads. This is the first step in reorganizing the Library and Tray.

Simplify the code to animate the buttons' padding when selected.