### PR TITLE
Move sound feedback setting to Controllers

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -6,16 +6,19 @@
 package com.igalia.wolvic.ui.widgets.settings;
 
 import android.content.Context;
+import android.graphics.Point;
 import android.view.LayoutInflater;
 
 import androidx.databinding.DataBindingUtil;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.audio.AudioEngine;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsControllerBinding;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 
 class ControllerOptionsView extends SettingsView {
 
@@ -55,6 +58,9 @@ class ControllerOptionsView extends SettingsView {
         mBinding.scrollDirectionRadio.setOnCheckedChangeListener(mScrollDirectionListener);
         setScrollDirection(mBinding.scrollDirectionRadio.getIdForValue(scrollDirection), false);
 
+        mBinding.soundEffectSwitch.setOnCheckedChangeListener(mSoundEffectListener);
+        setSoundEffect(SettingsStore.getInstance(getContext()).isAudioEnabled(), false);
+
         mBinding.hapticFeedbackSwitch.setOnCheckedChangeListener(mHapticFeedbackListener);
         setHapticFeedbackEnabled(SettingsStore.getInstance(getContext()).isHapticFeedbackEnabled(), false);
 
@@ -79,6 +85,7 @@ class ControllerOptionsView extends SettingsView {
         if (!mBinding.scrollDirectionRadio.getValueForId(mBinding.scrollDirectionRadio.getCheckedRadioButtonId()).equals(SettingsStore.SCROLL_DIRECTION_DEFAULT)) {
             setScrollDirection(mBinding.scrollDirectionRadio.getIdForValue(SettingsStore.SCROLL_DIRECTION_DEFAULT), true);
         }
+        setSoundEffect(SettingsStore.AUDIO_ENABLED, true);
         setHapticFeedbackEnabled(SettingsStore.HAPTIC_FEEDBACK_ENABLED, true);
         setPointerMode(SettingsStore.POINTER_MODE_DEFAULT, true);
         setHandTrackingEnabled(true, true);
@@ -102,6 +109,17 @@ class ControllerOptionsView extends SettingsView {
 
         if (doApply) {
             SettingsStore.getInstance(getContext()).setScrollDirection((int)mBinding.scrollDirectionRadio.getValueForId(checkedId));
+        }
+    }
+
+    private void setSoundEffect(boolean value, boolean doApply) {
+        mBinding.soundEffectSwitch.setOnCheckedChangeListener(null);
+        mBinding.soundEffectSwitch.setValue(value, false);
+        mBinding.soundEffectSwitch.setOnCheckedChangeListener(mSoundEffectListener);
+
+        if (doApply) {
+            SettingsStore.getInstance(getContext()).setAudioEnabled(value);
+            AudioEngine.fromContext(getContext()).setEnabled(value);
         }
     }
 
@@ -144,6 +162,10 @@ class ControllerOptionsView extends SettingsView {
         setScrollDirection(checkedId, doApply);
     };
 
+    private SwitchSetting.OnCheckedChangeListener mSoundEffectListener = (compoundButton, enabled, apply) -> {
+        setSoundEffect(enabled, true);
+    };
+
     private SwitchSetting.OnCheckedChangeListener mHapticFeedbackListener = (compoundButton, enabled, apply) ->
     setHapticFeedbackEnabled(enabled, true);
 
@@ -165,6 +187,12 @@ class ControllerOptionsView extends SettingsView {
 
     private SwitchSetting.OnCheckedChangeListener mHandtrackingListener = (compoundButton, enabled, apply) ->
             setHandTrackingEnabled(enabled, true);
+
+    @Override
+    public Point getDimensions() {
+        return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
+                WidgetPlacement.dpDimension(getContext(), R.dimen.controller_options_height));
+    }
 
     @Override
     protected SettingViewType getType() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.databinding.DataBindingUtil;
 
 import com.igalia.wolvic.R;
-import com.igalia.wolvic.audio.AudioEngine;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsDisplayBinding;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
@@ -97,9 +96,6 @@ class DisplayOptionsView extends SettingsView {
         } else {
             mBinding.startWithPassthroughSwitch.setVisibility(View.GONE);
         }
-
-        mBinding.soundEffectSwitch.setOnCheckedChangeListener(mSoundEffectListener);
-        setSoundEffect(SettingsStore.getInstance(getContext()).isAudioEnabled(), false);
 
         mBinding.latinAutoCompleteSwitch.setOnCheckedChangeListener(mLatinAutoCompleteListener);
         setLatinAutoComplete(SettingsStore.getInstance(getContext()).isLatinAutoCompleteEnabled(), false);
@@ -192,10 +188,6 @@ class DisplayOptionsView extends SettingsView {
         setStartWithPassthrough(value);
     };
 
-    private SwitchSetting.OnCheckedChangeListener mSoundEffectListener = (compoundButton, enabled, apply) -> {
-        setSoundEffect(enabled, true);
-    };
-
     private SwitchSetting.OnCheckedChangeListener mLatinAutoCompleteListener = (compoundButton, enabled, apply) -> {
         setLatinAutoComplete(enabled, true);
     };
@@ -285,7 +277,6 @@ class DisplayOptionsView extends SettingsView {
         setAutoplay(SettingsStore.AUTOPLAY_ENABLED, true);
         setCurvedDisplay(false, true);
         setHeadLock(SettingsStore.HEAD_LOCK_DEFAULT, true);
-        setSoundEffect(SettingsStore.AUDIO_ENABLED, true);
         setLatinAutoComplete(SettingsStore.LATIN_AUTO_COMPLETE_ENABLED, true);
         setCenterWindows(SettingsStore.CENTER_WINDOWS_DEFAULT, true);
         setWindowDistance(SettingsStore.WINDOW_DISTANCE_DEFAULT, true);
@@ -362,17 +353,6 @@ class DisplayOptionsView extends SettingsView {
         SettingsStore settingsStore = SettingsStore.getInstance(getContext());
         if (doApply) {
             settingsStore.setHeadLockEnabled(value);
-        }
-    }
-
-    private void setSoundEffect(boolean value, boolean doApply) {
-        mBinding.soundEffectSwitch.setOnCheckedChangeListener(null);
-        mBinding.soundEffectSwitch.setValue(value, false);
-        mBinding.soundEffectSwitch.setOnCheckedChangeListener(mSoundEffectListener);
-
-        if (doApply) {
-            SettingsStore.getInstance(getContext()).setAudioEnabled(value);
-            AudioEngine.fromContext(getContext()).setEnabled(value);
         }
     }
 

--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -3,6 +3,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+        <import type="com.igalia.wolvic.BuildConfig"/>
+        <import type="android.view.View" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -47,6 +52,13 @@
                     app:description="@string/controller_options_pointer_mode"
                     app:options="@array/developer_options_pointer_modes"
                     app:values="@array/developer_options_pointer_modes_values" />
+
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/soundEffectSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="@{BuildConfig.FLAVOR_backend == &quot;chromium&quot; ? View.VISIBLE : View.GONE}"
+                    app:description="@string/display_options_sound_effect" />
 
                 <com.igalia.wolvic.ui.views.settings.SwitchSetting
                     android:id="@+id/haptic_feedback_switch"

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -2,11 +2,6 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <data>
-        <import type="com.igalia.wolvic.BuildConfig"/>
-        <import type="android.view.View" />
-    </data>
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -60,13 +55,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:description="@string/security_options_autoplay" />
-
-                <com.igalia.wolvic.ui.views.settings.SwitchSetting
-                    android:id="@+id/soundEffectSwitch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="@{BuildConfig.FLAVOR_backend == &quot;chromium&quot; ? View.VISIBLE : View.GONE}"
-                    app:description="@string/display_options_sound_effect" />
 
                 <com.igalia.wolvic.ui.views.settings.SwitchSetting
                     android:id="@+id/latinAutoCompleteSwitch"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -267,6 +267,9 @@
     <!-- Language and voice settings -->
     <dimen name="language_options_height">400dp</dimen>
 
+    <!-- Controller settings -->
+    <dimen name="controller_options_height">450dp</dimen>
+
     <!-- JS Prompt dialogs -->
     <item name="js_prompt_y_distance" format="float" type="dimen">1.2</item>
 


### PR DESCRIPTION
Move the sound feedback setting from the Display section to the Controllers section in the Settings, next to the one for enabling and disabling haptic feedback. This will make this functionality more discoverable.

Slightly increase the height of the Controllers section.