### PR TITLE
[WebPayments] Introduce OverlayWidget & Use it by PaymentHandler

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -25,6 +25,7 @@ import org.chromium.content_public.browser.WebContents;
 import org.chromium.wolvic.DownloadManagerBridge;
 import org.chromium.wolvic.PasswordForm;
 import org.chromium.wolvic.PermissionManagerBridge;
+import org.chromium.wolvic.TabCompositorView;
 import org.chromium.wolvic.UserDialogManagerBridge;
 
 import java.io.InputStream;
@@ -114,8 +115,8 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
         if (mTab == null)
             return;
 
-        assert mTab.getContentView() != null;
-        WebContents webContents = mTab.getContentView().getWebContents();
+        assert mTab.getActiveWebContents() != null;
+        WebContents webContents = mTab.getActiveWebContents();
         if (active) {
             webContents.onShow();
         } else {
@@ -129,8 +130,8 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     public void setFocused(boolean focused) {
         if (mTab == null)
             return;
-        assert mTab.getContentView() != null;
-        mTab.getContentView().getWebContents().setFocus(focused);
+        assert mTab.getActiveWebContents() != null;
+        mTab.getActiveWebContents().setFocus(focused);
     }
 
     @Override
@@ -212,6 +213,20 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     @Override
     public void releaseDisplay(@NonNull WDisplay display) {
         mRuntime.getContainerView().removeView(mTab.getCompositorView());
+        getTextInput().setView(null);
+    }
+
+    public WDisplay acquireOverlayDisplay(TabCompositorView compositorView) {
+        SettingsStore settings = SettingsStore.getInstance(mRuntime.getContext());
+        WDisplay display = new DisplayImpl(this, compositorView);
+        mRuntime.getContainerView().addView(compositorView,
+                new ViewGroup.LayoutParams(settings.getWindowWidth() / 2, settings.getWindowHeight() / 2));
+        getTextInput().setView(getContentView());
+        return display;
+    }
+
+    public void releaseOverlayDisplay(TabCompositorView compositorView) {
+        mRuntime.getContainerView().removeView(compositorView);
         getTextInput().setView(null);
     }
 
@@ -457,7 +472,7 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     }
 
     public ViewGroup getContentView() {
-        return mTab != null ? mTab.getContentView() : null;
+        return mTab != null ? mTab.getActiveContentView() : null;
     }
 
     // The onReadyCallback() mechanism is really limited because it heavily depends on renderers

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabImpl.java
@@ -4,18 +4,25 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import org.chromium.components.embedder_support.view.ContentView;
 import org.chromium.content_public.browser.MediaSessionObserver;
 import org.chromium.content_public.browser.SelectionPopupController;
 import org.chromium.content_public.browser.WebContents;
 import org.chromium.wolvic.Tab;
