### PR TITLE
Fix content type values being null after deserializing

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -98,7 +98,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         int textureHeight;
         float worldWidth;
         int tabIndex = -1;
-        ContentType panelType = ContentType.WEB_CONTENT;
+        // NOTE: Enum values may be null when deserialized by GSON.
+        ContentType contentType = ContentType.WEB_CONTENT;
 
         public void load(@NonNull WindowWidget aWindow, WindowsState aState, int aTabIndex) {
             WidgetPlacement widgetPlacement;
@@ -118,10 +119,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             worldWidth = widgetPlacement.worldWidth;
             tabIndex = aTabIndex;
             if (aWindow.isNativeContentVisible()) {
-                panelType = aWindow.getSelectedPanel();
+                contentType = aWindow.getSelectedPanel();
 
             } else {
-                panelType = ContentType.WEB_CONTENT;
+                contentType = ContentType.WEB_CONTENT;
             }
         }
     }
@@ -171,9 +172,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         DOWNLOADS(UrlUtils.ABOUT_DOWNLOADS),
         ADDONS(UrlUtils.ABOUT_ADDONS),
         NOTIFICATIONS(UrlUtils.ABOUT_NOTIFICATIONS);
-        public final String URL;
 
-        ContentType(String url) {
+        @NonNull
+        public final String URL;
+        ContentType(@NonNull String url) {
             this.URL = url;
         }
     }
@@ -365,13 +367,16 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (aSession != null) {
             aSession.setActive(true);
         }
+        if (aState.contentType == null) {
+            aState.contentType = ContentType.WEB_CONTENT;
+        }
         WindowWidget newWindow = createWindow(aSession);
         newWindow.getPlacement().width = aState.textureWidth;
         newWindow.getPlacement().height = aState.textureHeight;
         newWindow.getPlacement().worldWidth = aState.worldWidth;
         placeWindow(newWindow, aState.placement);
         if (newWindow.getSession() != null) {
-            switch (aState.panelType) {
+            switch (aState.contentType) {
                 case BOOKMARKS:
                     newWindow.getSession().loadUri(UrlUtils.ABOUT_BOOKMARKS);
                     break;


### PR DESCRIPTION
When we restore the window state from a JSON file, the content type field may be null if the GSON library was not able to map it to one of the enum values.

https://github.com/Igalia/wolvic/pull/1644 changed the type of the WindowState.panelType field from integer to enum. This meant that the serialized values did not match the new type, causing the restored field to unexpectedly become NULL. This caused a crash.

The solution is to change the name of the field to WindowState.contentType so it will not cause a clash when serializing and deserializing. Additionally, this PR adds checks to ensure that the restored value is not NULL.

Fixes https://github.com/Igalia/wolvic/issues/1648