### PR TITLE
Apply MediaSession fixes to all videos

### DIFF
--- a/app/src/main/assets/extensions/fxr_mediasession/main.js
+++ b/app/src/main/assets/extensions/fxr_mediasession/main.js
@@ -53,24 +53,8 @@ function mediaSessionFix() {
     });
 }
 
-document.addEventListener('fullscreenchange', (event) => {
-  if (!document.fullscreenElement) {
-    if (video) {
-        video.removeEventListener('ratechange', handleVideoUpdate);
-        video.removeEventListener('timeupdate', handleVideoUpdate);
-    }
-    video = null;
-    return;
-  }
-
-  if (document.fullscreenElement.tagName.toLowerCase() === "video") {
-    video = document.fullscreenElement;
-  } else {
-    video = document.fullscreenElement.getElementsByTagName("video")[0] || null;
-  }
-
-  if (video) {
-    logDebug("Apply MediaSession fixes for video");
+addEventListener('playing', (event) => {
+    logDebug('Playing event:', event.target.src);
+    video = event.target;
     mediaSessionFix();
-  }
-});
+}, {capture: true});


### PR DESCRIPTION
Wolvic has an internal extension which feeds the navigator.mediaSession object with progress information. It was initially developed to get progress information for the progress bar that is shown on fullscreen videos. That's the reason why the extension was only injecting data into the web engine for those videos that were emitting the onfullscreen events.

The problem is that in VisionGlass we have another progress bar that is shown in the phone UI but for all videos, not only fullscreen ones.

The fix is to capture the playing event and then apply the mediasession fixes that we already have in place for the video element that issued the event.

Fixes #1406