+import org.chromium.wolvic.TabCompositorView;
 
 /**
- * Controlls a single tab content in a browser for chromium backend.
+ * Controls a single tab content in a browser for chromium backend.
  */
 public class TabImpl extends Tab {
     private TabMediaSessionObserver mTabMediaSessionObserver;
     private TabWebContentsDelegate mTabWebContentsDelegate;
     private TabWebContentsObserver mWebContentsObserver;
+    private WebContents mPaymentHandlerWebContents;
+    // TODO: Need to Payment's mediator
+    private ContentView mPaymentHandlerContentView;
+    private TabCompositorView mPaymentHandlerCompositorView;
+
 
     public TabImpl(@NonNull Context context, @NonNull SessionImpl session, WebContents webContents) {
         super(context, session.getSettings().getUsePrivateMode(), webContents);
@@ -27,7 +34,7 @@ public class TabImpl extends Tab {
         mTabWebContentsDelegate = new TabWebContentsDelegate(session, mWebContents);
         setWebContentsDelegate(mWebContents, mTabWebContentsDelegate);
 
-        mWebContentsObserver = new TabWebContentsObserver(mWebContents, session);
+        mWebContentsObserver = new TabWebContentsObserver(this, session);
 
         SelectionPopupController controller =
                 SelectionPopupController.fromWebContents(mWebContents);
@@ -46,5 +53,23 @@ public class TabImpl extends Tab {
 
     public void purgeHistory() {
         mWebContents.getNavigationController().clearHistory();
+    }
+
+    public void setPaymentWebContents(WebContents webContents, ContentView contentView, TabCompositorView compositorView) {
+        mPaymentHandlerWebContents = webContents;
+        mPaymentHandlerContentView = contentView;
+        mPaymentHandlerCompositorView = compositorView;
+    }
+
+    public WebContents getActiveWebContents() {
+        return mPaymentHandlerWebContents != null ? mPaymentHandlerWebContents : mWebContents;
+    }
+
+    public ContentView getActiveContentView() {
+       return mPaymentHandlerContentView != null ? mPaymentHandlerContentView : getContentView();
+    }
+
+    public TabCompositorView getActiveCompositorView() {
+       return mPaymentHandlerCompositorView != null ? mPaymentHandlerCompositorView : getCompositorView();
     }
 }

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -21,6 +21,7 @@ import org.chromium.ui.base.IntentRequestTracker;
 import org.chromium.ui.base.ViewAndroidDelegate;
 import org.chromium.ui.base.WindowAndroid;
 import org.chromium.url.GURL;
+import org.chromium.wolvic.Tab;
 import org.chromium.wolvic.TabCompositorView;
 import org.chromium.wolvic.WolvicWebContentsFactory;
 
@@ -128,13 +129,10 @@ public class TabWebContentsObserver extends WebContentsObserver {
             return;
         }
 
+        Context context = mWebContents.get().getTopLevelNativeWindow().getContext().get();
+        final TabCompositorView compositorView = Tab.createNewTab(context, newWebContents);
         assert newWebContents.getViewAndroidDelegate() != null
              : "WebContents should be initialized.";
-        WindowAndroid windowAndroid = newWebContents.getTopLevelNativeWindow();
-        Context context = mWebContents.get().getTopLevelNativeWindow().getContext().get();
-        final TabCompositorView compositorView = new TabCompositorView(context);
-        compositorView.onNativeLibraryLoaded(windowAndroid);
-        windowAndroid.setAnimationPlaceholderView(compositorView);
 
         ViewAndroidDelegate viewDelegate = newWebContents.getViewAndroidDelegate();
         assert viewDelegate.getContainerView() instanceof ContentView

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TabWebContentsObserver.java
@@ -22,6 +22,7 @@ import org.chromium.ui.base.ViewAndroidDelegate;
 import org.chromium.ui.base.WindowAndroid;
 import org.chromium.url.GURL;
 import org.chromium.wolvic.Tab;
+import org.chromium.wolvic.payments.ui.PaymentRequestUI;
 import org.chromium.wolvic.TabCompositorView;
 import org.chromium.wolvic.WolvicWebContentsFactory;
 
@@ -130,7 +131,8 @@ public class TabWebContentsObserver extends WebContentsObserver {
         }
 
         Context context = mWebContents.get().getTopLevelNativeWindow().getContext().get();
-        final TabCompositorView compositorView = Tab.createNewTab(context, newWebContents);
+        PaymentRequestUI paymentHandler = new PaymentRequestUI(context, newWebContents, null);
+        final TabCompositorView compositorView = paymentHandler.getCompositorView();
         assert newWebContents.getViewAndroidDelegate() != null
              : "WebContents should be initialized.";
 

--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/TextInputImpl.java
@@ -19,6 +19,7 @@ import com.igalia.wolvic.browser.api.WTextInput;
 
 import org.chromium.content_public.browser.ImeAdapter;
 import org.chromium.content_public.browser.InputMethodManagerWrapper;
+import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.WindowAndroid;
 
 public class TextInputImpl implements WTextInput {
@@ -180,6 +181,7 @@ public class TextInputImpl implements WTextInput {
     }
 
     private ImeAdapter getImeAdapter() {
-        return mSession.getTab() != null ? mSession.getTab().getImeAdapter() : null;
+        WebContents webContents = mSession.getTab() != null ? mSession.getTab().getActiveWebContents() : null;
+        return webContents != null ? ImeAdapter.fromWebContents(webContents) : null;
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -71,6 +71,7 @@ import com.igalia.wolvic.ui.adapters.Language;
 import com.igalia.wolvic.ui.widgets.AppServicesProvider;
 import com.igalia.wolvic.ui.widgets.KeyboardWidget;
 import com.igalia.wolvic.ui.widgets.NavigationBarWidget;
+import com.igalia.wolvic.ui.widgets.OverlayContentWidget;
 import com.igalia.wolvic.ui.widgets.RootWidget;
 import com.igalia.wolvic.ui.widgets.TrayWidget;
 import com.igalia.wolvic.ui.widgets.UISurfaceTextureRenderer;
@@ -1107,6 +1108,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 if (!windowWidget.isLibraryVisible()) {
                     scale = 1.0f;
                 }
+            } else if (widget instanceof OverlayContentWidget) {
+                scale = 1.0f;
             }
             final float x = aX / scale;
             final float y = aY / scale;

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -317,6 +317,29 @@ public interface WSession {
          */
         @UiThread
         default void onShowDynamicToolbar(@NonNull final WSession aSession) {}
+
+        public interface OnPaymentHandlerCallback {
+            void onDismiss();
+        }
+
+        /**
+         * The view should display its payment handler, overlayed on the active tab.
+         *
+         * @param aSession ISession that initiated the callback.
+         * @param aDisplay IDisplay that initiated the callback.
+         * @param callback Callback interface.
+         */
+        @UiThread
+        default void onShowPaymentHandler(@NonNull final WSession aSession,
+                @NonNull final WDisplay aDisplay,
+                @NonNull final OnPaymentHandlerCallback callback) {}
+        /**
+         * The view should hide its payment handler.
+         *
+         * @param aSession ISession that initiated the callback.
+         */
+        @UiThread
+        default void onHidePaymentHandler(@NonNull final WSession aSession) {}
     }
 
     interface NavigationDelegate {

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1422,6 +1422,20 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         }
     }
 
+    @Override
+    public void onShowPaymentHandler(@NonNull final WSession aSession, @NonNull WDisplay aDisplay, @NonNull OnPaymentHandlerCallback callback) {
+        for (WSession.ContentDelegate listener : mContentListeners) {
+            listener.onShowPaymentHandler(aSession, aDisplay, callback);
+        }
+    }
+
+    @Override
+    public void onHidePaymentHandler(@NonNull final WSession aSession) {
+        for (WSession.ContentDelegate listener : mContentListeners) {
+            listener.onHidePaymentHandler(aSession);
+        }
+    }
+
     // TextInput Delegate
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/OverlayContentWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/OverlayContentWidget.java
@@ -1,0 +1,228 @@
+package com.igalia.wolvic.ui.widgets;
+
+import android.content.Context;
+import android.graphics.SurfaceTexture;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.Surface;
+
+import androidx.annotation.NonNull;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserApplication;
+import com.igalia.wolvic.browser.api.WDisplay;
+import com.igalia.wolvic.browser.api.WSession;
+
+import java.util.concurrent.Executor;
+
+public class OverlayContentWidget extends UIWidget implements WidgetManagerDelegate.WorldClickListener {
+    private Surface mSurface;
+    private int mSurfaceWidth;
+    private int mSurfaceHeight;
+    private Runnable mFirstDrawCallback;
+    private WSession mSession;
+    private WDisplay mDisplay;
+    private WSession.ContentDelegate.OnPaymentHandlerCallback mCallback;
+    private Executor mUIThreadExecutor;
+    private Handler mHandler;
+
+    public OverlayContentWidget(Context aContext) {
+        super(aContext);
+        initialize(aContext);
+    }
+
+    public OverlayContentWidget(Context aContext, AttributeSet aAttrs) {
+        super(aContext, aAttrs);
+        initialize(aContext);
+    }
+
+    public OverlayContentWidget(Context aContext, AttributeSet aAttrs, int aDefStyle) {
+        super(aContext, aAttrs, aDefStyle);
+        initialize(aContext);
+    }
+
+    public void setDelegates(@NonNull WSession session, @NonNull WDisplay display,
+                             @NonNull WSession.ContentDelegate.OnPaymentHandlerCallback callback) {
+        mSession = session;
+        mDisplay = display;
+        mCallback = callback;
+    }
+
+    @Override
+    public void releaseWidget() {
+        mWidgetManager.removeWorldClickListener(this);
+        mCallback.onDismiss();
+
+        super.releaseWidget();
+    }
+
+    @Override
+    protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
+        aPlacement.visible = false;
+        aPlacement.width =  WidgetPlacement.dpDimension(getContext(), R.dimen.tabs_width);
+        aPlacement.height = WidgetPlacement.dpDimension(getContext(), R.dimen.tabs_height);
+
+        aPlacement.parentAnchorX = 0.5f;
+        aPlacement.parentAnchorY = 0.0f;
+        aPlacement.anchorX = 0.5f;
+        aPlacement.anchorY = 0.5f;
+        aPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_y) -
+                                  WidgetPlacement.unitFromMeters(getContext(), R.dimen.window_world_y);
+        updatePlacementTranslationZ();
+    }
+
+    @Override
+    public void updatePlacementTranslationZ() {
+        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_z) -
+                                      WidgetPlacement.getWindowWorldZMeters(getContext());
+    }
+
+    private void initialize(Context aContext) {
+        mUIThreadExecutor = ((VRBrowserApplication)aContext.getApplicationContext()).getExecutors().mainThread();
+        mHandler = new Handler(Looper.getMainLooper());
+
+        mWidgetManager.addWorldClickListener(this);
+    }
+
+    @Override
+    public void attachToWindow(@NonNull WindowWidget window) {
+        mWidgetPlacement.parentHandle = window.getHandle();
+    }
+
+    // View
+    @Override
+    public boolean onKeyPreIme(int aKeyCode, KeyEvent aEvent) {
+        if (super.onKeyPreIme(aKeyCode, aEvent)) {
+            return true;
+        }
+        return mSession.getTextInput().onKeyPreIme(aKeyCode, aEvent);
+    }
+
+    @Override
+    public boolean onKeyUp(int aKeyCode, KeyEvent aEvent) {
+        if (super.onKeyUp(aKeyCode, aEvent)) {
+            return true;
+        }
+        return mSession.getTextInput().onKeyUp(aKeyCode, aEvent);
+    }
+
+    @Override
+    public boolean onKeyDown(int aKeyCode, KeyEvent aEvent) {
+        if (super.onKeyDown(aKeyCode, aEvent)) {
+            return true;
+        }
+        return mSession.getTextInput().onKeyDown(aKeyCode, aEvent);
+    }
+
+    @Override
+    public boolean onKeyLongPress(int aKeyCode, KeyEvent aEvent) {
+        if (super.onKeyLongPress(aKeyCode, aEvent)) {
+            return true;
+        }
+        return mSession.getTextInput().onKeyLongPress(aKeyCode, aEvent);
+    }
+
+    @Override
+    public boolean onKeyMultiple(int aKeyCode, int repeatCount, KeyEvent aEvent) {
+        if (super.onKeyMultiple(aKeyCode, repeatCount, aEvent)) {
+            return true;
+        }
+        return mSession.getTextInput().onKeyMultiple(aKeyCode, repeatCount, aEvent);
+    }
+
+    @Override
+    public void handleHoverEvent(MotionEvent aEvent) {
+        mSession.getPanZoomController().onMotionEvent(aEvent);
+    }
+
+    @Override
+    public void handleTouchEvent(MotionEvent aEvent) {
+        if (aEvent.getActionMasked() == MotionEvent.ACTION_DOWN) {
+            requestFocus();
+            requestFocusFromTouch();
+        }
+
+        mSession.getPanZoomController().onTouchEvent(aEvent);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent aEvent) {
+        mSession.getPanZoomController().onTouchEvent(aEvent);
+        return true;
+    }
+
+    @Override
+    public boolean onGenericMotionEvent(MotionEvent aEvent) {
+        mSession.getPanZoomController().onMotionEvent(aEvent);
+        return true;
+    }
+
+    @Override
+    public void setSurfaceTexture(SurfaceTexture aTexture, final int aWidth, final int aHeight, Runnable aFirstDrawCallback) {
+        mFirstDrawCallback = aFirstDrawCallback;
+         if (aTexture == null) {
+            setWillNotDraw(true);
+            return;
+        }
+        mSurfaceWidth = aWidth;
+        mSurfaceHeight = aHeight;
+        mTexture = aTexture;
+        aTexture.setDefaultBufferSize(aWidth, aHeight);
+        mSurface = new Surface(aTexture);
+        callSurfaceChanged();
+        if (mFirstDrawCallback != null) {
+             mUIThreadExecutor.execute(mFirstDrawCallback);
+             mFirstDrawCallback = null;
+        }
+    }
+
+    @Override
+    public void setSurface(Surface aSurface, final int aWidth, final int aHeight, Runnable aFirstDrawCallback) {
+        mSurfaceWidth = aWidth;
+        mSurfaceHeight = aHeight;
+        mSurface = aSurface;
+        mFirstDrawCallback = aFirstDrawCallback;
+        if (mSurface != null) {
+            callSurfaceChanged();
+        } else {
+            mDisplay.surfaceDestroyed();
+        }
+        if (mFirstDrawCallback != null) {
+            mUIThreadExecutor.execute(mFirstDrawCallback);
+            mFirstDrawCallback = null;
+        }
+    }
+
+    private void callSurfaceChanged() {
+        if (mSurface != null) {
+            mDisplay.surfaceChanged(mSurface, 0, 0, mSurfaceWidth, mSurfaceHeight);
+        }
+    }
+
+    @Override
+    public void resizeSurface(final int aWidth, final int aHeight) {
+        mSurfaceWidth = aWidth;
+        mSurfaceHeight = aHeight;
+        if (mTexture != null) {
+            mTexture.setDefaultBufferSize(aWidth, aHeight);
+        }
+
+        if (mTexture != null && mSurface != null) {
+            callSurfaceChanged();
+        }
+    }
+
+    @Override
+    public void onWorldClick() {
+        post(this::onDismiss);
+        mCallback.onDismiss();
+    }
+
+    @Override
+    public boolean isDialog() {
+        return true;
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -48,6 +48,7 @@ import com.igalia.wolvic.browser.SessionChangeListener;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.VideoAvailabilityListener;
 import com.igalia.wolvic.browser.api.WAllowOrDeny;
+import com.igalia.wolvic.browser.api.WDisplay;
 import com.igalia.wolvic.browser.api.WMediaSession;
 import com.igalia.wolvic.browser.api.WResult;
 import com.igalia.wolvic.browser.api.WSession;
@@ -125,6 +126,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private PromptDialogWidget mAppDialog;
     private ContextMenuWidget mContextMenu;
     private SelectionActionWidget mSelectionMenu;
+    private OverlayContentWidget mPaymentHandler;
     private int mWidthBackup;
     private int mHeightBackup;
     private int mBorderWidth;
@@ -1867,6 +1869,26 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                         getResources().getString(R.string.download_open_file_open_unsupported_body),
                         null);
             }
