### PR TITLE
Do not replace YouTube's service worker URL

### DIFF
--- a/app/src/main/assets/extensions/fxr_youtube/background.js
+++ b/app/src/main/assets/extensions/fxr_youtube/background.js
@@ -40,8 +40,9 @@ function redirect(details) {
         }
 
         // Add app=desktop to the query string if it's not already there. Don't do it for
-        // the consent page as it breaks the request.
-        if (!uri.searchParams.has("app") && !uri.hostname.startsWith("consent.youtube.com")) {
+        // the consent page as it breaks the request. Same for the service worker.
+        if (!uri.searchParams.has("app") && !uri.hostname.startsWith("consent.youtube.com")
+            && !uri.pathname.startsWith("/sw.js")) {
             uri.searchParams.append('app', 'desktop');
             return { redirectUrl: uri.href };
         }


### PR DESCRIPTION
The YouTube web extension appends "app=desktop" to the end of the URL in order to get the immersive video formats from the server. However we cannot do that for every YouTube URL as it breaks some of them. One example is the consent page and another one is the service worker URL which was failing with this error:

"JavaScript Error: "Invalid redirectUrl https://www.youtube.com/sw.js?app=desktop on service worker main script https://www.youtube.com/sw.js requested by fxr-webcompat_youtube@mozilla.org"