### PR TITLE
Reduce sensitivity required by controller trigger

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -215,7 +215,6 @@ struct BrowserWorld::State {
   bool isApplicationEntitled = false;
 #endif
   TrackedKeyboardRendererPtr trackedKeyboardRenderer;
-  float selectThreshold;
 
   State() : paused(true), glInitialized(false), modelsLoaded(false), env(nullptr), cylinderDensity(0.0f), nearClip(0.1f),
             farClip(300.0f), activity(nullptr), windowsInitialized(false), exitImmersiveRequested(false), loaderDelay(0) {
@@ -529,7 +528,7 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
 
         const float scale = (hitPoint - device->GetHeadTransform().MultiplyPosition(vrb::Vector(0.0f, 0.0f, 0.0f))).Magnitude();
         controller.pointer->SetScale(scale + kPointerSize - controller.selectFactor * kPointerSize);
-        if (controller.selectFactor >= selectThreshold)
+        if (controller.selectFactor >= device->GetSelectThreshold(controller.index))
           controller.pointer->SetPointerColor(kPointerColorSelected);
         else
           controller.pointer->SetPointerColor(VRBrowser::GetPointerColor());
@@ -934,7 +933,6 @@ BrowserWorld::RegisterDeviceDelegate(DeviceDelegatePtr aDelegate) {
     m.device->SetControllerDelegate(delegate);
     m.device->SetReorientClient(this);
     m.gestures = m.device->GetGestureDelegate();
-    m.selectThreshold = m.device->GetSelectThreshold();
   } else if (previousDevice) {
     m.leftCamera = m.rightCamera = nullptr;
     m.controllers->Reset();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -138,7 +138,7 @@ public:
   virtual void SetImmersiveBlendMode(device::BlendMode) {};
   virtual bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) { return false; };
   virtual void SetHandTrackingEnabled(bool value) {};
-  virtual float GetSelectThreshold() { return 1.f; };
+  virtual float GetSelectThreshold(int32_t controllerIndex) { return 1.f; };
 
 protected:
   DeviceDelegate() {}

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -1751,8 +1751,8 @@ void DeviceDelegateOpenXR::SetHandTrackingEnabled(bool value) {
   m.handTrackingEnabled = value;
 }
 
-float DeviceDelegateOpenXR::GetSelectThreshold() {
-  return kClickThreshold;
+float DeviceDelegateOpenXR::GetSelectThreshold(int32_t aControllerIndex) {
+  return m.input->GetSelectThreshold(aControllerIndex);
 }
 
 void

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -80,7 +80,7 @@ public:
   bool ExitApp();
   bool ShouldExitRenderLoop() const;
   void SetImmersiveBlendMode(device::BlendMode) override;
-  float GetSelectThreshold() override;
+  float GetSelectThreshold(int32_t controllerIndex) override;
 
 protected:
   struct State;

--- a/app/src/openxr/cpp/OpenXRHelpers.h
+++ b/app/src/openxr/cpp/OpenXRHelpers.h
@@ -14,10 +14,6 @@
 
 namespace crow {
 
-// Threshold to consider a trigger value as a click
-// Used when devices don't map the click value for triggers;
-const float kClickThreshold = 0.91f;
-
 #if defined(HVR)
   const vrb::Vector kAverageHeight(0.0f, 1.6f, 0.0f);
 #else

--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -380,4 +380,10 @@ bool OpenXRInput::updateEyeGaze(XrFrameState frameState, const vrb::Matrix& head
     return true;
 }
 
+
+float OpenXRInput::GetSelectThreshold(int32_t aControllerIndex) const {
+  ASSERT(mInputSources.at(aControllerIndex));
+  return mInputSources.at(aControllerIndex)->GetSelectThreshold();
+}
+
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInput.h
+++ b/app/src/openxr/cpp/OpenXRInput.h
@@ -76,6 +76,7 @@ public:
   void InitializeEyeGaze(ControllerDelegate&);
   void InitializeEyeGazeSpaces();
   bool updateEyeGaze(XrFrameState, const vrb::Matrix& head, ControllerDelegate&);
+  float GetSelectThreshold(int32_t aControllerIndex) const;
 };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -88,7 +88,7 @@ private:
     vrb::Vector mControllerPositionOnScrollStart;
     vrb::Matrix mEyeGazeTransformOnPinchStart;
     XrTime mEyeTrackingPinchStartTime { 0 };
-    float mClickThreshold;
+    float mClickThreshold { 1.0f };
 
     struct HandMeshMSFT {
         XrSpace space = XR_NULL_HANDLE;

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -88,6 +88,7 @@ private:
     vrb::Vector mControllerPositionOnScrollStart;
     vrb::Matrix mEyeGazeTransformOnPinchStart;
     XrTime mEyeTrackingPinchStartTime { 0 };
+    float mClickThreshold;
 
     struct HandMeshMSFT {
         XrSpace space = XR_NULL_HANDLE;
@@ -122,6 +123,7 @@ public:
     bool HasPhysicalControllersAvailable() const;
     void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
     HandMeshBufferPtr GetNextHandMeshBuffer();
+    float GetSelectThreshold() const { return mClickThreshold; }
 };
 
 } // namespace crow


### PR DESCRIPTION
We've been traditionally using a high value for clicking threshold (0.91) in order not to generate false positives specially when using hand tracking. However, that does not make much sense when using physical controllers because they're very precise and false positives are not a real problem there.

We can actually lower it to just 25% of the full pressed position without any accuracy loss, and indeed, the experience is much better. It's also good for a11y.

Fixes #1487