### PR TITLE
Revert the changes related to the new intent-filter for the USB_DEVICE_ATTACHED"

### DIFF
--- a/app/src/visionglass/AndroidManifest.xml
+++ b/app/src/visionglass/AndroidManifest.xml
@@ -4,8 +4,6 @@
     <uses-feature
         android:name="android.hardware.vr.headtracking"
         android:required="false" />
-    <uses-feature android:name="android.hardware.usb.host" />
-
 
     <application>
         <activity
@@ -16,12 +14,6 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
-            </intent-filter>
-            <meta-data
-                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
-                android:resource="@xml/device_filter" />
         </activity>
         <activity
             android:name=".FirstRunActivity"

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -19,8 +19,6 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.hardware.display.DisplayManager;
-import android.hardware.usb.UsbDevice;
-import android.hardware.usb.UsbManager;
 import android.opengl.GLSurfaceView;
 import android.os.Build;
 import android.os.Bundle;
@@ -77,8 +75,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
     static String LOGTAG = SystemUtils.createLogtag(PlatformActivity.class);
 
     public static final String HUAWEI_USB_PERMISSION = "com.huawei.usblib.USB_PERMISSION";
-    public static final int VISION_GLASS_VENDOR_ID = 18455;
-    public static final int VISION_GLASS_PRODUCT_ID = 16962;
 
     private boolean mIsAskingForPermission;
     private PhoneUIViewModel mViewModel;
@@ -182,21 +178,10 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
     private final BroadcastReceiver mUsbPermissionReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (HUAWEI_USB_PERMISSION.equals(intent.getAction())) {
-                Log.d("MainActivity", "USB permission broadcast; waiting for permission: " + mIsAskingForPermission + "; intent: " + intent.toString());
+            Log.d(LOGTAG, "USB permission broadcast; waiting for permission: " + mIsAskingForPermission + "; intent: " + intent.toString());
 
-                mIsAskingForPermission = false;
-                initVisionGlass();
-            } else if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(intent.getAction())) {
-                Log.d("MainActivity", "USB device attached");
-                UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
-                if (device != null && device.getVendorId() == VISION_GLASS_VENDOR_ID && device.getProductId() == VISION_GLASS_PRODUCT_ID) {
-                    Log.d("MainActivity", "USB device attached: " + device.getDeviceName());
-                    if (!VisionGlass.getInstance().hasUsbPermission()) {
-                        VisionGlass.getInstance().requestUsbPermission();
-                    }
-                }
-            }
+            mIsAskingForPermission = false;
+            initVisionGlass();
         }
     };
 
@@ -221,7 +206,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
         // Alternatively: android.hardware.usb.action.USB_DEVICE_ATTACHED, USB_DEVICE_DETACHED.
         IntentFilter usbPermissionFilter = new IntentFilter();
         usbPermissionFilter.addAction(HUAWEI_USB_PERMISSION);
-        usbPermissionFilter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(mUsbPermissionReceiver, usbPermissionFilter, Context.RECEIVER_NOT_EXPORTED);
         } else {

--- a/app/src/visionglass/res/xml/device_filter.xml
+++ b/app/src/visionglass/res/xml/device_filter.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <usb-device vendor-id="18455" product-id="16962" class="239" subclass="2" protocol="1"/>
-</resources>


### PR DESCRIPTION
The PR#1769 is a step in the good direction to correctly handling the USB events in Wolvic Vision. However, the new behavior unveils or makes easier to reproduce other issues (eg issue #1764) we have in our implementation. 

Hence, until we analyze our logic to manage the display and USB events, it's better to leave our current behavior, even if we know it has problems.