### PR TITLE
[VisionGlass] Create the GestureManager from an UI context

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -527,16 +527,18 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
     }
 
     public final PlatformActivityPlugin createPlatformPlugin(WidgetManagerDelegate delegate) {
-        return new PlatformActivityPluginVisionGlass(delegate);
+        return new PlatformActivityPluginVisionGlass(delegate, this);
     }
 
     private class PlatformActivityPluginVisionGlass extends PlatformActivityPlugin {
-        private WidgetManagerDelegate mDelegate;
+        private final WidgetManagerDelegate mDelegate;
         private WMediaSession.Delegate mMediaSessionDelegate;
         private GestureDetector mGestureDetector;
+        private final Context mContext;
 
-        PlatformActivityPluginVisionGlass(WidgetManagerDelegate delegate) {
+        PlatformActivityPluginVisionGlass(WidgetManagerDelegate delegate, Context context) {
             mDelegate = delegate;
+            mContext = context;
             setupPhoneUI();
         }
 
@@ -650,7 +652,7 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                 }
             });
 
-            mGestureDetector = new GestureDetector(getApplicationContext(), new GestureDetector.SimpleOnGestureListener() {
+            mGestureDetector = new GestureDetector(mContext, new GestureDetector.SimpleOnGestureListener() {
                 @Override
                 public boolean onScroll(@Nullable MotionEvent e1, @NonNull MotionEvent e2, float distanceX, float distanceY) {
                     // Use inverted axis so the scroll feels more natural.


### PR DESCRIPTION
In order to initialize properly the GestureManager object it must be created with an UI context, like for example an Activity. Use the Wolvic's main activity to initialize it.

This was found by StrictMode. It was throwing the following exception:

Tried to access the API:GestureDetector#init which needs to have proper configuration from a non-UI Context:com.igalia.wolvic.VRBrowserApplication@ff7c8aa The API:GestureDetector#init needs a proper configuration. Use UI contexts such as an activity or a context created via createWindowContext(Display, int, Bundle) or  createConfigurationContext(Configuration) with a proper configuration.

java.lang.IllegalAccessException: Tried to access the API:GestureDetector#init which needs to have proper configuration from a non-UI Context:com.igalia.wolvic.VRBrowserApplication@ff7c8aa
      	at android.os.StrictMode.assertConfigurationContext(StrictMode.java:2297)
      	at android.view.GestureDetector.init(GestureDetector.java:480)
  	at android.view.GestureDetector.<init>(GestureDetector.java:440)
     	at android.view.GestureDetector.<init>(GestureDetector.java:408)
      	at com.igalia.wolvic.PlatformActivity$PlatformActivityPluginVisionGlass.setupPhoneUI(PlatformActivity.java:654)
   	at com.igalia.wolvic.PlatformActivity$PlatformActivityPluginVisionGlass.<init>(PlatformActivity.java:541)
   	at com.igalia.wolvic.PlatformActivity.createPlatformPlugin(PlatformActivity.java:531)
      	at com.igalia.wolvic.VRBrowserActivity.initializeWidgets(VRBrowserActivity.java:477)
       	at com.igalia.wolvic.VRBrowserActivity.onCreate(VRBrowserActivity.java:362)