### PR TITLE
[PicoXR] Do not use XR_FB_hand_tracking_aim

### DIFF
--- a/app/src/openxr/cpp/OpenXRGestureManager.cpp
+++ b/app/src/openxr/cpp/OpenXRGestureManager.cpp
@@ -117,15 +117,8 @@ OpenXRGestureManagerFBHandTrackingAim::systemGestureDetected(const vrb::Matrix& 
 void
 OpenXRGestureManagerFBHandTrackingAim::getTriggerPinchStatusAndFactor(const HandJointsArray& handJoints,
                                                                          bool& isPinching, double& pinchFactor) {
-#ifdef PICOXR
-    // Pico's support for XR_FB_hand_tracking_aim extension doesn't give correct
-    // values for flags and piching strength, so fallback to our own pinch detection
-    // algorithm.
-    OpenXRGestureManager::getTriggerPinchStatusAndFactor(handJoints, isPinching, pinchFactor);
-#else
     isPinching = mFBAimState.status & XR_HAND_TRACKING_AIM_INDEX_PINCHING_BIT_FB;
     pinchFactor = mFBAimState.pinchStrengthIndex;
-#endif
 }
 
 OpenXRGestureManagerHandJoints::OpenXRGestureManagerHandJoints(HandJointsArray& handJoints, OneEuroFilterParams* filterParams)

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -130,13 +130,8 @@ XrResult OpenXRInputSource::Initialize()
                                                                       &mHandTracker));
 
         mSupportsHandJointsMotionRangeInfo = OpenXRExtensions::IsExtensionSupported(XR_EXT_HAND_JOINTS_MOTION_RANGE_EXTENSION_NAME);
-
-#if defined(PICOXR)
-        // Pico's runtime does not advertise it but it does work.
-        mSupportsFBHandTrackingAim = true;
-#else
         mSupportsFBHandTrackingAim = OpenXRExtensions::IsExtensionSupported(XR_FB_HAND_TRACKING_AIM_EXTENSION_NAME);
-#endif
+
         if (!mIsHandInteractionSupported) {
             if (mSupportsFBHandTrackingAim) {
                 mGestureManager = std::make_unique<OpenXRGestureManagerFBHandTrackingAim>();


### PR DESCRIPTION
This vendor extension provides very good values for aim when using hand tracking and is also able to detect some common gestures like pinching or doing a system gesture. It has never been really advertised by the runtime as supported but we knew it worked so we were using it anyway.

However the behaviour in the latest versions of the OpenXR runtime from Pico has degraded a lot, to the point that is no longer able to detect those hand gestures. This means that we could only use the aim at the most. Provided our computed aim is good enough it's better to completely disable the extension for Pico.

A nice side effect, is that the ray now properly originates from the hand. With the extension the ray origin was shifted upwards.

Fixes #1679