### PR TITLE
Remove duplicate permission.INTERNET declarations

### DIFF
--- a/app/src/hvr/AndroidManifest.xml
+++ b/app/src/hvr/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.usb.host" />
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="com.huawei.vrhandle.permission.DEVICE_MANAGER" />

--- a/app/src/spaces/AndroidManifest.xml
+++ b/app/src/spaces/AndroidManifest.xml
@@ -21,7 +21,6 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.intent.action.CLOSE_SYSTEM_DIALOGS" />
     <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
     <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />


### PR DESCRIPTION
It is already declared in the main manifest so there is no need to duplicate declarations.