### PR TITLE
[Vision Glass] Reorient button also recenters the window

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -221,8 +221,8 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
             mAlignNotificationUIDialog = null;
         }
 
+        runVRBrowserActivityCallback(activity -> activity.recenterUIYaw(WidgetManagerDelegate.YAW_TARGET_ALL));
         queueRunnable(this::calibrateController);
-
     }
 
     private void onConnectionStateChanged(PhoneUIViewModel.ConnectionState connectionState) {


### PR DESCRIPTION
Restore the functionality that clicking the reorient button also recenters the window in the user's field of view.

Not doing this is quite inconvenient because there isn't shortcut for recentering the windows like in other systems. Furthermore, the lack of peripheral vision means that it is not hard for the window to become "lost" and the only other solution at that point is to look around until it is found.