### PR TITLE
FxA: small improvements to sync

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/FxAAccountOptionsView.java
@@ -283,6 +283,8 @@ class FxAAccountOptionsView extends SettingsView {
     private void sync(View view) {
         mAccounts.syncNowAsync(SyncReason.User.INSTANCE, false);
         mAccounts.updateProfileAsync();
+        mAccounts.refreshDevicesAsync();
+        mAccounts.pollForEventsAsync();
     }
 
     private void signOut(View view) {


### PR DESCRIPTION
Ensure that the last sync time is kept updated.

Add log messages for account error and ready states.

The Sync button in the Settings will also refresh the list of devices and poll for events (e.g. sharing tabs).