### PR TITLE
[VisionGlasss] Start the IMU service when a new Display is added

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -783,6 +783,11 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
         }
     }
 
+    private void startIMUService() {
+        Log.d(LOGTAG, "Starting IMU service");
+        VisionGlass.getInstance().startImu((w, x, y, z) -> queueRunnable(() -> setHead(x, y, z, w)));
+    }
+
     private final DisplayManager.DisplayListener mDisplayListener =
             new DisplayManager.DisplayListener() {
                 private void callUpdateIfIsPresentation(int displayId) {
@@ -796,6 +801,7 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                 @Override
                 public void onDisplayAdded(int displayId) {
                     Log.d(LOGTAG, "display listener: onDisplayAdded displayId = " + displayId);
+                    startIMUService();
                     callUpdateIfIsPresentation(displayId);
                 }
 
@@ -827,9 +833,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
             mViewModel.updateConnectionState(PhoneUIViewModel.ConnectionState.ACTIVE);
             return;
         }
-
-        Log.d(LOGTAG, "Starting IMU");
-        VisionGlass.getInstance().startImu((w, x, y, z) -> queueRunnable(() -> setHead(x, y, z, w)));
 
         VisionGlassPresentation presentation = new VisionGlassPresentation(this, presentationDisplay);
         Display.Mode[] modes = presentationDisplay.getSupportedModes();


### PR DESCRIPTION
The Vision SDK is providing us wrong position data in the callback passed to the startIMU method. This is happening only the first time Wolvic is laucnhed after connecting the device to the USB port.

We were calling to the startIMU() method as part of the showPresentation logic. It's only called if the display received as argument is different to the current presentationDisplay and or if there isn't an instance of the VisionGlassPresentation class yet.

It seems that calling the startUMI() method everytime a new display is added solves the issue. We need to do it independently of whether the display has the FLAG_PRESENTATION bit enabled or not. Actually, we need to call it at least once if both cases.

It's important to know that this is just a workaround, since we don't understand completely the root cause of the issue, or why this change solve it. However, I haven't seen any regression caused but this change, so I believe it's a safe approach.

I also want to mention that before this change, in the case of the subsequent launches of Wolvic, after having granted USB persisions and the Wired Projection, the startIMU() method is called as part of the updateDisplays() call form the onResume() method. In this case, the Presentation display from the previous execution is still handled by the DisplayManager. As a matter of fact, we use that one to create the new VisionGlassPresentation instance. This PR changes that case as well, since now the startIMU() method is called only after a new display is added, in this case it'd be one with the FLAG_PRESENTAITON bit disabled.