### PR TITLE
Add a link to Add-ons in the Settings

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/delegates/LibraryNavigationDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/delegates/LibraryNavigationDelegate.java
@@ -4,8 +4,10 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import com.igalia.wolvic.ui.widgets.Windows;
+
 public interface LibraryNavigationDelegate {
-    default void onButtonClick(@NonNull View view) {}
+    default void onButtonClick(Windows.ContentType contentType) {}
     default void onClose(@NonNull View view) {}
     default void onBack(@NonNull View view) {}
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -440,6 +440,10 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
             return;
         }
 
+        if (button.getAnimation() != null) {
+            button.getAnimation().cancel();
+        }
+
         int paddingStart = button.getPaddingLeft();
         button.animate()
                 .setDuration(duration)
@@ -605,6 +609,10 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
     }
 
     private Observer<Windows.ContentType> mCurrentContentTypeObserver = contentType -> {
+        // Prevent a race condition in case the animation runs faster than the data binding.
+        mBinding.bookmarksButton.setActiveMode(contentType != Windows.ContentType.WEB_CONTENT && contentType != Windows.ContentType.DOWNLOADS);
+        mBinding.downloadsButton.setActiveMode(contentType == Windows.ContentType.DOWNLOADS);
+
         if (contentType == Windows.ContentType.WEB_CONTENT) {
             animateButtonPadding(mBinding.bookmarksButton, mMaxPadding, ICON_ANIMATION_DURATION);
             animateButtonPadding(mBinding.downloadsButton, mMaxPadding, ICON_ANIMATION_DURATION);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -217,6 +217,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         setupListeners(mSession);
 
         mLibrary = new LibraryPanel(aContext);
+        mLibrary.setController(this::showPanel);
 
         SessionStore.get().getBookmarkStore().addListener(mBookmarksListener);
 

--- a/app/src/main/res/layout/library.xml
+++ b/app/src/main/res/layout/library.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
     <data>
+        <import type="com.igalia.wolvic.ui.widgets.Windows.ContentType"/>
         <variable
             name="delegate"
             type="com.igalia.wolvic.ui.delegates.LibraryNavigationDelegate" />
@@ -31,32 +32,32 @@
                         style="@style/libraryButtonStartTheme"
                         android:src="@drawable/ic_icon_bookmark"
                         android:id="@+id/bookmarks"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
+                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(ContentType.BOOKMARKS) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
                         style="@style/libraryButtonMiddleTheme"
                         android:src="@drawable/ic_icon_webapps"
                         android:id="@+id/web_apps"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
+                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(ContentType.WEB_APPS) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
                         style="@style/libraryButtonMiddleTheme"
                         android:src="@drawable/ic_icon_history"
                         android:id="@+id/history"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
+                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(ContentType.HISTORY) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
                         style="@style/libraryButtonMiddleTheme"
                         android:src="@drawable/ic_icon_downloads"
                         android:id="@+id/downloads"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
+                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(ContentType.DOWNLOADS) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
                         style="@style/libraryButtonMiddleTheme"
                         android:src="@drawable/ic_icon_addons"
                         android:id="@+id/addons"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"/>
+                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(ContentType.ADDONS) : void}"/>
                     <com.igalia.wolvic.ui.views.UIButton
                         style="@style/libraryButtonMiddleTheme"
                         android:src="@drawable/ic_icon_dialog_notification"
                         android:id="@+id/notifications"
-                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(view) : void}"
+                        android:onClick="@{(view) -> delegate != null ? delegate.onButtonClick(ContentType.NOTIFICATIONS) : void}"
                         visibleGone="@{supportsSystemNotifications}"/>
                 </LinearLayout>
             </FrameLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
         <variable
@@ -28,90 +29,98 @@
             android:layout_marginTop="50dp"
             android:src="@drawable/ic_icon_back"
             android:drawableTint="@color/fog_void_tint"
-            android:tint="@color/fog_void_tint"
             android:background="@drawable/media_button"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <LinearLayout
-            android:id="@+id/settingsMasthead"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
+        <ImageView
+            android:id="@+id/ff_logo_settings"
+            android:layout_width="130dp"
+            android:layout_height="84dp"
+            android:layout_gravity="center"
             android:layout_marginTop="23dp"
             android:clickable="true"
-            android:contextClickable="false"
-            android:focusable="true"
-            android:gravity="center_horizontal"
-            android:orientation="vertical"
-            android:contentDescription="Wolvic logo"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ff_logo"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageView
-                android:id="@+id/ff_logo_settings"
-                android:layout_width="130dp"
-                android:layout_height="84dp"
-                android:layout_gravity="center"
-                android:clickable="false"
-                android:scaleType="fitCenter"
-                android:src="@drawable/ff_logo" />
+        <TextView
+            android:id="@+id/versionText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:fontFamily="sans-serif"
+            android:gravity="center"
+            android:minHeight="@dimen/settings_outline_button_height"
+            android:text="@string/app_name"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_big_size"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ff_logo_settings" />
 
