### PR TITLE
Update URL bar when hiding the Library

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -561,6 +561,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             unsetView(mLibrary, switchSurface);
             mLibrary.onHide();
             mViewModel.setCurrentContentType(Windows.ContentType.WEB_CONTENT);
+            mViewModel.setUrl(mSession.getCurrentUri());
         }
         if (switchSurface && mRestoreFirstPaint != null) {
             mRestoreFirstPaint.run();


### PR DESCRIPTION
Update the URL in the WindowViewModel when a panel is hidden, so the URL bar correctly shows the URL of the page being shown.

Fixes: https://github.com/Igalia/wolvic/issues/1777