### PR TITLE
Do not leak private IP addresses via WebRTC

### DIFF
--- a/app/src/main/res/raw/fxr_config.yaml
+++ b/app/src/main/res/raw/fxr_config.yaml
@@ -27,3 +27,4 @@ prefs:
   browser.gesture.pinch.out.shift: ''
   browser.gesture.pinch.in.shift: ''
   apz.one_touch_pinch.enabled: false
+  media.peerconnection.ice.obfuscate_host_addresses: true


### PR DESCRIPTION
WebRTC protocol can leak local IP addresses by design. This can be prevented by obfuscation. This is done via a preference in Gecko.

This can be easily tested in https://browserleaks.com/webrtc. "WebRTC Leak Test" should say "no leak" and there shouldn't be any local ip address there.

Fixes #1773 