### PR TITLE
Upgrade Gecko version in the user agent for desktop mode

### DIFF
--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -43,7 +43,7 @@ public class SessionImpl implements WSession {
     // The difference between "Mobile" and "VR" matches GeckoViewSettings.jsm
     private static final String WOLVIC_USER_AGENT_MOBILE = GeckoSession.getDefaultUserAgent() + " Wolvic/" + BuildConfig.VERSION_NAME;
     private static final String WOLVIC_USER_AGENT_VR = WOLVIC_USER_AGENT_MOBILE.replace("Mobile", "Mobile VR");
-    private static final String WOLVIC_USER_AGENT_DESKTOP = "Mozilla/5.0 (X11; Linux x86_64; rv:105.0) Gecko/20100101 Firefox/105.0";
+    private static final String WOLVIC_USER_AGENT_DESKTOP = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
 
     public SessionImpl(@Nullable WSessionSettings settings) {
         if (settings == null) {


### PR DESCRIPTION
We were using Gecko 105 which is super old now. Some sites were even complaining about using a too old version of the browser.