-            <TextView
-                android:id="@+id/versionText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:clickable="false"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:textColor="@color/white"
-                android:text="@string/app_name"
-                android:textSize="@dimen/text_big_size" />
+        <TextView
+            android:id="@+id/chinaLicenseNumber"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="false"
+            android:fontFamily="sans-serif"
+            android:gravity="center"
+            android:text="@string/rCN_license_number"
+            android:textColor="@color/azure"
+            android:textColorHighlight="@android:color/transparent"
+            android:textColorLink="@color/azure"
+            android:textSize="@dimen/text_medium_size"
+            android:textStyle="bold"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/versionText"
+            app:visibleGone="@{DeviceType.getStoreType() == DeviceType.StoreType.MAINLAND_CHINA}"
+            tools:text="(China license number)" />
 
-            <TextView
-                android:id="@+id/surveyLink"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:clickable="false"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:text="@string/settings_send_your_feedback"
-                android:textColorHighlight="@android:color/transparent"
-                android:textColorLink="@color/azure"
-                android:textColor="@color/azure"
-                android:autoLink="all"
-                android:textStyle="bold"
-                android:textSize="@dimen/text_smaller_size"
-                app:visibleGone="@{DeviceType.getStoreType() != DeviceType.StoreType.MAINLAND_CHINA}" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/surveyLink"
+            style="@style/SettingsLinkButtonStyle"
+            android:src="@drawable/baseline_contact_support_24"
+            android:text="@string/settings_send_your_feedback"
+            android:theme="@style/FxR.Dark"
+            app:icon="@drawable/baseline_contact_support_24"
+            app:layout_constraintEnd_toEndOf="@id/scrollView2"
+            app:layout_constraintBottom_toBottomOf="@id/whatsNewButton"
+            app:visibleGone="@{DeviceType.getStoreType() != DeviceType.StoreType.MAINLAND_CHINA}" />
 
-            <TextView
-                android:id="@+id/chinaLicenseNumber"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:clickable="false"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:text="@string/rCN_license_number"
-                android:textColor="@color/azure"
-                android:textColorHighlight="@android:color/transparent"
-                android:textColorLink="@color/azure"
-                android:textSize="@dimen/text_medium_size"
-                android:textStyle="bold"
-                app:visibleGone="@{DeviceType.getStoreType() == DeviceType.StoreType.MAINLAND_CHINA}" />
+        <TextView
+            android:id="@+id/buildText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="false"
+            android:fontFamily="sans-serif"
+            android:gravity="center"
+            android:minHeight="@dimen/settings_outline_button_height"
+            android:text="@string/settings_version_developer"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_smaller_size"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/chinaLicenseNumber" />
 
-            <TextView
-                android:id="@+id/buildText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:clickable="false"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:text="@string/settings_version_developer"
-                android:textColor="@color/white"
-                android:textSize="@dimen/text_smaller_size" />
-        </LinearLayout>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/whatsNewButton"
+            style="@style/SettingsLinkButtonStyle"
+            android:layout_marginStart="8dp"
+            android:layout_marginBottom="8dp"
+            android:backgroundTint="@{settingsmodel.isWhatsNewVisible?@color/azure:@color/asphalt}"
+            android:src="@drawable/ic_whats_new"
+            android:text="@string/settings_whats_new"
+            android:theme="@style/FxR.Dark"
+            android:layout_marginTop="10dp"
+            app:icon="@drawable/ic_whats_new"
+            app:layout_constraintEnd_toEndOf="@id/ff_logo_settings"
+            app:layout_constraintStart_toStartOf="@id/ff_logo_settings"
+            app:layout_constraintTop_toBottomOf="@id/scrollView2" />
 
         <ScrollView
             android:id="@+id/scrollView2"
@@ -124,7 +133,7 @@
             android:scrollbars="none"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/settingsMasthead">
+            app:layout_constraintTop_toBottomOf="@id/buildText">
 
             <HorizontalScrollView
                 android:layout_width="wrap_content"
@@ -208,32 +217,18 @@
                             app:honeycombButtonTextSize="@dimen/settings_main_button_text_width" />
 
                         <com.igalia.wolvic.ui.views.HoneycombButton
+                            android:id="@+id/addonsButton"
+                            style="?attr/honeycombButtonStyle"
+                            app:honeycombButtonIcon="@drawable/ic_icon_addons"
+                            app:honeycombButtonText="@string/url_addons_title"
+                            app:honeycombButtonTextSize="@dimen/settings_main_button_text_width" />
+
+                        <com.igalia.wolvic.ui.views.HoneycombButton
                             android:id="@+id/helpButton"
                             style="?attr/honeycombButtonStyle"
                             app:honeycombButtonIcon="@drawable/ic_settings_help"
                             app:honeycombButtonText="@string/settings_help"
                             app:honeycombButtonTextSize="@dimen/settings_main_button_text_width" />
