### PR TITLE
Add a new Sync button in the tabs bar

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/AbstractTabsBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/AbstractTabsBar.java
@@ -1,8 +1,10 @@
 package com.igalia.wolvic.ui.widgets;
 
 import android.content.Context;
+import android.widget.Button;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.databinding.ObservableBoolean;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
@@ -15,13 +17,22 @@ import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.ui.viewmodel.WindowViewModel;
 import com.igalia.wolvic.utils.SystemUtils;
 
-public abstract class AbstractTabsBar extends UIWidget implements SessionChangeListener, WidgetManagerDelegate.UpdateListener {
+import org.jetbrains.annotations.NotNull;
+
+import mozilla.components.concept.sync.AccountObserver;
+import mozilla.components.concept.sync.AuthFlowError;
+import mozilla.components.concept.sync.AuthType;
+import mozilla.components.concept.sync.OAuthAccount;
+import mozilla.components.concept.sync.Profile;
+
+public abstract class AbstractTabsBar extends UIWidget implements SessionChangeListener, WidgetManagerDelegate.UpdateListener, AccountObserver {
 
     protected final String LOGTAG = SystemUtils.createLogtag(this.getClass());
 
     protected boolean mPrivateMode;
     protected WindowWidget mAttachedWindow;
     protected WindowViewModel mWindowViewModel;
+    protected Button mSyncTabButton;
 
     public AbstractTabsBar(Context aContext) {
         super(aContext);
@@ -143,4 +154,32 @@ public abstract class AbstractTabsBar extends UIWidget implements SessionChangeL
     public void onUnstackSession(Session aSession, Session aParent) {
         refreshTabs();
     }
+
+    // AccountObserver
+
+    @Override
+    public void onLoggedOut() {
+        if (mSyncTabButton != null) {
+            mSyncTabButton.setVisibility(GONE);
+        }
+    }
+
+    @Override
+    public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
+        if (mSyncTabButton != null) {
+            mSyncTabButton.setVisibility(VISIBLE);
+        }
+    }
+
+    @Override
+    public void onProfileUpdated(@NonNull Profile profile) {}
+
+    @Override
+    public void onAuthenticationProblems() {}
+
+    @Override
+    public void onFlowError(@NotNull AuthFlowError authFlowError) {}
+
+    @Override
+    public void onReady(@Nullable OAuthAccount oAuthAccount) {}
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/HorizontalTabsBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/HorizontalTabsBar.java
@@ -3,6 +3,7 @@ package com.igalia.wolvic.ui.widgets;
 import android.content.Context;
 import android.widget.Button;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -32,6 +33,10 @@ public class HorizontalTabsBar extends AbstractTabsBar {
 
         mAddTabButton = findViewById(R.id.add_tab);
         mAddTabButton.setOnClickListener(v -> mTabDelegate.onTabAdd());
+
+        mSyncTabButton = findViewById(R.id.sync_tabs);
+        mSyncTabButton.setOnClickListener(v -> mTabDelegate.onTabSync());
+        mSyncTabButton.setVisibility(mTabDelegate.accountIsConnected() ? VISIBLE : GONE);
 
         mTabsList = findViewById(R.id.tabsRecyclerView);
         mLayoutManager = new LinearLayoutManager(getContext());
@@ -68,4 +73,5 @@ public class HorizontalTabsBar extends AbstractTabsBar {
     public void refreshTabs() {
         mAdapter.updateTabs(SessionStore.get().getSessions(mPrivateMode));
     }
+
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabDelegate.java
@@ -4,9 +4,13 @@ import com.igalia.wolvic.browser.engine.Session;
 
 import java.util.List;
 
+import mozilla.components.concept.sync.AccountObserver;
+
 public interface TabDelegate {
     void onTabAdd();
     void onTabSelect(Session aTab);
     void onTabsClose(List<Session> aTabs);
     void onTabsBookmark(List<Session> aTabs);
+    void onTabSync();
+    boolean accountIsConnected();
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/VerticalTabsBar.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/VerticalTabsBar.java
@@ -3,7 +3,6 @@ package com.igalia.wolvic.ui.widgets;
 import android.content.Context;
 import android.widget.Button;
 
-import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -33,6 +32,10 @@ public class VerticalTabsBar extends AbstractTabsBar {
 
         mAddTabButton = findViewById(R.id.add_tab);
         mAddTabButton.setOnClickListener(v -> mTabDelegate.onTabAdd());
+
+        mSyncTabButton = findViewById(R.id.sync_tabs);
+        mSyncTabButton.setOnClickListener(v -> mTabDelegate.onTabSync());
+        mSyncTabButton.setVisibility(mTabDelegate.accountIsConnected() ? VISIBLE : GONE);
 
         mTabsList = findViewById(R.id.tabsRecyclerView);
         mLayoutManager = new LinearLayoutManager(getContext());
@@ -69,3 +72,4 @@ public class VerticalTabsBar extends AbstractTabsBar {
         mAdapter.updateTabs(SessionStore.get().getSessions(mPrivateMode));
     }
 }
+

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -1617,6 +1617,19 @@ public void selectTab(@NonNull Session aTab) {
         }
     }
 
+    @Override
+    public void onTabSync() {
+        // If we're signed-in, poll for any new device events (e.g. received tabs)
+        // There's no push support right now, so this helps with the perception of speedy tab delivery.
+        mAccounts.refreshDevicesAsync();
+        mAccounts.pollForEventsAsync();
+    }
+
+    @Override
+    public boolean accountIsConnected() {
+        return mAccounts.isSignedIn();
+    }
+
     public void closeTab(@NonNull Session aTab) {
         if (isSessionFocused(aTab)) {
             closeTabs(Collections.singletonList(aTab), mPrivateMode, true);

--- a/app/src/main/res/drawable/ic_icon_tabs_sync.xml
+++ b/app/src/main/res/drawable/ic_icon_tabs_sync.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,4L12,1L8,5l4,4L12,6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z"/>
+    
+</vector>

--- a/app/src/main/res/layout/tabs_bar_horizontal.xml
+++ b/app/src/main/res/layout/tabs_bar_horizontal.xml
@@ -9,6 +9,20 @@
     android:orientation="horizontal">
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/sync_tabs"
+        android:layout_width="64dp"
+        android:layout_height="match_parent"
+        android:layout_margin="4dp"
+        android:background="@drawable/tab_add_background"
+        android:scaleType="fitCenter"
+        app:backgroundTint="@null"
+        app:icon="@drawable/ic_icon_tabs_sync"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
+        app:iconSize="24dp"
+        app:iconTint="@color/fog" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/add_tab"
         android:layout_width="64dp"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/tabs_bar_vertical.xml
+++ b/app/src/main/res/layout/tabs_bar_vertical.xml
@@ -9,6 +9,20 @@
     android:orientation="vertical">
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/sync_tabs"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_margin="4dp"
+        android:background="@drawable/tab_add_background"
+        android:scaleType="fitCenter"
+        app:backgroundTint="@null"
+        app:icon="@drawable/ic_icon_tabs_sync"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
+        app:iconSize="36dp"
+        app:iconTint="@color/rhino" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/add_tab"
         android:layout_width="match_parent"
         android:layout_height="48dp"


### PR DESCRIPTION
In order to receive tabs through the FxA SendTabTo service we need to poll the API; the new button will perform this action.

Ideally, we should be able to observe events from the FxA push service, but for now we need to depend on user intervention to ask the server for new tabs.