### PR TITLE
Synthesize a move up event when a controller is disabled while dragging

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -429,6 +429,14 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
   int rightBatteryLevel = -1;
   for (Controller& controller: controllers->GetControllers()) {
     if (!controller.enabled || (controller.index < 0)) {
+      if (controller.widget) {
+          // If the controller became unavailable while dragging we must synthesize a UP event
+          // so that the widget it was interacting with does not get stuck and does not allow
+          // other controllers to interact with it.
+          VRBrowser::HandleMotionEvent(controller.widget, controller.index, jboolean(controller.focused),
+                                       jboolean(false), controller.pointerX, controller.pointerY);
+          controller.widget = 0;
+      }
       continue;
     }
     if (controller.index != device->GazeModeIndex()) {


### PR DESCRIPTION
When doing a click and hold over a widget (like when scrolling) it might happen that the controller becomes unavailable, for example, if it goes out of sight. In those cases we must stop the dragging because otherwise the widget will think that the drag is still taking place and will refuse to accept any other event (like clicks with other controllers).

Fixes #1712