-
-                        <RelativeLayout
-                            android:layout_width="136dp"
-                            android:layout_height="136dp"
-                            android:layout_marginEnd="-10dp">
-                            <com.igalia.wolvic.ui.views.HoneycombButton
-                                android:id="@+id/whatsNewButton"
-                                style="?attr/honeycombButtonStyle"
-                                app:honeycombButtonIcon="@drawable/ic_whats_new"
-                                app:honeycombButtonText="@string/settings_whats_new"
-                                app:honeycombButtonTextSize="@dimen/settings_main_button_text_width" />
-                            <com.google.android.material.textview.MaterialTextView
-                                android:layout_width="6dp"
-                                android:layout_height="6dp"
-                                android:layout_marginTop="48dp"
-                                android:layout_marginEnd="58dp"
-                                android:layout_alignParentTop="true"
-                                android:layout_alignParentEnd="true"
-                                android:background="@drawable/downloads_badge"
-                                app:visibleGone="@{settingsmodel.isWhatsNewVisible}"/>
-                        </RelativeLayout>
                     </LinearLayout>
                 </RelativeLayout>
             </HorizontalScrollView>

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -189,7 +189,7 @@
                 style="@style/trayButtonMiddleTheme"
                 android:src="@drawable/ic_icon_bookmark"
                 android:tooltipText="@{viewmodel.currentContentType == ContentType.BOOKMARKS ? @string/close_bookmarks_tooltip : @string/open_bookmarks_tooltip}"
-                app:activeMode="@{viewmodel.currentContentType == ContentType.BOOKMARKS}"
+                app:activeMode="@{viewmodel.currentContentType != ContentType.WEB_CONTENT &amp;&amp; viewmodel.currentContentType != ContentType.DOWNLOADS}"
                 app:clipDrawable="@drawable/ic_icon_library_clip"
                 app:tooltipDensity="@dimen/tray_tooltip_density"
                 app:tooltipLayout="@layout/tooltip_tray"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -75,6 +75,7 @@
     <dimen name="settings_width">680dp</dimen>
     <dimen name="settings_height">490dp</dimen>
     <dimen name="settings_main_button_text_width">125dp</dimen>
+    <dimen name="settings_outline_button_height">24dp</dimen>
 
     <!-- Lang Selector -->
     <dimen name="lang_selector_narrow_col_item_width">100dp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -225,6 +225,9 @@
     <string name="keyboard_nl_NL_popup_u" translatable="false">uúüûùūůų</string>
     <string name="keyboard_nl_NL_popup_i" translatable="false">ìíiïîįī</string>
 
+    <!-- Homepage link -->
+    <string name="home_page_url" translatable="false">https://wolvic.com/</string>
+
     <!-- Settings Survey link -->
     <string name="feedback_link" translatable="false">https://wolvic.com/en/feedback/index.html?version=%1$s&amp;device=%2$d</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -506,6 +506,15 @@
         <!-- Phone window decoration -->
         <item name="android:statusBarColor">@color/midnight</item>
         <item name="android:navigationBarColor">@color/midnight</item>
+
+        <!-- Basic colors for Material buttons and other elements -->
+        <item name="colorOnSurface">@color/fog</item>
+        <item name="colorSurface">@color/asphalt</item>
+        <item name="colorOnContainer">@color/fog</item>
+        <item name="colorContainer">@color/asphalt</item>
+        <item name="colorOnSecondaryContainer">@color/fog</item>
+        <item name="colorSecondaryContainer">@color/azure</item>
+
     </style>
 
     <style name="Widget.FastScroll" parent="android:Widget.Material.FastScroll"/>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -312,6 +312,20 @@
         <item name="android:clickable">true</item>
     </style>
 
+    <style name="SettingsLinkButtonStyle" parent="Widget.Material3.Button.Icon">
+        <item name="android:insetBottom">0dp</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:layout_height">@dimen/settings_outline_button_height</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:minWidth">116dp</item>
+        <item name="android:paddingBottom">0dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">@dimen/text_smaller_size</item>
+        <item name="iconSize">14dp</item>
+        <item name="textAllCaps">false</item>
+    </style>
+
     <style name="tabsButton">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Add a button to open the Add-ons page from the Settings, since that is a pretty obvious place to find this functionality.

To avoid messing up the layout of the honeycomb buttons, I've moved the "What's New" button closer to the version details. After some experimentation, I've placed two small buttons on the right side of the Settings window, linking to the Feedback and News pages.

The background of the What's New button becomes highlighted when the details of the new version are available (this replaces the little blue dot that we had before).

I have also simplified the implementation of the hidden shortcut to show the version details. Now it is just a matter of clicking on the app logo or the app name.

Finally, I have also simplified the layout in the Settings window by removing an unneeded LinearLayout and using the parent ConstraintLayout instead.