### PR TITLE
[PicoXR] Remove version check to enable passthrough

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -203,9 +203,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     static final long RESET_CRASH_COUNT_DELAY = 5000;
     static final int UPDATE_NATIVE_WIDGETS_DELAY = 50; // milliseconds
 
-    // Passthrough was enabled on Pico version 5.7.1, via XR_FB_passthrough extension
-    static final String kPicoVersionPassthroughUpdate = "5.7.1";
-
     static final String LOGTAG = SystemUtils.createLogtag(VRBrowserActivity.class);
     ConcurrentHashMap<Integer, Widget> mWidgets;
     private int mWidgetHandleIndex = 1;
@@ -2042,8 +2039,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
     @Override
     public boolean isPassthroughSupported() {
-        return DeviceType.isOculusBuild() || DeviceType.isLynx() || DeviceType.isSnapdragonSpaces() ||
-               (DeviceType.isPicoXR() && Build.ID.compareTo(kPicoVersionPassthroughUpdate) >= 0);
+        return DeviceType.isOculusBuild() || DeviceType.isLynx() || DeviceType.isSnapdragonSpaces() || DeviceType.isPicoXR();
     }
     @Override
     public boolean areControllersAvailable() {


### PR DESCRIPTION
Passthrough was enabled in PicoOS 5.7.1 via a FB OpenXR extension. We added a version check to avoid enabling passthrough in unsupported OS versions. That version number was retrieved from a system property, and lexicographically checked against "5.7.1". The problem is that "5.10" in indeed < "5.7" because we're not comparing the versions but the whole string.

The solution is to remove the check because it's pointless now as it's a very old version. We actually removed those checks in native code long time ago.

Fixes #1720