### PR TITLE
Replace GitHub link with regular feedback page

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -219,7 +219,8 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
                 }
-                mWidgetManager.openNewTabForeground(getResources().getString(R.string.survey_link));
+                String uri = getResources().getString(R.string.feedback_link, BuildConfig.VERSION_NAME, DeviceType.getType());
+                mWidgetManager.openNewPageNoInterrupt(uri);
                 exitWholeSettings();
             });
         }

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -226,7 +226,6 @@
     <string name="keyboard_nl_NL_popup_i" translatable="false">ìíiïîįī</string>
 
     <!-- Settings Survey link -->
-    <string name="survey_link" translatable="false">https://github.com/Igalia/wolvic/issues/</string>
     <string name="feedback_link" translatable="false">https://wolvic.com/en/feedback/index.html?version=%1$s&amp;device=%2$d</string>
 
     <!-- Phone UI links -->


### PR DESCRIPTION
Use the regular feedback page in the "Feedback" link in the Settings, instead of taking users to GitHub. This is the same link that is used in a similar functionality in the navigation bar.

It is unexpected that two similar "feedback" buttons would take the user to two different pages. Furthermore, most users do not have a GitHub account.