### PR TITLE
[Pico] Workaround input profile selection in Pico4 Ultra

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -47,6 +47,7 @@ namespace crow {
     constexpr const char* kPathActionReady { "ready_ext" };
     constexpr const char* kInteractionProfileHandInteraction { "/interaction_profiles/ext/hand_interaction_ext" };
     constexpr const char* kInteractionProfileMSFTHandInteraction { "/interaction_profiles/microsoft/hand_interaction" };
+    constexpr const char* kInteractionProfileKHRSimple { "/interaction_profiles/khr/simple_controller" };
 
     // OpenXR Button List
     enum class OpenXRButtonType {
@@ -460,7 +461,7 @@ namespace crow {
 
     // Default fallback: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-button.json
     const OpenXRInputMapping KHRSimple {
-            "/interaction_profiles/khr/simple_controller",
+            kInteractionProfileKHRSimple,
             "generic-trigger.obj",
             "generic-trigger.obj",
             device::UnknownType,

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -81,6 +81,12 @@ XrResult OpenXRInputSource::Initialize()
     for (auto& mapping: OpenXRInputMappings) {
       // Always populate default/fall-back profiles
       if (mapping.controllerType == device::UnknownType) {
+#if PICOXR
+          // Pico4U runtime incorrectly prioritize the Khronos simple controller over Pico's
+          // specific one. Workaround that bad behaviour by skipping the simple controller profile.
+          if (mDeviceType == device::Pico4U && !strcmp(mapping.path, kInteractionProfileKHRSimple))
+              continue;
+#endif
           mMappings.push_back(mapping);
           // Use the system's deviceType instead to ensure we get a valid VRController on WebXR sessions
           mMappings.back().controllerType = mDeviceType;


### PR DESCRIPTION
The OpenXR runtime in the Pico4 Ultra incorrectly selects the Khronos simple profile instead of the more specific Pico4 one provided by the XR_BD_controller_interaction extension.

This results in Wolvic rendering a generic trigger controller instead of the actual 3D model for Pico4 Ultra controllers.