### PR TITLE
[PICO] Disable the controller when no position info is available

### DIFF
--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -829,6 +829,9 @@ void OpenXRInputSource::Update(const XrFrameState& frameState, XrSpace localSpac
             }
             handFacesHead = OpenXRGestureManager::handFacesHead(jointTransforms[HAND_JOINT_FOR_AIM], head);
             delegate.SetHandJointLocations(mIndex, std::move(jointTransforms), std::move(jointRadii));
+        } else if (isControllerUnavailable) {
+            delegate.SetEnabled(mIndex, false);
+            return;
         }
     }
 


### PR DESCRIPTION
PICO continuously tracks the controllers even when they are not in use, so we always check for additional hand tracking information.

However, it might happen that the PICO controller has the SPACE_LOCATION_ORIENTATION_VALID flag unset and at the same time we are not able to get hand tracking information.

In that scenario, we should hide the controller.