### PR TITLE
[PicoXR] Added a new interaction profile for the Pico 4 Ultra

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -47,7 +47,6 @@ namespace crow {
     constexpr const char* kPathActionReady { "ready_ext" };
     constexpr const char* kInteractionProfileHandInteraction { "/interaction_profiles/ext/hand_interaction_ext" };
     constexpr const char* kInteractionProfileMSFTHandInteraction { "/interaction_profiles/microsoft/hand_interaction" };
-    constexpr const char* kInteractionProfileKHRSimple { "/interaction_profiles/khr/simple_controller" };
 
     // OpenXR Button List
     enum class OpenXRButtonType {
@@ -461,7 +460,7 @@ namespace crow {
 
     // Default fallback: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-button.json
     const OpenXRInputMapping KHRSimple {
-            kInteractionProfileKHRSimple,
+            "/interaction_profiles/khr/simple_controller",
             "generic-trigger.obj",
             "generic-trigger.obj",
             device::UnknownType,

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -239,31 +239,6 @@ namespace crow {
             },
     };
 
-    // Pico controller: this definition was created for the Pico 4, but the Neo 3 will likely also be compatible
-    const OpenXRInputMapping Pico4xOld {
-            "/interaction_profiles/pico/neo3_controller",
-            "vr_controller_pico4_left.obj",
-            "vr_controller_pico4_right.obj",
-            device::Pico4x,
-            std::vector<OpenXRInputProfile> { "pico-4", "generic-trigger-squeeze-thumbstick" },
-            std::vector<OpenXRButton> {
-                    { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::ValueTouch, OpenXRHandFlags::Both },
-                    { OpenXRButtonType::Squeeze, kPathSqueeze, OpenXRButtonFlags::Value, OpenXRHandFlags::Both },
-                    { OpenXRButtonType::Thumbstick, kPathThumbstick, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Both },
-                    { OpenXRButtonType::ButtonX, kPathButtonX, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left },
-                    { OpenXRButtonType::ButtonY, kPathButtonY, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left,  },
-                    { OpenXRButtonType::ButtonA, kPathButtonA, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
-                    { OpenXRButtonType::ButtonB, kPathButtonB, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
-                    { OpenXRButtonType::Back, kPathBack, OpenXRButtonFlags::Click, OpenXRHandFlags::Left, ControllerDelegate::Button::BUTTON_APP, true }
-            },
-            std::vector<OpenXRAxis> {
-                    { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
-            },
-            std::vector<OpenXRHaptic> {
-                    { kPathHaptic, OpenXRHandFlags::Both },
-            },
-    };
-
     const OpenXRInputMapping Pico4x {
             "/interaction_profiles/bytedance/pico4_controller",
             "vr_controller_pico4_left.obj",
@@ -475,8 +450,8 @@ namespace crow {
             },
     };
 
-    const std::array<OpenXRInputMapping, 15> OpenXRInputMappings {
-            OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4U, Pico4x, Pico4xOld, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, HandInteraction, MSFTHandInteraction, KHRSimple
+    const std::array<OpenXRInputMapping, 14> OpenXRInputMappings {
+            OculusTouch, OculusTouch2, MetaQuestTouchPro, Pico4U, Pico4x, PicoNeo3, Hvr6DOF, Hvr3DOF, LenovoVRX, MagicLeap2, MetaTouchPlus, HandInteraction, MSFTHandInteraction, KHRSimple
     };
 
 } // namespace crow

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -289,7 +289,7 @@ namespace crow {
     };
 
     const OpenXRInputMapping Pico4U {
-            "/interaction_profiles/bytedance/pico4_controller",
+            "/interaction_profiles/bytedance/pico4s_controller",
             "vr_controller_pico4u_left.obj",
             "vr_controller_pico4u_right.obj",
             device::Pico4U,

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -81,12 +81,6 @@ XrResult OpenXRInputSource::Initialize()
     for (auto& mapping: OpenXRInputMappings) {
       // Always populate default/fall-back profiles
       if (mapping.controllerType == device::UnknownType) {
-#if PICOXR
-          // Pico4U runtime incorrectly prioritize the Khronos simple controller over Pico's
-          // specific one. Workaround that bad behaviour by skipping the simple controller profile.
-          if (mDeviceType == device::Pico4U && !strcmp(mapping.path, kInteractionProfileKHRSimple))
-              continue;
-#endif
           mMappings.push_back(mapping);
           // Use the system's deviceType instead to ensure we get a valid VRController on WebXR sessions
           mMappings.back().controllerType = mDeviceType;


### PR DESCRIPTION
The 4 Ultra has its own interaction profile. It cannot be found in any online sources that we know but we were told about it by the Pico's customer service.

This allows us to remove the workaround that we landed to select the Pico4 profile over the generic Khronos one.

Apart from that, we take the chance to remove the unused Pico4xOld profile, that might potentially break controller support for devices with old PicoOS versions.