### PR TITLE
Chromium: Make password saving option independent from autofill option in Privacy settings

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
@@ -958,6 +958,8 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
         private LoginSavePrompt mLoginSavePrompt;
         private LoginSelectPrompt mLoginSelectPrompt;
 
+        private boolean showLoginSelectPrompt;
+
         public void setListener(PasswordManager.Listener listener) {
             mPasswordManagerListener = listener;
         }
@@ -973,7 +975,11 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
 
         @Override
         public boolean isAutoFillEnabled(Context context) {
-            return SettingsStore.getInstance(context).isAutoFillEnabled();
+            // Chromium doesn't provide an autofill option.
+            // Instead, it provides a login selection prompt that let users decide whether to autofill the saved password or not.
+            // We'll only show this prompt if users enable autofill.
+            showLoginSelectPrompt = SettingsStore.getInstance(context).isAutoFillEnabled();
+            return true;
         }
 
         @Override
@@ -1011,6 +1017,10 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
 
         @Override
         public boolean onLoginSelect(PasswordForm[] forms) {
+            if (!showLoginSelectPrompt) {
+                return false;
+            }
+
             dismiss();
             assert mPasswordManagerListener != null;
 
@@ -1038,6 +1048,10 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
 
         @Override
         public boolean onLoginSelect(String[] username) {
+            if (!showLoginSelectPrompt) {
+                return false;
+            }
+
             dismiss();
             assert mAutofillManagerListener != null;
 


### PR DESCRIPTION
Chromium: Make password saving option independent from autofill option in Privacy settings
    
Currently in Privacy settings in Chromium backend, the password saving option depends on the autofill option. If autofill is disabled, password saving doesn't work whether enabled or not. This is because Chromium doesn't provide an autofill option but provides a login selection prompt that asks users whether to autofill the saved password or not. This commit makes password saving option independent from autofill option. The autofill option now only affects whether to show login selection prompt.
    
Fixes #1707