### PR TITLE
Use the move bar to freely position windows

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -2200,6 +2200,20 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     public boolean isEyeTrackingSupported() { return mIsEyeTrackingSupported; }
 
+    // Sigmoid transform to allow faster window movements as the distance increases.
+    private static float sigmoidTransform(float x, float xMax, float k, float xMid) {
+        float xNorm = x / xMax;
+        return (float) (1 / (1 + Math.exp(-k * (xNorm - xMid))));
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
+    private void setWindowDistance(float aDistance) {
+        float xMid = 0.5f; // sigmoid centered in y axis
+        float xMax = 0.7f; // 70cm as a good average value for adult human arm
+        mSettings.setWindowDistance(sigmoidTransform(aDistance, 0.5f, 10, xMid));
+    }
+
     private native void addWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateVisibleWidgetsNative();

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1388,10 +1388,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Keep
     @SuppressWarnings("unused")
     public void resetWindowsPosition() {
-        // Reset the position of the windows when we are not in headlock and window movement is enabled.
-        if (!mSettings.isHeadLockEnabled() && mSettings.isWindowMovementEnabled()) {
-            runOnUiThread(() -> mWindows.resetWindowsPosition());
-        }
+        // Reset the position of the windows when we are not in headlock.
+        if (mSettings.isHeadLockEnabled())
+            return;
+        runOnUiThread(() -> mWindows.resetWindowsPosition());
     }
 
     @Keep

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -374,7 +374,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         if (false)
             checkForCrash();
 
-        setHeadLockEnabled(mSettings.isHeadLockEnabled());
+        setLockMode(mSettings.isHeadLockEnabled() ? WidgetManagerDelegate.HEAD_LOCK : WidgetManagerDelegate.NO_LOCK);
         if (mSettings.getPointerMode() == WidgetManagerDelegate.TRACKED_EYE)
             checkEyeTrackingPermissions(aPermissionGranted -> setPointerMode(aPermissionGranted ? WidgetManagerDelegate.TRACKED_EYE : WidgetManagerDelegate.TRACKED_POINTER));
         else
@@ -736,7 +736,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 initializeSpeechRecognizer();
             } else if (key.equals(getString(R.string.settings_key_head_lock))) {
                 boolean isHeadLockEnabled = SettingsStore.getInstance(this).isHeadLockEnabled();
-                setHeadLockEnabled(isHeadLockEnabled);
+                setLockMode(isHeadLockEnabled ? WidgetManagerDelegate.HEAD_LOCK : WidgetManagerDelegate.NO_LOCK);
                 if (!isHeadLockEnabled)
                     recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL);
             }
