### PR TITLE
Do not show builtin extensions (addons) in the hamburger menu

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
@@ -211,6 +211,12 @@ public class HamburgerMenuWidget extends UIWidget implements
                             return;
                         }
 
+                        // Do not show builtin extensions in the hamburger menu. As they are inside the APK, their URLs
+                        // always start with "resource://android".
+                        if (extension.getUrl().startsWith("resource://android")) {
+                            return;
+                        }
+
                         final WebExtensionState tabExtensionState = tab.getExtensionState().get(extension.getId());
                         if (extension.getBrowserAction() != null) {
                             addOrUpdateAddonMenuItem(


### PR DESCRIPTION
Wolvic uses builtin extensions (not user installable) for several matters, from better YouTube experiences to workarounding issues in media playing. Those builtin addons are not user installable and they can't be disabled or uninstalled either. Actually the point is to make them completely transparent to the users. That's why we should not show them in the hamburger menu.