### PR TITLE
Fix undetected click events on some OpenXR runtimes

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -265,14 +265,12 @@ std::optional<OpenXRInputSource::OpenXRButtonState> OpenXRInputSource::GetButton
     };
 
     queryActionState(button.flags & OpenXRButtonFlags::Click, actions.click, result.clicked, false);
-    bool clickedHasValue = hasValue;
     queryActionState(button.flags & OpenXRButtonFlags::Touch, actions.touch, result.touched, result.clicked);
     queryActionState(button.flags & OpenXRButtonFlags::Value, actions.value, result.value, result.clicked ? 1.0 : 0.0);
     queryActionState(button.flags & OpenXRButtonFlags::Ready, actions.ready, result.ready, true);
 
-    if (!clickedHasValue && result.value > mClickThreshold) {
-      result.clicked = true;
-    }
+    if (!result.clicked)
+      result.clicked = result.value > mClickThreshold;
 
     if (result.clicked) {
       VRB_DEBUG("OpenXR button clicked: %s", OpenXRButtonTypeNames->at((int) button.type));


### PR DESCRIPTION
Wolvic has had since very early on, a code that considered button presses over a threshold as clicks (full presses) because some old devices only reported clicks with a 100% pressed value which was not very reliable. This meant that values > 91% were considered clicks as well.

We recently landed a patch that lowered that limit for physical controllers because they're much more reliable now and this way users didn't have to fully press them which is better for a11y.

That change unveiled a bug that has been there for a while. Runtimes don't often return the clicked bit set unless the pressed value is 100%. However some others (like the ML2 one) do. The condition that was setting the clicked value to true if the value was above a certain limit assumed that the runtime was not setting the clicked value to true. That's true for most of runtimes but not MagicLeap's which works better.

Fixes #1703