### PR TITLE
Open tabs in background by default and make it configurable

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -158,6 +158,7 @@ public class SettingsStore {
     private final static long CRASH_RESTART_DELTA = 2000;
     public final static boolean AUTOPLAY_ENABLED = false;
     public final static boolean HEAD_LOCK_DEFAULT = false;
+    public final static boolean OPEN_TABS_IN_BACKGROUND_DEFAULT = true;
     public final static boolean DEBUG_LOGGING_DEFAULT = BuildConfig.DEBUG;
     public final static boolean POP_UPS_BLOCKING_DEFAULT = true;
     public final static boolean WEBXR_ENABLED_DEFAULT = true;
@@ -395,6 +396,17 @@ public class SettingsStore {
     public void setHeadLockEnabled(boolean isEnabled) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putBoolean(mContext.getString(R.string.settings_key_head_lock), isEnabled);
+        editor.apply();
+    }
+
+    public boolean isOpenTabsInBackgroundEnabled() {
+        return mPrefs.getBoolean(
+                mContext.getString(R.string.settings_key_open_tabs_in_background), OPEN_TABS_IN_BACKGROUND_DEFAULT);
+    }
+
+    public void setOpenTabsInBackgroundEnabled(boolean isEnabled) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(mContext.getString(R.string.settings_key_open_tabs_in_background), isEnabled);
         editor.apply();
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -192,6 +192,10 @@ public class SessionStore implements
             mStoreSubscription.resume();
         }
 
+        for (SessionChangeListener listener : mSessionChangeListeners) {
+            listener.onSessionAdded(aSession);
+        }
+
         return aSession;
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
@@ -20,6 +20,7 @@ import com.igalia.wolvic.browser.engine.Session;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WindowWidget;
+import com.igalia.wolvic.utils.StringUtils;
 import com.igalia.wolvic.utils.UrlUtils;
 
 import java.util.Objects;
@@ -99,8 +100,14 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
             mSession.addNavigationListener(this);
             mSession.addSessionChangeListener(this);
 
