### PR TITLE
Move prompt dialogs closer to the window and the tray

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/TrayViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/TrayViewModel.java
@@ -19,6 +19,7 @@ public class TrayViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isKeyboardVisible;
     private MutableLiveData<ObservableInt> downloadsNumber;
     private MediatorLiveData<ObservableBoolean> isVisible;
+    private MutableLiveData<ObservableBoolean> isTabsWidgetVisible;
     private MutableLiveData<String> time;
     private MutableLiveData<String> pm;
     private MutableLiveData<ObservableBoolean> wifiConnected;
@@ -41,6 +42,7 @@ public class TrayViewModel extends AndroidViewModel {
         isVisible.addSource(shouldBeVisible, mIsVisibleObserver);
         isVisible.addSource(isKeyboardVisible, mIsVisibleObserver);
         isVisible.setValue(new ObservableBoolean(false));
+        isTabsWidgetVisible = new MutableLiveData<>(new ObservableBoolean(false));
         time = new MutableLiveData<>();
         pm = new MutableLiveData<>();
         pm = new MutableLiveData<>();
@@ -67,6 +69,7 @@ public class TrayViewModel extends AndroidViewModel {
         isMaxWindows.setValue(isMaxWindows.getValue());
         shouldBeVisible.setValue(shouldBeVisible.getValue());
         isKeyboardVisible.setValue(isKeyboardVisible.getValue());
+        isTabsWidgetVisible.postValue(isTabsWidgetVisible.getValue());
         time.postValue(time.getValue());
         pm.postValue(pm.getValue());
         wifiConnected.postValue(wifiConnected.getValue());
@@ -93,6 +96,14 @@ public class TrayViewModel extends AndroidViewModel {
 
     public void setIsKeyboardVisible(boolean isVisible) {
         this.isKeyboardVisible.setValue(new ObservableBoolean(isVisible));
+    }
+
+    public void setIsTabsWidgetVisible(boolean isTabsWidgetVisible) {
+        this.isTabsWidgetVisible.setValue(new ObservableBoolean(isTabsWidgetVisible));
+    }
+
+    public MutableLiveData<ObservableBoolean> getIsTabsWidgetVisible() {
+        return isTabsWidgetVisible;
     }
 
     public void setIsVisible(boolean isVisible) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
@@ -77,7 +77,7 @@ public class TabsWidget extends UIDialog {
 
     @Override
     public void updatePlacementTranslationZ() {
-        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_z) -
+        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tray_world_z) -
                 WidgetPlacement.getWindowWorldZMeters(getContext());
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
@@ -67,18 +67,12 @@ public class TabsWidget extends UIDialog {
         aPlacement.width =  WidgetPlacement.dpDimension(getContext(), R.dimen.tabs_width);
         aPlacement.height = WidgetPlacement.dpDimension(getContext(), R.dimen.tabs_height);
         aPlacement.parentAnchorX = 0.5f;
-        aPlacement.parentAnchorY = 0.0f;
+        aPlacement.parentAnchorY = 1.0f;
         aPlacement.anchorX = 0.5f;
-        aPlacement.anchorY = 0.5f;
-        aPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_y) -
-                WidgetPlacement.unitFromMeters(getContext(), R.dimen.window_world_y);
-        updatePlacementTranslationZ();
-    }
-
-    @Override
-    public void updatePlacementTranslationZ() {
-        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tray_world_z) -
-                WidgetPlacement.getWindowWorldZMeters(getContext());
+        aPlacement.anchorY = 0.0f;
+        // Undo the rotation of the parent widget (tray).
+        aPlacement.rotationAxisX = 1.0f;
+        aPlacement.rotation = (float) Math.toRadians(45);
     }
 
     private void initialize() {
@@ -168,9 +162,8 @@ public class TabsWidget extends UIDialog {
         updateUI();
     }
 
-    public void attachToWindow(WindowWidget aWindow) {
-        mPrivateMode = aWindow.getSession().isPrivateMode();
-        mWidgetPlacement.parentHandle = aWindow.getHandle();
+    public void setPrivateMode(boolean privateMode) {
+        mPrivateMode = privateMode;
     }
 
     @Override
@@ -394,6 +387,9 @@ public class TabsWidget extends UIDialog {
     protected void onDismiss() {
         exitSelectMode();
         hide(KEEP_WIDGET);
+        if (mDelegate != null) {
+            mDelegate.onDismiss();
+        }
     }
 
     public class GridSpacingItemDecoration extends RecyclerView.ItemDecoration {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -659,6 +659,10 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
         mTrayViewModel.setIsMaxWindows(!aVisible);
     }
 
+    public void setTabsWidgetVisible(boolean aVisible) {
+        mTrayViewModel.setIsTabsWidgetVisible(aVisible);
+    }
+
     // WidgetManagerDelegate.UpdateListener
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -1225,15 +1225,16 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             mTabsWidget.setTabDelegate(this);
         }
 
-        if (mFocusedWindow != null) {
-            mTabsWidget.getPlacement().parentHandle = mFocusedWindow.getHandle();
-            mTabsWidget.attachToWindow(mFocusedWindow);
-            mTabsWidget.show(UIWidget.KEEP_FOCUS);
-            // If we're signed-in, poll for any new device events (e.g. received tabs)
-            // There's no push support right now, so this helps with the perception of speedy tab delivery.
-            ((VRBrowserApplication)mContext.getApplicationContext()).getAccounts().refreshDevicesAsync();
-            ((VRBrowserApplication)mContext.getApplicationContext()).getAccounts().pollForEventsAsync();
-        }
+        mTabsWidget.getPlacement().parentHandle = mWidgetManager.getTray().getHandle();
+        mTabsWidget.setPrivateMode(mPrivateMode);
+        mTabsWidget.setDelegate(() -> mWidgetManager.getTray().setTabsWidgetVisible(false));
+        mWidgetManager.getTray().setTabsWidgetVisible(true);
+        mTabsWidget.show(UIWidget.KEEP_FOCUS);
+
+        // If we're signed-in, poll for any new device events (e.g. received tabs)
+        // There's no push support right now, so this helps with the perception of speedy tab delivery.
+        ((VRBrowserApplication)mContext.getApplicationContext()).getAccounts().refreshDevicesAsync();
+        ((VRBrowserApplication)mContext.getApplicationContext()).getAccounts().pollForEventsAsync();
 
         // Capture active session snapshots when showing the tabs menu
         for (WindowWidget window: getCurrentWindows()) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/PromptDialogWidget.java
@@ -102,7 +102,7 @@ public class PromptDialogWidget extends UIDialog {
 
     @Override
     public void updatePlacementTranslationZ() {
-        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_z) -
+        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tray_world_z) -
                 WidgetPlacement.getWindowWorldZMeters(getContext());
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -153,7 +153,7 @@ public class VoiceSearchWidget extends UIDialog implements Application.ActivityL
 
     @Override
     public void updatePlacementTranslationZ() {
-        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_z) -
+        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tray_world_z) -
                 WidgetPlacement.getWindowWorldZMeters(getContext());
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/SaveLoginPromptWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/SaveLoginPromptWidget.java
@@ -98,7 +98,7 @@ public class SaveLoginPromptWidget extends UIDialog {
 
     @Override
     public void updatePlacementTranslationZ() {
-        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_z) -
+        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tray_world_z) -
                 WidgetPlacement.getWindowWorldZMeters(getContext());
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/SelectLoginPromptWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/SelectLoginPromptWidget.java
@@ -103,7 +103,7 @@ public class SelectLoginPromptWidget extends UIDialog implements LoginsAdapter.D
 
     @Override
     public void updatePlacementTranslationZ() {
-        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.settings_world_z) -
+        getPlacement().translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tray_world_z) -
                 WidgetPlacement.getWindowWorldZMeters(getContext());
     }
 

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -170,6 +170,7 @@
                 app:tooltipPosition="bottom"
                 app:tooltipLayout="@layout/tooltip_tray"
                 android:src="@drawable/ic_icon_tray_tabs"
+                app:activeMode="@{traymodel.isTabsWidgetVisible}"
                 app:regularModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_unchecked_start : @drawable/tray_background_unchecked_middle}"
                 app:privateModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_start_private : @drawable/tray_background_middle_private}"
                 app:activeModeBackground="@{traymodel.isMaxWindows ? @drawable/tray_background_checked_start : @drawable/tray_background_checked_middle}"/>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -109,7 +109,7 @@
 
     <!-- Tabs -->
     <dimen name="tabs_width">650dp</dimen>
-    <dimen name="tabs_height">380dp</dimen>
+    <dimen name="tabs_height">490dp</dimen>
     <dimen name="tabs_spacing_h">6dp</dimen>
     <dimen name="tab_view_height">87dp</dimen>
     <dimen name="tab_view_url_height">16dp</dimen>


### PR DESCRIPTION
Set the Z translation of prompt windows, including the one with the list of tabs, to be the same as the tray.

The list of tabs is opened from the tray, but currently there isn't a clear visual connection between the two. This PR moves that widget right next to the tray and also sets as active the associated tray button.