### PR TITLE
Remove unneeded scrollbar from Settings/Language

### DIFF
--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -253,7 +253,7 @@
     <dimen name="display_options_height">420dp</dimen>
 
     <!-- Language and voice settings -->
-    <dimen name="language_options_height">380dp</dimen>
+    <dimen name="language_options_height">400dp</dimen>
 
     <!-- JS Prompt dialogs -->
     <item name="js_prompt_y_distance" format="float" type="dimen">1.2</item>


### PR DESCRIPTION
The Language dialog in the Settings is slightly too short, so the container displays an ugly scrollbar.

This change simply makes the dialog a bit taller, so the scrollbar goes away.