### PR TITLE
Reland the changes related to the new intent-filter for the USB_DEVICE_ATTACHED

### DIFF
--- a/app/src/visionglass/AndroidManifest.xml
+++ b/app/src/visionglass/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-feature
         android:name="android.hardware.vr.headtracking"
         android:required="false" />
+    <uses-feature android:name="android.hardware.usb.host" />
+
 
     <application>
         <activity
@@ -14,6 +16,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
         </activity>
         <activity
             android:name=".FirstRunActivity"

--- a/app/src/visionglass/res/xml/device_filter.xml
+++ b/app/src/visionglass/res/xml/device_filter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <usb-device vendor-id="18455" product-id="16962" class="239" subclass="2" protocol="1"/>
+</resources>


### PR DESCRIPTION
This PR has been reverted in PR #1775 and we are trying to land it again now. 

Please, test the cases described in the issues that this change supposedly fixes.

This PR it's **blocked** on the issue #1764 so it should not be merged until we have a fix.

Fixes #1765 #1767
