### PR TITLE
New intent-filter for the USB_DEVICE_ATTACHED

### DIFF
--- a/app/src/visionglass/AndroidManifest.xml
+++ b/app/src/visionglass/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-feature
         android:name="android.hardware.vr.headtracking"
         android:required="false" />
+    <uses-feature android:name="android.hardware.usb.host" />
+
 
     <application>
         <activity
@@ -14,6 +16,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
         </activity>
         <activity
             android:name=".FirstRunActivity"

--- a/app/src/visionglass/res/xml/device_filter.xml
+++ b/app/src/visionglass/res/xml/device_filter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <usb-device vendor-id="18455" product-id="16962" class="239" subclass="2" protocol="1"/>
+</resources>


### PR DESCRIPTION
This change adds in the Manifest a new intent-filter  and a meta-data section for the USB_DEVICE_ATTACHED action to identify the Vision Glass device, so that it can be selected by the user as the default application to handle such USB device.

Additionally, for the case of connecting the device while Wolvic is already running, we handle the USB_DEVICE_ATTACHED intent action in order to ensure we don't ask for permissions if we already granted them.

Fixes #1765, #1767