### PR TITLE
[PicoXR] Do not disable controllers when disabling hand tracking

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -795,17 +795,17 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
         return;
     }
 
-#if defined(PICOXR)
-    // Pico does continuously track the controllers even when left alone. That's why we return
-    // always true so that we always check hand tracking just in case.
-    bool isControllerUnavailable = true;
-#else
     bool isControllerUnavailable = (poseLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) == 0;
-#endif
-
     auto gotHandTrackingInfo = false;
     auto handFacesHead = false;
-    if (isControllerUnavailable || mUsingHandInteractionProfile) {
+#if defined(PICOXR)
+    // Pico does continuously track the controllers even when left alone. That's why we return
+    // always true so that we always check hand tracking just in case (unless it's disabled).
+    bool mustAlwaysCheckHandTracking = handTrackingEnabled;
+#else
+    bool mustAlwaysCheckHandTracking = false;
+#endif
+    if (isControllerUnavailable || mUsingHandInteractionProfile || mustAlwaysCheckHandTracking) {
         if (!handTrackingEnabled) {
             delegate.SetEnabled(mIndex, false);
             return;


### PR DESCRIPTION
The PicoXR runtime is a bit special with regard to controller tracking. It never stops tracking them even if the controller was left aside or is outside users' field of view. That's why the PicoXR runtime considers the controllers as always available. We usually use that availability to decide whether to render hands or controllers.

For the case of PicoXR, as controllers always appear as available, we have to always check for hand tracking. The problem is that it was not properly done. In the case of having hand tracking disabled the code was disabling all controllers. The problem was that, in order to force a hand tracking check, we were forcing the variable that checked whether or not controllers were available to false. If hand tracking was disabled by users, then the code was disabling all controllers, because hand tracking was not available and there were no controllers.

We should instead use a different variable to force the hand tracking check without overwritting other variables which cause nasty side effects like this one.

Fixes #1721