### PR TITLE
Do not use the deprecated buildDir in gradle scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ allprojects {
 }
 
 tasks.register("clean", Delete) {
-    delete rootProject.buildDir
+    delete layout.buildDirectory
 }


### PR DESCRIPTION
Replace it by layout.buildDiretory instead.