### PR TITLE
[Lynx] Workaround a runtime bug not reporting tracked hand positions

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -868,7 +868,12 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
 
     device::CapabilityFlags flags = device::Orientation;
+#ifndef LYNX
     const bool positionTracked = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
+#else
+    // Lynx runtime incorrectly never sets the TRACKED bit.
+    const bool positionTracked = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT;
+#endif
     flags |= positionTracked ? device::Position : device::PositionEmulated;
 
     vrb::Matrix pointerTransform = XrPoseToMatrix(poseLocation.pose);

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -868,11 +868,11 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
     delegate.SetHandActionEnabled(mIndex, isHandActionEnabled);
 
     device::CapabilityFlags flags = device::Orientation;
-#ifndef LYNX
-    const bool positionTracked = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
-#else
+#ifdef LYNX
     // Lynx runtime incorrectly never sets the TRACKED bit.
     const bool positionTracked = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT;
+#else
+    const bool positionTracked = poseLocation.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
 #endif
     flags |= positionTracked ? device::Position : device::PositionEmulated;
 


### PR DESCRIPTION
Lynx runtime never returns the XR_SPACE_LOCATION_POSITION_TRACKED_BIT flag as active, even if it's really actively tracking the position of the hands. That confused the code and made it think that emulated positions were returned instead.

That was causing the origin of the aim pose (and thus the origin of the aim ray) to be incorrectly shifted from the hands. The workaround is replacing the check for POSITION_TRACKED_BIT by POSITION_VALID_BIT. That way we'd still be able to detected when hands are not tracked while providing a much better aim.