-            mTitle.setText(mSession.getCurrentTitle());
-            mSubtitle.setText(UrlUtils.stripProtocol(mSession.getCurrentUri()));
+            String title = mSession.getCurrentTitle();
+            String uri = mSession.getCurrentUri();
+            if (StringUtils.isEmpty(title)) {
+                title = UrlUtils.stripCommonSubdomains(UrlUtils.getHost(uri));
+            }
+            mTitle.setText(title);
+            mSubtitle.setText(UrlUtils.stripProtocol(uri));
+
             SessionStore.get().getBrowserIcons().loadIntoView(
                     mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
@@ -16,6 +16,7 @@ import android.webkit.URLUtil;
 import androidx.annotation.StringRes;
 
 import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.downloads.DownloadJob;
 import com.igalia.wolvic.telemetry.TelemetryService;
@@ -101,7 +102,11 @@ public class ContextMenuWidget extends MenuWidget {
             // Open link in a new tab
             mItems.add(new MenuWidget.MenuItem(getContext().getString(R.string.context_menu_open_link_new_tab_1), 0, () -> {
                 if (!StringUtils.isEmpty(aContextElement.linkUri)) {
-                    widgetManager.openNewTab(aContextElement.linkUri);
+                    if (SettingsStore.getInstance(getContext()).isOpenTabsInBackgroundEnabled()) {
+                        widgetManager.openNewTab(aContextElement.linkUri);
+                    } else {
+                        widgetManager.openNewTabForeground(aContextElement.linkUri);
+                    }
                     TelemetryService.Tabs.openedCounter(TelemetryService.Tabs.TabSource.CONTEXT_MENU);
                 }
                 onDismiss();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/ContextMenuWidget.java
@@ -101,7 +101,7 @@ public class ContextMenuWidget extends MenuWidget {
             // Open link in a new tab
             mItems.add(new MenuWidget.MenuItem(getContext().getString(R.string.context_menu_open_link_new_tab_1), 0, () -> {
                 if (!StringUtils.isEmpty(aContextElement.linkUri)) {
-                    widgetManager.openNewTabForeground(aContextElement.linkUri);
+                    widgetManager.openNewTab(aContextElement.linkUri);
                     TelemetryService.Tabs.openedCounter(TelemetryService.Tabs.TabSource.CONTEXT_MENU);
                 }
                 onDismiss();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -16,7 +16,6 @@ import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsDisplayBinding;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
-import com.igalia.wolvic.ui.views.settings.SliderSetting;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
@@ -98,6 +97,9 @@ class DisplayOptionsView extends SettingsView {
 
         mBinding.headLockSwitch.setOnCheckedChangeListener(mHeadLockListener);
         setHeadLock(SettingsStore.getInstance(getContext()).isHeadLockEnabled(), false);
+
+        mBinding.openTabsInBackgroundSwitch.setOnCheckedChangeListener(mOpenTabsInBackgroundListener);
+        setOpenTabsInBackground(SettingsStore.getInstance(getContext()).isOpenTabsInBackgroundEnabled(), false);
 
         @SettingsStore.TabsLocation int tabsLocation = SettingsStore.getInstance(getContext()).getTabsLocation();
         mBinding.tabsLocationRadio.setOnCheckedChangeListener(mTabsLocationChangeListener);
@@ -186,6 +188,10 @@ class DisplayOptionsView extends SettingsView {
 
     private SwitchSetting.OnCheckedChangeListener mHeadLockListener = (compoundButton, value, doApply) -> {
         setHeadLock(value, true);
+    };
+
+    private SwitchSetting.OnCheckedChangeListener mOpenTabsInBackgroundListener = (compoundButton, value, doApply) -> {
+        setOpenTabsInBackground(value, true);
     };
 
     private RadioGroupSetting.OnCheckedChangeListener mTabsLocationChangeListener = (radioGroup, checkedId, doApply) -> {
@@ -344,6 +350,17 @@ class DisplayOptionsView extends SettingsView {
         SettingsStore settingsStore = SettingsStore.getInstance(getContext());
         if (doApply) {
             settingsStore.setHeadLockEnabled(value);
+        }
+    }
+
+    private void setOpenTabsInBackground(boolean value, boolean doApply) {
+        mBinding.openTabsInBackgroundSwitch.setOnCheckedChangeListener(null);
+        mBinding.openTabsInBackgroundSwitch.setValue(value, false);
+        mBinding.openTabsInBackgroundSwitch.setOnCheckedChangeListener(mOpenTabsInBackgroundListener);
+
+        SettingsStore settingsStore = SettingsStore.getInstance(getContext());
+        if (doApply) {
+            settingsStore.setOpenTabsInBackgroundEnabled(value);
         }
     }
 

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -84,6 +84,12 @@
                     android:layout_height="wrap_content"
                     app:description="@string/display_options_latin_auto_complete" />
 
+                <com.igalia.wolvic.ui.views.settings.SwitchSetting
+                    android:id="@+id/openTabsInBackgroundSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/display_options_open_tabs_in_background" />
+
                 <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
                     android:id="@+id/tabs_location_radio"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -262,7 +262,7 @@
     <dimen name="privacy_options_height">490dp</dimen>
 
     <!-- Display settings -->
-    <dimen name="display_options_height">420dp</dimen>
+    <dimen name="display_options_height">450dp</dimen>
 
     <!-- Language and voice settings -->
     <dimen name="language_options_height">400dp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -12,6 +12,7 @@
     <string name="settings_key_start_with_passthrough" translatable="false">settings_start_with_passthrough</string>
     <string name="settings_key_latin_auto_complete" translatable="false">settings_latin_auto_complete</string>
     <string name="settings_key_head_lock" translatable="false">settings_head_lock</string>
+    <string name="settings_key_open_tabs_in_background" translatable="false">settings_open_tabs_in_background</string>
     <string name="settings_key_window_movement" translatable="false">settings_window_movement</string>
     <string name="settings_key_environment_override" translatable="false">settings_environment_override</string>
     <string name="settings_key_performance_monitor" translatable="false">settings_performance_monitor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,6 +523,10 @@
          and is used to customize the windows distance. -->
     <string name="display_options_windows_distance">Windows Distance</string>
 
+    <!-- This string labels an On/Off switch in the 'Display Options' dialog and is used to choose
+         whether new tabs will be activated immediately or they will remain in the background. -->
+    <string name="display_options_open_tabs_in_background">Open new tabs in the background</string>
+
     <!-- This string labels an On/Off switch in the developer options dialog
          and is used to customize background environments of the app. -->
     <string name="developer_options_env_override">Enable Environment Override</string>


### PR DESCRIPTION
This change restores the behaviour of opening new tabs in the background by default.

This functionality had been changed when the new tabs bar was implemented. The reason was that opening a tab in the background leaves it in an uninitialized state until the user clicks on that tab, and this made it difficult to keep the tabs bar
updated in real time.

Additionally, we will use the domain name as the title of background tabs until the user clicks on them (this was empty previously).

This change also adds a new switch to Options / Display that allows the user to choose whether new tabs will be activated immediately or they will remain in the background.

For now, this setting only affects the contextual menu.