### PR TITLE
DownloadManager: process intents from external apps

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
+++ b/app/src/common/shared/com/igalia/wolvic/downloads/DownloadsManager.java
@@ -70,8 +70,8 @@ public class DownloadsManager {
 
     public void init() {
         IntentFilter filter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            mContext.registerReceiver(mDownloadReceiver, filter, null, mMainHandler, Context.RECEIVER_NOT_EXPORTED);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mContext.registerReceiver(mDownloadReceiver, filter, null, mMainHandler, Context.RECEIVER_EXPORTED);
         } else {
             mContext.registerReceiver(mDownloadReceiver, filter, null, mMainHandler);
         }


### PR DESCRIPTION
That's required in Pico4Ultra to receive intents from the Android's DownloadManager. Without that, things like downloading environments don't work because we don't get notified when the download is finished.

Fixes #1740