+        }
+    }
+
+    @Override
+    public void onShowPaymentHandler(@NonNull WSession session, @NonNull WDisplay display, @NonNull OnPaymentHandlerCallback callback) {
+        assert mPaymentHandler == null;
+        mPaymentHandler = new OverlayContentWidget(getContext());
+        mPaymentHandler.setDelegates(session, display, callback);
+
+        mPaymentHandler.getPlacement().parentHandle = getHandle();
+        mPaymentHandler.attachToWindow(this);
+        mPaymentHandler.show(KEEP_FOCUS);
+    }
+
+    @Override
+    public void onHidePaymentHandler(@NonNull WSession session) {
+        if (mPaymentHandler != null) {
+            mPaymentHandler.hide(REMOVE_WIDGET);
+            mPaymentHandler.releaseWidget();
+            mPaymentHandler = null;
         }
     }
 


### PR DESCRIPTION
A new OverlayWidget class is defined to render the payment handler  WebContents instance, provided by the web engine, as a result of the call to the Payment Request API. 

The tab that initiates the payment request needs to handle 2 WebContents instances, determining which one is active during the process. Hence, The OverlayWidget is implemented as modal dialog, preventing the original web-content to be updated until the payment request is completed.

The TabsWebContentObserver must implement a new WebContentsObserver method, defined to notify Wolvic that the new payment handler WebContents instance is ready. 

This PR depends on the [PR #143](https://github.com/Igalia/wolvic-chromium/pull/143) in the Chromium backend.  

This feature can be tested using the Web Payments demo at https://paymentrequest.show/demo