### PR TITLE
[VisionGlass] Improve reliability of phone pointer

### DIFF
--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -365,12 +365,12 @@ DeviceDelegateVisionGlass::ControllerButtonPressed(const bool aDown) {
 }
 
 void
-DeviceDelegateVisionGlass::setHead(const float aX, const float aY, const float aZ, const float aW) {
+DeviceDelegateVisionGlass::setHead(const double aX, const double aY, const double aZ, const double aW) {
   m.headOrientation = vrb::Quaternion(aX, aY, aZ, aW);
 }
 
 void
-DeviceDelegateVisionGlass::setControllerOrientation(const float aX, const float aY, const float aZ, const float aW) {
+DeviceDelegateVisionGlass::setControllerOrientation(const double aX, const double aY, const double aZ, const double aW) {
     m.controllerOrientation = vrb::Quaternion(aX, aY, aZ, aW);
 }
 

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.h
@@ -51,8 +51,8 @@ public:
   void Resume();
   void TouchEvent(const bool aDown, const float aX, const float aY);
   void ControllerButtonPressed(const bool aDown);
-  void setHead(const float aX, const float aY, const float aZ, const float aW);
-  void setControllerOrientation(const float aX, const float aY, const float aZ, const float aW);
+  void setHead(const double aX, const double aY, const double aZ, const double aW);
+  void setControllerOrientation(const double aX, const double aY, const double aZ, const double aW);
   void CalibrateController();
 protected:
   struct State;


### PR DESCRIPTION
We used to get the data about the phone orientation from the TYPE_GAME_ROTATION_VECTOR which is not aligned with the geomagnetic field of earth, and thus does not have a fixed reference frame. As the docs say, this might cause drift in the measurements as time passes by. Replacing it by TYPE_ROTATION_VECTOR should improve that.

As the phone and the glasses use different reference frames we need to translate the info from the phone to the reference frame of the glasses, that's why we now need to store that translation of reference frames in a quaternion and apply it on each frame. The good part is that we don't need to rely on resetting the IMU of the phone hoping for getting similar reference frames for the phone and glasses.