@@ -1998,8 +1998,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
-    public void setHeadLockEnabled(boolean isHeadLockEnabled) {
-        queueRunnable(() -> setHeadLockEnabledNative(isHeadLockEnabled));
+    public void setLockMode(@LockMode int lockMode) {
+        queueRunnable(() -> setLockEnabledNative(lockMode));
     }
 
     @Override
@@ -2209,7 +2209,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void showVRVideoNative(int aWindowHandler, int aVideoProjection);
     private native void hideVRVideoNative();
     private native void togglePassthroughNative();
-    private native void setHeadLockEnabledNative(boolean isEnabled);
+    private native void setLockEnabledNative(@LockMode int aLockMode);
     private native void recenterUIYawNative(@YawTarget int aTarget);
     private native void setControllersVisibleNative(boolean aVisible);
     private native void runCallbackNative(long aCallback);

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1763,6 +1763,16 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    public void startWindowMove() {
+        queueRunnable(() -> setLockEnabledNative(WidgetManagerDelegate.CONTROLLER_LOCK));
+    }
+
+    @Override
+    public void finishWindowMove() {
+        queueRunnable(() -> setLockEnabledNative(WidgetManagerDelegate.NO_LOCK));
+    }
+
+    @Override
     public void addUpdateListener(@NonNull UpdateListener aUpdateListener) {
         if (!mWidgetUpdateListeners.contains(aUpdateListener)) {
             mWidgetUpdateListeners.add(aUpdateListener);

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -391,19 +391,6 @@ public class SettingsStore {
         editor.apply();
     }
 
-    public boolean isWindowMovementEnabled() {
-        return mPrefs.getBoolean(
-                mContext.getString(R.string.settings_key_window_movement), WINDOW_MOVEMENT_DEFAULT);
-    }
-
-    public void setWindowMovementEnabled(boolean isEnabled) {
-        SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putBoolean(mContext.getString(R.string.settings_key_window_movement), isEnabled);
-        editor.apply();
-
-        mSettingsViewModel.setWindowMovementEnabled(isEnabled);
-    }
-
     public boolean isEnvironmentOverrideEnabled() {
         return mPrefs.getBoolean(
                 mContext.getString(R.string.settings_key_environment_override), ENV_OVERRIDE_DEFAULT);

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
@@ -32,7 +32,6 @@ public class SettingsViewModel extends AndroidViewModel {
     private MutableLiveData<String> propsVersionName;
     private MutableLiveData<Map<String, RemoteProperties>> props;
     private MutableLiveData<ObservableBoolean> isWhatsNewVisible;
-    private MutableLiveData<ObservableBoolean> isWindowMovementEnabled;
 
     public SettingsViewModel(@NonNull Application application) {
         super(application);
@@ -44,7 +43,6 @@ public class SettingsViewModel extends AndroidViewModel {
         propsVersionName = new MutableLiveData<>();
         props = new MutableLiveData<>(Collections.emptyMap());
         isWhatsNewVisible = new MutableLiveData<>(new ObservableBoolean(false));
-        isWindowMovementEnabled = new MutableLiveData<>(new ObservableBoolean(false));
 
         propsVersionName.observeForever(props -> isWhatsNewVisible());
         props.observeForever(versionName -> isWhatsNewVisible());
@@ -66,9 +64,6 @@ public class SettingsViewModel extends AndroidViewModel {
 
         String appVersionName = SettingsStore.getInstance(getApplication().getBaseContext()).getRemotePropsVersionName();
         propsVersionName.postValue(appVersionName);
-
-        boolean windowMovementVisible = SettingsStore.getInstance(getApplication().getBaseContext()).isWindowMovementEnabled();
-        isWindowMovementEnabled.postValue(new ObservableBoolean(windowMovementVisible));
     }
 
     private void isWhatsNewVisible() {
@@ -108,14 +103,6 @@ public class SettingsViewModel extends AndroidViewModel {
 
     public MutableLiveData<ObservableBoolean> getIsWebXREnabled() {
         return isWebXREnabled;
-    }
-
-    public void setWindowMovementEnabled(boolean isEnabled) {
-        this.isWindowMovementEnabled.setValue(new ObservableBoolean(isEnabled));
-    }
-
-    public MutableLiveData<ObservableBoolean> isWindowMovementEnabled() {
-        return isWindowMovementEnabled;
     }
 
     public void setPropsVersionName(String appVersionName) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -152,7 +152,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
                     if (background != null) {
                         background.setColorFilter(getContext().getColor(R.color.design_default_color_primary), PorterDuff.Mode.ADD);
                     }
-                    mWidgetManager.startWidgetMove(mWidgetManager.getWindows().getFrontWindow(), WidgetManagerDelegate.WIDGET_MOVE_BEHAVIOUR_WINDOW);
+                    mWidgetManager.startWindowMove();
                     break;
                 case MotionEvent.ACTION_POINTER_UP:
                 case MotionEvent.ACTION_UP:
@@ -161,7 +161,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
                     if (background != null) {
                         background.clearColorFilter();
                     }
-                    mWidgetManager.finishWidgetMove();
+                    mWidgetManager.finishWindowMove();
                     break;
                 default:
                     return false;

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -71,6 +71,12 @@ public interface WidgetManagerDelegate {
     int TRACKED_POINTER = 0;
     int TRACKED_EYE = 1;
 
+    @IntDef(value = { NO_LOCK, HEAD_LOCK, CONTROLLER_LOCK})
+    @interface LockMode {}
+    int NO_LOCK = 0;
+    int HEAD_LOCK = 1;
+    int CONTROLLER_LOCK = 2;
+
     enum OriginatorType {WEBSITE, APPLICATION}
 
     int newWidgetHandle();
@@ -103,7 +109,7 @@ public interface WidgetManagerDelegate {
     boolean isPassthroughEnabled();
     boolean isPassthroughSupported();
     boolean isPageZoomEnabled();
-    void setHeadLockEnabled(boolean isHeadLockEnabled);
+    void setLockMode(@LockMode int lockMode);
     void recenterUIYaw(@YawTarget int target);
     void setCylinderDensity(float aDensity);
     void setCylinderDensityForce(float aDensity);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -90,6 +90,8 @@ public interface WidgetManagerDelegate {
     void finishWidgetResize(WindowWidget aWidget);
     void startWidgetMove(Widget aWidget, @WidgetMoveBehaviourFlags int aMoveBehaviour);
     void finishWidgetMove();
+    void startWindowMove();
+    void finishWindowMove();
     void addUpdateListener(@NonNull UpdateListener aUpdateListener);
     void removeUpdateListener(@NonNull UpdateListener aUpdateListener);
     void pushBackHandler(@NonNull Runnable aRunnable);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -1388,17 +1388,18 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             for (WindowWidget win: getCurrentWindows()) {
                 setWindowVisible(win, win == mFullscreenWindow);
             }
-            updateMaxWindowScales();
-            updateViews();
-        } else if (mFullscreenWindow != null) {
+        } else {
+            if (mFullscreenWindow == null)
+                return;
             aWindow.restoreBeforeFullscreenPlacement();
             mFullscreenWindow = null;
             for (WindowWidget win : getCurrentWindows()) {
                 setWindowVisible(win, true);
             }
-            updateMaxWindowScales();
-            updateViews();
         }
+        updateMaxWindowScales();
+        updateCurvedMode(true);
+
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -63,10 +63,6 @@ class DisplayOptionsView extends SettingsView {
         mBinding.centerWindowsSwitch.setOnCheckedChangeListener(mCenterWindowsListener);
         setCenterWindows(SettingsStore.getInstance(getContext()).isCenterWindows(), false);
 
-        float windowDistance = SettingsStore.getInstance(getContext()).getWindowDistance();
-        mBinding.windowDistanceSlider.setOnValueChangeListener(mWindowDistanceListener);
-        setWindowDistance(windowDistance, false);
-
         int uaMode = SettingsStore.getInstance(getContext()).getUaMode();
         mBinding.uaRadio.setOnCheckedChangeListener(mUaModeListener);
         setUaMode(mBinding.uaRadio.getIdForValue(uaMode), false);
@@ -163,10 +159,6 @@ class DisplayOptionsView extends SettingsView {
 
         return editing;
     }
-
-    private SliderSetting.OnValueChangeListener mWindowDistanceListener = (slider, value, doApply) -> {
-        setWindowDistance(value, true);
-    };
 
     private RadioGroupSetting.OnCheckedChangeListener mUaModeListener = (radioGroup, checkedId, doApply) -> {
         setUaMode(checkedId, true);
@@ -277,7 +269,6 @@ class DisplayOptionsView extends SettingsView {
         setSoundEffect(SettingsStore.AUDIO_ENABLED, true);
         setLatinAutoComplete(SettingsStore.LATIN_AUTO_COMPLETE_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
-        setWindowDistance(SettingsStore.WINDOW_DISTANCE_DEFAULT, true);
 
         if (mBinding.startWithPassthroughSwitch.isChecked() != SettingsStore.shouldStartWithPassthrougEnabled()) {
             setStartWithPassthrough(SettingsStore.shouldStartWithPassthrougEnabled());
@@ -370,14 +361,6 @@ class DisplayOptionsView extends SettingsView {
         mBinding.homepageEdit.setFirstText(newHomepage);
         SettingsStore.getInstance(getContext()).setHomepage(newHomepage);
         mBinding.homepageEdit.setOnClickListener(mHomepageListener);
-    }
-
-    private void setWindowDistance(float value, boolean doApply) {
-        mBinding.windowDistanceSlider.setOnValueChangeListener(null);
-        mBinding.windowDistanceSlider.setValue(value, doApply);
-        mBinding.windowDistanceSlider.setOnValueChangeListener(mWindowDistanceListener);
-
-        SettingsStore.getInstance(getContext()).setWindowDistance(mBinding.windowDistanceSlider.getValue());
     }
 
     private void setUaMode(int checkId, boolean doApply) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -100,9 +100,6 @@ class DisplayOptionsView extends SettingsView {
         mBinding.latinAutoCompleteSwitch.setOnCheckedChangeListener(mLatinAutoCompleteListener);
         setLatinAutoComplete(SettingsStore.getInstance(getContext()).isLatinAutoCompleteEnabled(), false);
 
-        mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
-        setHeadLock(SettingsStore.getInstance(getContext()).isHeadLockEnabled(), false);
-
         mDefaultHomepageUrl = getContext().getString(R.string.HOMEPAGE_URL);
 
         mBinding.homepageEdit.setHint1(getContext().getString(R.string.homepage_hint, getContext().getString(R.string.app_name)));
@@ -188,10 +185,6 @@ class DisplayOptionsView extends SettingsView {
         setLatinAutoComplete(enabled, true);
     };
 
-    private SwitchSetting.OnCheckedChangeListener mHeadLockListener = (compoundButton, value, doApply) -> {
-        setHeadLock(value, true);
-    };
-
     private OnClickListener mHomepageListener = (view) -> {
         if (!mBinding.homepageEdit.getFirstText().isEmpty()) {
             setHomepage(mBinding.homepageEdit.getFirstText());
@@ -265,7 +258,6 @@ class DisplayOptionsView extends SettingsView {
         setHomepage(mDefaultHomepageUrl);
         setAutoplay(SettingsStore.AUTOPLAY_ENABLED, true);
         setCurvedDisplay(false, true);
-        setHeadLock(SettingsStore.HEAD_LOCK_DEFAULT, true);
         setSoundEffect(SettingsStore.AUDIO_ENABLED, true);
         setLatinAutoComplete(SettingsStore.LATIN_AUTO_COMPLETE_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
@@ -331,17 +323,6 @@ class DisplayOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setLatinAutoComplete(value);
-        }
-    }
-
-    private void setHeadLock(boolean value, boolean doApply) {
-        mBinding.headLockSwitch.setOnCheckedChangeListener(null);
-        mBinding.headLockSwitch.setValue(value, false);
-        mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
-
-        SettingsStore settingsStore = SettingsStore.getInstance(getContext());
-        if (doApply) {
-            settingsStore.setHeadLockEnabled(value);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -107,9 +107,6 @@ class DisplayOptionsView extends SettingsView {
         mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
         setHeadLock(SettingsStore.getInstance(getContext()).isHeadLockEnabled(), false);
 
-        mBinding.windowMovementSwitch.setOnCheckedChangeListener(mWindowMovementListener);
-        setWindowMovement(SettingsStore.getInstance(getContext()).isWindowMovementEnabled(), false);
-
         mDefaultHomepageUrl = getContext().getString(R.string.HOMEPAGE_URL);
 
         mBinding.homepageEdit.setHint1(getContext().getString(R.string.homepage_hint, getContext().getString(R.string.app_name)));
@@ -203,10 +200,6 @@ class DisplayOptionsView extends SettingsView {
         setHeadLock(value, true);
     };
 
-    private SwitchSetting.OnCheckedChangeListener mWindowMovementListener = (compoundButton, enabled, apply) -> {
-        setWindowMovement(enabled, true);
-    };
-
     private OnClickListener mHomepageListener = (view) -> {
         if (!mBinding.homepageEdit.getFirstText().isEmpty()) {
             setHomepage(mBinding.homepageEdit.getFirstText());
@@ -284,7 +277,6 @@ class DisplayOptionsView extends SettingsView {
         setSoundEffect(SettingsStore.AUDIO_ENABLED, true);
         setLatinAutoComplete(SettingsStore.LATIN_AUTO_COMPLETE_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
-        setWindowMovement(SettingsStore.WINDOW_MOVEMENT_DEFAULT, true);
         setWindowDistance(SettingsStore.WINDOW_DISTANCE_DEFAULT, true);
 
         if (mBinding.startWithPassthroughSwitch.isChecked() != SettingsStore.shouldStartWithPassthrougEnabled()) {
@@ -360,12 +352,6 @@ class DisplayOptionsView extends SettingsView {
         if (doApply) {
             settingsStore.setHeadLockEnabled(value);
         }
-
-        if (value && settingsStore.isWindowMovementEnabled()) {
-            // Disable window movement if head lock is enabled,
-            // otherwise the windows might be moved out of the user's reach.
-            setWindowMovement(false, true);
-        }
     }
 
     private void setSoundEffect(boolean value, boolean doApply) {
@@ -376,23 +362,6 @@ class DisplayOptionsView extends SettingsView {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setAudioEnabled(value);
             AudioEngine.fromContext(getContext()).setEnabled(value);
-        }
-    }
-
-    private void setWindowMovement(boolean value, boolean doApply) {
-        mBinding.windowMovementSwitch.setOnCheckedChangeListener(null);
-        mBinding.windowMovementSwitch.setValue(value, false);
-        mBinding.windowMovementSwitch.setOnCheckedChangeListener(mWindowMovementListener);
-
-        SettingsStore settingsStore = SettingsStore.getInstance(getContext());
-        if (doApply) {
-            settingsStore.setWindowMovementEnabled(value);
-        }
-
-        if (value && settingsStore.isHeadLockEnabled()) {
-            // Disable head lock if window movement is enabled,
-            // otherwise the windows might be moved out of the user's reach.
-            setHeadLock(false, true);
         }
     }
 

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -91,6 +91,9 @@ const vrb::Color kPointerColorSelected = vrb::Color(0.32f, 0.56f, 0.88f);
 // How big is the pointer target while in hand-tracking mode
 const float kPointerSize = 3.0;
 
+// When moving windows, the minimum amount of movement required to start moving the window
+float kWindowMoveZThreshold = 0.01;
+
 class SurfaceObserver;
 typedef std::shared_ptr<SurfaceObserver> SurfaceObserverPtr;
 
@@ -1220,6 +1223,11 @@ BrowserWorld::StartFrame() {
       auto transform = m.lockMode == LockMode::HEAD ? m.device->GetHeadTransform() : GetActiveControllerOrientation();
       transform.PostMultiplyInPlace(m.lockModeInitialTransform.Inverse());
       m.device->Reorient(transform);
+      if (m.lockMode == LockMode::CONTROLLER) {
+          float deltaZ = m.lockModeInitialTransform.GetTranslation().z() - GetActiveControllerOrientation().GetTranslation().z();
+          if (abs(deltaZ) > kWindowMoveZThreshold)
+            VRBrowser::SetWindowDistance(deltaZ);
+      }
     }
     if (m.reorientRequested)
       relayoutWidgets = std::exchange(m.reorientRequested, false);

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -208,7 +208,7 @@ struct BrowserWorld::State {
   bool wasWebXRRendering = false;
   double lastBatteryLevelUpdate = -1.0;
   bool reorientRequested = false;
-  bool inHeadLockMode = false;
+  LockMode lockMode = LockMode::NO_LOCK;
 #if HVR
   bool wasButtonAppPressed = false;
 #elif defined(OCULUSVR) && defined(STORE_BUILD)
@@ -1204,7 +1204,7 @@ BrowserWorld::StartFrame() {
     m.UpdateGazeModeState();
     m.UpdateControllers(relayoutWidgets);
     m.UpdateTrackedKeyboard();
-    if (m.inHeadLockMode) {
+    if (m.lockMode != LockMode::NO_LOCK) {
       OnReorient();
       m.device->Reorient();
     }
@@ -1279,9 +1279,9 @@ BrowserWorld::TogglePassthrough() {
 }
 
 void
-BrowserWorld::SetHeadLockEnabled(const bool isEnabled) {
+BrowserWorld::SetLockMode(LockMode lockMode) {
   ASSERT_ON_RENDER_THREAD();
-  m.inHeadLockMode = isEnabled;
+  m.lockMode = lockMode;
 }
 
 void
@@ -2135,9 +2135,9 @@ JNI_METHOD(void, togglePassthroughNative)
   crow::BrowserWorld::Instance().TogglePassthrough();
 }
 
-JNI_METHOD(void, setHeadLockEnabledNative)
-(JNIEnv*, jobject, jboolean isEnabled) {
-  crow::BrowserWorld::Instance().SetHeadLockEnabled(isEnabled);
+JNI_METHOD(void, setLockEnabledNative)
+(JNIEnv*, jobject, jint lockMode) {
+    crow::BrowserWorld::Instance().SetLockMode(static_cast<crow::BrowserWorld::LockMode>(lockMode));
 }
 
 JNI_METHOD(void, exitImmersiveNative)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -103,6 +103,7 @@ private:
 #if defined(OCULUSVR) && defined(STORE_BUILD)
   void ProcessOVRPlatformEvents();
 #endif
+  vrb::Matrix GetActiveControllerOrientation() const;
   State& m;
   BrowserWorld() = delete;
   VRB_NO_DEFAULTS(BrowserWorld)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -49,7 +49,8 @@ public:
   void EndFrame();
   void TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity, const int aControllerId);
   void TogglePassthrough();
-  void SetHeadLockEnabled(const bool isEnabled);
+  enum class LockMode { NO_LOCK, HEAD, CONTROLLER };
+  void SetLockMode(LockMode);
   void SetTemporaryFilePath(const std::string& aPath);
   void UpdateEnvironment();
   void UpdatePointerColor();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -79,7 +79,7 @@ public:
   virtual const vrb::Matrix& GetHeadTransform() const = 0;
   virtual const vrb::Matrix& GetReorientTransform() const = 0;
   virtual void SetReorientTransform(const vrb::Matrix& aMatrix) = 0;
-  virtual void Reorient() = 0;
+  virtual void Reorient(vrb::Matrix&) = 0;
   virtual void SetClearColor(const vrb::Color& aColor) = 0;
   virtual void SetClipPlanes(const float aNear, const float aFar) = 0;
   virtual void SetControllerDelegate(ControllerDelegatePtr& aController) = 0;

--- a/app/src/main/cpp/DeviceUtils.cpp
+++ b/app/src/main/cpp/DeviceUtils.cpp
@@ -20,8 +20,8 @@ DeviceUtils::CalculateReorientationMatrix(const vrb::Matrix& aHeadTransform, con
 }
 
 vrb::Matrix
-DeviceUtils::CalculateReorientationMatrixOnHeadLock(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition) {
-  return CalculateReorientationMatrixWithThreshold(aHeadTransform, aHeightPosition, 0.0f, 0.0f, 0.0f);
+DeviceUtils::CalculateReorientationMatrixOnHeadLock(const vrb::Matrix& aHeadTransform) {
+  return CalculateReorientationMatrixWithThreshold(aHeadTransform, aHeadTransform.GetTranslation(), 0.0f, 0.0f, 0.0f);
 }
 
 vrb::Matrix

--- a/app/src/main/cpp/DeviceUtils.h
+++ b/app/src/main/cpp/DeviceUtils.h
@@ -18,7 +18,7 @@ namespace crow {
 class DeviceUtils {
 public:
   static vrb::Matrix CalculateReorientationMatrix(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition);
-  static vrb::Matrix CalculateReorientationMatrixOnHeadLock(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition);
+  static vrb::Matrix CalculateReorientationMatrixOnHeadLock(const vrb::Matrix& aHeadTransform);
   static void GetTargetImmersiveSize(const uint32_t aRequestedWidth, const uint32_t  aRequestedHeight,
                                      const uint32_t aRecommendedWidth, const uint32_t aRecommendedHeight,
                                      uint32_t& aTargetWidth, uint32_t& aTargetHeight) {

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -78,7 +78,8 @@ const char* const kSetHandTrackingSupported = "setHandTrackingSupported";
 const char* const kSetHandTrackingSupportedSignature = "(Z)V";
 const char* const kOnControllersAvailable = "onControllersAvailable";
 const char* const kOnControllersAvailableSignature = "()V";
-
+const char* const kSetWindowDistance = "setWindowDistance";
+const char* const kSetWindowDistanceSignature = "(F)V";
 
 JNIEnv* sEnv = nullptr;
 jclass sBrowserClass = nullptr;
@@ -117,6 +118,7 @@ jmethodID sOnAppFocusChanged = nullptr;
 jmethodID sSetEyeTrackingSupported = nullptr;
 jmethodID sSetHandTrackingSupported = nullptr;
 jmethodID sOnControllersAvailable = nullptr;
+jmethodID sSetWindowDistance = nullptr;
 
 } // namespace
 
@@ -171,6 +173,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sSetEyeTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetEyeTrackingSupported, kSetEyeTrackingSupportedSignature);
   sSetHandTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetHandTrackingSupported, kSetHandTrackingSupportedSignature);
   sOnControllersAvailable = FindJNIMethodID(sEnv, sBrowserClass, kOnControllersAvailable, kOnControllersAvailableSignature);
+  sSetWindowDistance = FindJNIMethodID(sEnv, sBrowserClass, kSetWindowDistance, kSetWindowDistanceSignature);
 }
 
 JNIEnv * VRBrowser::Env()
@@ -220,6 +223,7 @@ VRBrowser::ShutdownJava() {
   sDisableLayers = nullptr;
   sEnv = nullptr;
   sAppendAppNotesToCrashReport = nullptr;
+  sSetWindowDistance = nullptr;
 }
 
 void
@@ -504,6 +508,13 @@ VRBrowser::OnControllersAvailable() {
     sEnv->CallVoidMethod(sActivity, sOnControllersAvailable);
     CheckJNIException(sEnv, __FUNCTION__);
 
+}
+
+void
+VRBrowser::SetWindowDistance(const float aDistance) {
+    if (!ValidateMethodID(sEnv, sActivity, sSetWindowDistance, __FUNCTION__)) { return; }
+    sEnv->CallVoidMethod(sActivity, sSetWindowDistance, aDistance);
+    CheckJNIException(sEnv, __FUNCTION__);
 }
 
 } // namespace crow

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -53,6 +53,7 @@ void OnAppFocusChanged(const bool aIsFocused);
 void SetEyeTrackingSupported(bool aIsSupported);
 void SetHandTrackingSupported(bool aIsSupported);
 void OnControllersAvailable();
+void SetWindowDistance(jfloat aDistance);
 } // namespace VRBrowser;
 
 } // namespace crow

--- a/app/src/main/res/drawable/rounded_line.xml
+++ b/app/src/main/res/drawable/rounded_line.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/white" />
+    <corners android:radius="5dp" />
+    <size android:height="5dp" />
+</shape>

--- a/app/src/main/res/layout/navigation_bar_fullscreen.xml
+++ b/app/src/main/res/layout/navigation_bar_fullscreen.xml
@@ -51,7 +51,7 @@
                 android:src="@drawable/ic_icon_move"
                 android:tooltipText="@string/move_tooltip"
                 app:privateMode="@{viewmodel.isPrivateSession}"
-                app:visibleGone="@{settingsmodel.isWindowMovementEnabled &amp;&amp; viewmodel.isCurved}" />
+                app:visibleGone="@{viewmodel.isCurved}" />
 
             <com.igalia.wolvic.ui.views.UIButton
                 android:id="@+id/brightnessButton"

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -11,8 +11,16 @@
             name="settingsmodel"
             type="com.igalia.wolvic.ui.viewmodel.SettingsViewModel" />
     </data>
+
     <LinearLayout
         android:id="@+id/navigationBarContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="0dp">
+
+    <!-- Navigation bar -->
+    <LinearLayout
         style="?attr/navigationBarStyle"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -136,16 +144,6 @@
         </RelativeLayout>
 
         <com.igalia.wolvic.ui.views.UIButton
-            android:id="@+id/moveButton"
-            style="?attr/navigationBarButtonStyle"
-            android:layout_marginStart="10dp"
-            android:layout_weight="0"
-            android:src="@drawable/ic_icon_move"
-            android:tooltipText="@string/move_tooltip"
-            app:privateMode="@{viewmodel.isPrivateSession}"
-            app:visibleGone="@{settingsmodel.isWindowMovementEnabled &amp;&amp; viewmodel.isCurved}" />
-
-        <com.igalia.wolvic.ui.views.UIButton
             android:id="@+id/menuButton"
             style="?attr/navigationBarButtonStyle"
             android:layout_marginStart="10dp"
@@ -153,5 +151,27 @@
             android:src="@drawable/ic_icon_hamburger_menu"
             android:tooltipText="@string/hamburger_menu_tooltip"
             app:privateMode="@{viewmodel.isPrivateSession}"/>
+    </LinearLayout>
+
+    <!-- Horizontal Divider -->
+        <FrameLayout
+            android:clickable="true"
+            android:id="@+id/moveBar"
+            android:radius="4dp"
+            android:layout_margin="10dp"
+            android:layout_width="128dp"
+            android:layout_height="32dp"
+            android:tooltipText="@string/move_tooltip"
+            android:layout_gravity="center_horizontal"
+            app:visibleGone="@{viewmodel.isCurved}">
+
+            <View
+                android:layout_width="@dimen/move_bar_width"
+                android:layout_height="8dp"
+                android:layout_gravity="center"
+                android:background="@drawable/rounded_line"
+                android:radius="4dp" />
+        </FrameLayout>
+
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -162,8 +162,7 @@
             android:layout_width="128dp"
             android:layout_height="32dp"
             android:tooltipText="@string/move_tooltip"
-            android:layout_gravity="center_horizontal"
-            app:visibleGone="@{viewmodel.isCurved}">
+            android:layout_gravity="center_horizontal">
 
             <View
                 android:layout_width="@dimen/move_bar_width"

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -149,12 +149,6 @@
                     android:layout_height="wrap_content"
                     app:description="@string/display_options_head_lock" />
 
-                <com.igalia.wolvic.ui.views.settings.SwitchSetting
-                    android:id="@+id/windowMovementSwitch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/display_options_windows_can_move" />
-
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -134,12 +134,6 @@
                     android:layout_height="wrap_content"
                     app:description="@string/developer_options_center_windows" />
 
-                <com.igalia.wolvic.ui.views.settings.SwitchSetting
-                    android:id="@+id/headLockSwitch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/display_options_head_lock" />
-
             </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -128,15 +128,6 @@
                     app:hintTextColor="@color/iron_blur"
                     app:highlightedTextColor="@color/fog" />
 
-                <com.igalia.wolvic.ui.views.settings.SliderSetting
-                    android:id="@+id/window_distance_slider"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/display_options_windows_distance"
-                    app:stepSize="0.1"
-                    app:valueFrom="0.0"
-                    app:valueTo="1.0" />
-
                 <com.igalia.wolvic.ui.views.settings.SwitchSetting
                     android:id="@+id/center_windows_switch"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1679,7 +1679,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n
 \nVIGTIGT: Medmindre du bruger Sync, vil den nye Wolvic-app ikke have dine bogmærker og faner.</string>
     <string name="developer_options_center_windows">Centrer vinduer vertikalt</string>
-    <string name="display_options_windows_can_move">Træk for at flytte vinduer</string>
     <string name="controller_options_haptic_feedback">Haptisk feedback</string>
     <string name="security_options_permission_fine_location_warning">Wolvic kan kun få din omtrentlige placering. Dette kan ændres i systemindstillingerne.</string>
     <string name="voice_input_start">Hvad vil du gerne have input til?</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -444,10 +444,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">Start with Passthrough Mode</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">Drag to move windows</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Use Sound Effects</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1789,7 +1789,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="display_options_start_with_passthrough">Usar el modo Passthrough al iniciar</string>
     <string name="tray_wifi_unavailable_ssid">SSID no disponible</string>
     <string name="voice_input_start">¿Qué te gustaría introducir?</string>
-    <string name="display_options_windows_can_move">Las ventanas se pueden mover</string>
     <string name="display_options_latin_auto_complete">Autocompletado con el teclado latino</string>
     <string name="display_options_head_lock">Activar Head Lock</string>
     <string name="controller_options_haptic_feedback">Feedback táctil</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1334,10 +1334,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">Iniciar en modo Passthrough</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">Las ventanas pueden moverse</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Usar efectos sonoros</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1563,7 +1563,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="developer_options_ua_vr">VR</string>
     <string name="developer_options_center_windows">Keskitä ikkunat pystysuoraan</string>
     <string name="display_options_head_lock">Ota päälukko käyttöön</string>
-    <string name="display_options_windows_can_move">Siirrä ikkunaa raahamalla</string>
     <string name="display_options_sound_effect">Käytä äänitehosteita</string>
     <string name="display_options_latin_auto_complete">Latinalaisen näppäimistön automaattinen täydennys</string>
     <string name="display_options_windows_distance">Ikkunan etäisyys</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1805,7 +1805,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="experimental_features">Fonctionnalités expérimentales</string>
     <string name="controller_options_haptic_feedback">Retour haptique</string>
     <string name="developer_options_center_windows">Centrer les fenêtres verticalement</string>
-    <string name="display_options_windows_can_move">Glisser pour déplacer les fenêtres</string>
     <string name="fxa_account_options_device_name">Nom de l\'appareil</string>
     <string name="device_name">%1$s sur %2$s</string>
     <string name="permission_rationale_title">Permissions supplémentaires</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -332,7 +332,6 @@
     <string name="history_context_add_bookmarks">Engadir aos marcadores</string>
     <string name="history_context_remove_bookmarks">Eliminar dos marcadores</string>
     <string name="download_context_delete">Borrar</string>
-    <string name="display_options_windows_can_move">As xanelas poden moverse</string>
     <string name="display_options_sound_effect">Usar efectos de son</string>
     <string name="display_options_head_lock">Activar Head Lock</string>
     <string name="display_options_windows_distance">Distancia das xanelas</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1688,7 +1688,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 \n\t•Wolvicの一部の機能はウェブ情報サービスを利用しています。そのサービスの信憑性やエラーの有無は保証できません。この機能に関する詳細（ウェブ情報サービスを利用する機能を不有効にする方法なども含み）は以下の利用規約に記述されています。</string>
     <string name="terms_service_subtitle_2">Wolvicウェブ情報サービス</string>
     <string name="developer_options_center_windows">ウィンドウを上下中央揃えにする</string>
-    <string name="display_options_windows_can_move">ウィンドウのドラッグを有効にする</string>
     <string name="display_options_sound_effect">効果音を使う</string>
     <string name="display_options_latin_auto_complete">ラテン文字キーボード入力の自動補完</string>
     <string name="display_options_head_lock">ヘッドロックを有効にする</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1796,7 +1796,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="video_mode_3d_top_bottom">3D 상하 화면</string>
     <string name="clear_user_data_dialog_text">%1$s이 초기화 됩니다. 동기화하지 않은 경우, 저장된 로그인 정보, 방문 기록과 북마크를 포함한 모든 데이터가 완전히 삭제됩니다. %1$s은 초기화가 완료된 후 자동으로 종료됩니다. 계속하시겠습니까?</string>
     <string name="security_options_use_system_root_ca">시스템에서 신뢰할 수 있는 루트 인증서 사용</string>
-    <string name="display_options_windows_can_move">드래그로 창 이동하기</string>
     <string name="display_options_latin_auto_complete">라틴어 키보드 입력 시 자동 완성</string>
     <string name="display_options_windows_distance">창 간 거리</string>
     <string name="controller_options_haptic_feedback">햅틱 피드백</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -768,7 +768,6 @@
     <string name="device_name">%1$s em %2$s</string>
     <string name="move_tooltip">Mover</string>
     <string name="developer_options_center_windows">Centralizar Janelas Verticalmente</string>
-    <string name="display_options_windows_can_move">Arraste para mover janelas</string>
     <string name="display_options_sound_effect">Usar efeitos sonoros</string>
     <string name="display_options_latin_auto_complete">Teclado em Latim com Autocompletar</string>
     <string name="display_options_head_lock">Habilitar bloqueio de cabeça</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -433,7 +433,6 @@
     <string name="developer_options_msaa_disabled">Desativado</string>
     <string name="settings_accounts_sign_out">Sair</string>
     <string name="developer_options_center_windows">Centralizar as Janelas Verticalmente</string>
-    <string name="display_options_windows_can_move">Arrastar para mover janelas</string>
     <string name="display_options_sound_effect">Usar efeitos sonoros</string>
     <string name="display_options_windows_distance">Distância das janelas</string>
     <string name="experimental_features">Funcionalidades experimentais</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1667,7 +1667,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="download_addon_install_blocked">Установка локального дополнения заблокирована</string>
     <string name="voice_service_metkai">MeetKai</string>
     <string name="developer_options_center_windows">Центрировать окна по вертикали</string>
-    <string name="display_options_windows_can_move">Передвигать окна перетаскиванием</string>
     <string name="display_options_sound_effect">Использовать звуковые эффекты</string>
     <string name="display_options_start_with_passthrough">Начинать в режиме Passthrough</string>
     <string name="display_options_latin_auto_complete">Автодополнение слов для латинской клавиатуры</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -1804,7 +1804,6 @@ the Select` button. When clicked it closes all the previously selected tabs -->
     <string name="controller_options_haptic_feedback">Haptisk feedback</string>
     <string name="fxa_account_options_device_name">Enhetsnamn</string>
     <string name="move_tooltip">Flytta</string>
-    <string name="display_options_windows_can_move">Dra för att flytta fönster</string>
     <string name="display_options_sound_effect">Använd ljudeffekter</string>
     <string name="display_options_windows_distance">Fönster distans</string>
     <string name="display_options_latin_auto_complete">Latinsk tangentbordsinmatning Automatisk komplettering</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -778,7 +778,6 @@
     <string name="fxa_account_options_device_name">Найменування пристрою</string>
     <string name="experimental_features">Експериментальні можливості</string>
     <string name="move_tooltip">Перемістити</string>
-    <string name="display_options_windows_can_move">Перетягування для переміщення вікон</string>
     <string name="display_options_sound_effect">Використовувати звукові ефекти</string>
     <string name="device_name">%1$s на %2$s</string>
     <string name="hamburger_menu_zoom">Масштабування</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -346,9 +346,6 @@
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">启动时使用直通模式</string>
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">拖拽移动窗口</string>
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">使用音效</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -446,10 +446,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">啟動時使用直通模式</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">拖拽移動視窗</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">使用音效</string>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -16,10 +16,12 @@
 
     <!-- Navigation bar -->
     <dimen name="navigation_bar_width">720dp</dimen>
-    <dimen name="navigation_bar_height">44dp</dimen>
+    <dimen name="navigation_bar_height">74dp</dimen>
     <dimen name="url_bar_item_width">28dp</dimen>
     <dimen name="url_bar_first_item_width">36dp</dimen>
     <dimen name="url_bar_last_item_width">36dp</dimen>
+    <dimen name="move_bar_width">60dp</dimen>
+    <dimen name="move_bar_hover_width">80dp</dimen>
 
     <!-- Title bar -->
     <dimen name="title_bar_width">300dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,10 +499,6 @@
          and is used to customize if we use passthrough mode when the app starts. -->
     <string name="display_options_start_with_passthrough">Start with Passthrough Mode</string>
 
-    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to
-         customize if windows can be moved. Enabling it adds a Move button to the navigation bar. -->
-    <string name="display_options_windows_can_move">Drag to move windows</string>
-
     <!-- This string labels an On/Off switch in the 'Display Options' dialog
          and is used to customize if we use sound effects when interacting with app. -->
     <string name="display_options_sound_effect">Use Sound Effects</string>

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
@@ -166,7 +166,7 @@ DeviceDelegateNoAPI::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
-DeviceDelegateNoAPI::Reorient() {
+DeviceDelegateNoAPI::Reorient(vrb::Matrix&) {
   // Ignore reorient
 }
 

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.h
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.h
@@ -30,7 +30,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
-  void Reorient() override;
+  void Reorient(vrb::Matrix&) override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -930,9 +930,8 @@ DeviceDelegateOpenXR::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
-DeviceDelegateOpenXR::Reorient() {
-  vrb::Matrix head = GetHeadTransform();
-  m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(head, kAverageHeight);
+DeviceDelegateOpenXR::Reorient(vrb::Matrix& transform) {
+  m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(transform);
 }
 
 void

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -34,7 +34,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
-  void Reorient() override;
+  void Reorient(vrb::Matrix&) override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -183,9 +183,8 @@ DeviceDelegateVisionGlass::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
-DeviceDelegateVisionGlass::Reorient() {
-    vrb::Matrix head = GetHeadTransform();
-    m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(head, kAverageHeight);
+DeviceDelegateVisionGlass::Reorient(vrb::Matrix& transform) {
+    m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(transform);
 }
 
 void

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
@@ -30,7 +30,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
-  void Reorient() override;
+  void Reorient(vrb::Matrix&) override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -594,7 +594,7 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
             mBinding.headlockToggleButton.setChecked(
                     SettingsStore.getInstance(PlatformActivity.this).isHeadLockEnabled());
             mBinding.headlockToggleButton.setOnClickListener(v -> {
-                mDelegate.setHeadLockEnabled(mBinding.headlockToggleButton.isChecked());
+                mDelegate.setLockMode(mBinding.headlockToggleButton.isChecked() ? WidgetManagerDelegate.HEAD_LOCK : WidgetManagerDelegate.NO_LOCK);
             });
 
             mBinding.playButton.setOnClickListener(v -> {

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -657,9 +657,8 @@ DeviceDelegateWaveVR::SetReorientTransform(const vrb::Matrix& aMatrix) {
 }
 
 void
-DeviceDelegateWaveVR::Reorient() {
-  vrb::Matrix head = GetHeadTransform();
-  m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(head, kAverageHeight);
+DeviceDelegateWaveVR::Reorient(vrb::Matrix& transform) {
+  m.reorientMatrix = DeviceUtils::CalculateReorientationMatrixOnHeadLock(transform);
 }
 
 void

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
@@ -26,7 +26,7 @@ public:
   const vrb::Matrix& GetHeadTransform() const override;
   const vrb::Matrix& GetReorientTransform() const override;
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
-  void Reorient() override;
+  void Reorient(vrb::Matrix&) override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;


### PR DESCRIPTION
Users should be able to move the windows around (although the 3 windows will still be grouped together) by clicking and dragging in the recently added move bar bellow the window. It's also possible to modify the distance from the user to the window by moving close/away the controller used to move the windows.

We can now get rid of the window distance slider in the display settings.

I'm also removing the head lock switch from the settings as it has never been very useful and similar positioning capabilities can be achieved now with this PR.

Fixes #99, fixes #927, fixes #707