### PR TITLE
Cleanup the Presentation class when disconnecting the Glasses

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -402,6 +402,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     protected void initializeWidgets() {
+        Log.d(LOGTAG, "VRBrowserActivity initializeWidgets");
         UISurfaceTextureRenderer.setRenderActive(true);
 
         // Empty widget just for handling focus on empty space
@@ -1649,6 +1650,15 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         return mWidgetHandleIndex++;
     }
 
+    @Override
+    public void restoreWidgets()  {
+        Log.d(LOGTAG, "VRBrowserActivity restoreWidgets");
+        for (Widget aWidget : mWidgets.values()) {
+            final int handle = aWidget.getHandle();
+            final WidgetPlacement clone = aWidget.getPlacement().clone();
+            queueRunnable(() -> addWidgetNative(handle, clone));
+        }
+    }
 
     public void addWidgets(final Iterable<? extends Widget> aWidgets) {
         for (Widget widget : aWidgets) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -749,6 +749,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             mProjectionMenu.setParentWidget(this);
             mProjectionMenuPlacement = new WidgetPlacement(getContext());
             mWidgetManager.addWidget(mProjectionMenu);
+            mWidgetManager.addWidget(mProjectionMenu);
             mProjectionMenu.setDelegate((projection)-> {
                 if (mViewModel.getIsInVRVideo().getValue().get()) {
                     if (projection == VIDEO_PROJECTION_NONE) {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -933,6 +933,7 @@ BrowserWorld::WasButtonAppPressed() {
 void
 BrowserWorld::RegisterDeviceDelegate(DeviceDelegatePtr aDelegate) {
   ASSERT_ON_RENDER_THREAD();
+  VRB_LOG("BrowserWorld::RegisterDeviceDelegate");
   DeviceDelegatePtr previousDevice = std::move(m.device);
   m.device = std::move(aDelegate);
   if (m.device) {
@@ -1414,6 +1415,7 @@ BrowserWorld::SetSurfaceTexture(const std::string& aName, jobject& aSurface) {
 void
 BrowserWorld::AddWidget(int32_t aHandle, const WidgetPlacementPtr& aPlacement) {
   ASSERT_ON_RENDER_THREAD();
+  VRB_LOG("Adding widget with handle %d", aHandle);
   if (m.GetWidget(aHandle)) {
     VRB_LOG("Widget with handle %d already added, updating it.", aHandle);
     UpdateWidget(aHandle, aPlacement);
@@ -1463,6 +1465,7 @@ BrowserWorld::AddWidget(int32_t aHandle, const WidgetPlacementPtr& aPlacement) {
 void
 BrowserWorld::UpdateWidget(int32_t aHandle, const WidgetPlacementPtr& aPlacement) {
   ASSERT_ON_RENDER_THREAD();
+  VRB_LOG("Updating widget with handle %d", aHandle);
   WidgetPtr widget = m.GetWidget(aHandle);
   if (!widget) {
       VRB_ERROR("Can't find Widget with handle: %d", aHandle);
@@ -1834,6 +1837,7 @@ BrowserWorld::Create() {
   result->m.self = result;
   result->m.surfaceObserver = std::make_shared<SurfaceObserver>(result->m.self);
   result->m.context->GetSurfaceTextureFactory()->AddGlobalObserver(result->m.surfaceObserver);
+  VRB_LOG("BrowserWorld created");
   return result;
 }
 
@@ -2073,10 +2077,13 @@ BrowserWorld::DrawSplashAnimation(device::Eye aEye) {
 void
 BrowserWorld::CreateSkyBox(const std::string& aBasePath, const std::string& aExtension) {
   ASSERT_ON_RENDER_THREAD();
+  VRB_LOG("BrowserWorld::CreateSkyBox - Creating skybox with path: %s", aBasePath.c_str());
   vrb::PausePerformanceMonitor pauseMonitor(*m.monitor);
   const bool empty = aBasePath == "cubemap/void";
   if (empty) {
+    VRB_LOG("BrowserWorld::CreateSkyBox - Removing skybox");
     if (m.skybox) {
+      VRB_LOG("BrowserWorld::CreateSkyBox - Removing skybox layer");
       VRLayerCubePtr layer = m.skybox->GetLayer();
       if (layer) {
         m.device->DeleteLayer(layer);
@@ -2106,6 +2113,7 @@ BrowserWorld::CreateSkyBox(const std::string& aBasePath, const std::string& aExt
 
   const int32_t size = 1024;
   if (m.skybox) {
+    VRB_LOG("BrowserWorld::CreateSkyBox - Updating skybox");
     m.skybox->SetVisible(true);
     if (m.skybox->GetLayer() && (m.skybox->GetLayer()->GetWidth() != size || m.skybox->GetLayer()->GetFormat() != glFormat)) {
       VRLayerCubePtr oldLayer = m.skybox->GetLayer();
@@ -2115,6 +2123,7 @@ BrowserWorld::CreateSkyBox(const std::string& aBasePath, const std::string& aExt
     }
     m.skybox->Load(m.loader, aBasePath, extension);
   } else {
+    VRB_LOG("BrowserWorld::CreateSkyBox - Creating skybox");
     VRLayerCubePtr layer = m.device->CreateLayerCube(size, size, glFormat);
     m.skybox = Skybox::Create(m.create, layer);
     m.rootOpaqueParent->AddNode(m.skybox->GetRoot());

--- a/app/src/main/cpp/Skybox.cpp
+++ b/app/src/main/cpp/Skybox.cpp
@@ -96,6 +96,7 @@ struct Skybox::State {
   }
 
   void LoadGeometry() {
+    VRB_LOG("Skybox::LoadGeometry() - %s", basePath.c_str());
     LoadTask task = [=](CreationContextPtr &aContext) -> GroupPtr {
       std::array<GLfloat, 24> cubeVertices{
           -1.0f, 1.0f, 1.0f, // 0
@@ -165,6 +166,7 @@ struct Skybox::State {
   }
 
   void LoadLayer() {
+    VRB_LOG("Skybox::LoadLayer() - %s %d", basePath.c_str(), layerTextureHandle);
     if (basePath.empty() || layerTextureHandle == 0) {
       return;
     }
@@ -178,6 +180,7 @@ struct Skybox::State {
 
 void
 Skybox::Load(const vrb::ModelLoaderAndroidPtr& aLoader, const std::string& aBasePath, const std::string& aExtension) {
+  VRB_LOG("Skybox::Load() - %s (current) %s (new)", m.basePath.c_str(), aBasePath.c_str());
   if (m.basePath == aBasePath) {
     return;
   }
@@ -283,6 +286,10 @@ Skybox::ValidateCustomSkyboxAndFindFileExtension(const std::string& aBasePath) {
 
 SkyboxPtr
 Skybox::Create(vrb::CreationContextPtr aContext, const VRLayerCubePtr& aLayer) {
+  VRB_LOG("Skybox::Create()");
+  if (aLayer == nullptr) {
+    VRB_ERROR("Skybox::Create() - Layer is null");
+  }
   SkyboxPtr result = std::make_shared<vrb::ConcreteClass<Skybox, Skybox::State> >(aContext);
   result->m.layer = aLayer;
   result->m.Initialize();

--- a/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
+++ b/app/src/visionglass/cpp/DeviceDelegateVisionGlass.cpp
@@ -120,6 +120,7 @@ struct DeviceDelegateVisionGlass::State {
 
 DeviceDelegateVRGlassPtr
 DeviceDelegateVisionGlass::Create(vrb::RenderContextPtr& aContext) {
+  VRB_LOG("DeviceDelegateVisionGlass::Create()");
   DeviceDelegateVRGlassPtr result = std::make_shared<vrb::ConcreteClass<DeviceDelegateVisionGlass, DeviceDelegateVisionGlass::State > > ();
   result->m.context = aContext;
   result->m.Initialize();

--- a/app/src/visionglass/cpp/native-lib.cpp
+++ b/app/src/visionglass/cpp/native-lib.cpp
@@ -25,6 +25,7 @@ extern "C" {
 
 JNI_METHOD(void, activityPaused)
 (JNIEnv*, jobject) {
+    VRB_LOG("native-lib - activityPaused");
     if (sAppContext->mDevice) {
         sAppContext->mDevice->Pause();
     }
@@ -34,6 +35,7 @@ JNI_METHOD(void, activityPaused)
 
 JNI_METHOD(void, activityResumed)
 (JNIEnv*, jobject) {
+    VRB_LOG("native-lib - activityResumed");
     if (sAppContext->mDevice) {
         sAppContext->mDevice->Resume();
     }
@@ -43,6 +45,7 @@ JNI_METHOD(void, activityResumed)
 
 JNI_METHOD(void, activityCreated)
 (JNIEnv* aEnv, jobject aActivity, jobject aAssetManager) {
+    VRB_LOG("native-lib - activityCreated");
     sAppContext->mJavaContext.activity = aEnv->NewGlobalRef(aActivity);
     sAppContext->mJavaContext.env = aEnv;
     sAppContext->mJavaContext.vm->AttachCurrentThread(&sAppContext->mJavaContext.env, nullptr);
@@ -69,6 +72,7 @@ JNI_METHOD(void, updateViewport)
 
 JNI_METHOD(void, activityDestroyed)
 (JNIEnv*, jobject) {
+    VRB_LOG("native-lib - activityDestroyed");
     BrowserWorld::Instance().ShutdownJava();
     BrowserWorld::Instance().RegisterDeviceDelegate(nullptr);
     BrowserWorld::Destroy();


### PR DESCRIPTION
We are creating new instances of the VisionGlassPresentation class whenever the device is reconnected to the  phone's USB port. This implies that the GLViewTexture we use to render the Wolvic window is recreated as well, hence it uses a different thread than the one used initially to setup the BrowserWorld::instance() singleton. This causes that subsequent calls to the different BrowserWorld native APIs (eg, activityCreated, activityPaused) fail due to the ```ASSERT_ON_RENDER_THREAD();``` check.

The problem is not that the calls made by the VisionGlassPersentation class on the java side are not being performed in the GL thread, but that it's a different thread, as I commented before. It seems that the ASSERT_ON_RENDER_THREAD assertion just checks whether the current thread (pthread_self() ) is the same than the one stored in the BrowserWorld.instance() singleton (m,selfThread). 

If we want to avoid restarting the whole app to handle the reconnection use case, we would need to cleanup the BrowserWorld data structures when we detect the disconnection event, so that the subsequent ```activityCreated```calls are executed with the new GL thread. 

Fixes #1764 