### PR TITLE
[VisionGlass] New Tray widget for the PhoneUI

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
+++ b/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
@@ -7,6 +7,15 @@ public abstract class PlatformActivityPlugin {
     public interface PlatformActivityPluginListener {
         void onPlatformScrollEvent(float distanceX, float distanceY);
     }
+
+    public interface TrayDelegate {
+        void onAddWindowClicked();
+        void onPrivateBrowsingClicked();
+        void onBookmarksClicked();
+        void onDownloadsClicked();
+        void onSettingsClicked();
+    }
+
     abstract void onVideoAvailabilityChange();
     abstract boolean onBackPressed();
     void registerListener(PlatformActivityPluginListener listener) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -35,6 +35,7 @@ import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.PreferenceManager;
 
+import com.igalia.wolvic.PlatformActivityPlugin;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.VRBrowserApplication;
@@ -64,7 +65,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-public class TrayWidget extends UIWidget implements WidgetManagerDelegate.UpdateListener,
+public class TrayWidget extends UIWidget implements WidgetManagerDelegate.UpdateListener, PlatformActivityPlugin.TrayDelegate,
         DownloadsManager.DownloadsListener, ConnectivityReceiver.Delegate,
         SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -691,6 +692,34 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mTrayViewModel.setIsKeyboardVisible(aWidget.isVisible());
     }
+
+    // PlatformActivityPlugin.TrayDelegate
+    @Override
+    public void onAddWindowClicked() {
+        mBinding.addwindowButton.performClick();
+    }
+
+    @Override
+    public void onPrivateBrowsingClicked() {
+        mBinding.privateButton.performClick();
+    }
+
+    @Override
+    public void onBookmarksClicked() {
+        mBinding.bookmarksButton.performClick();
+    }
+
+    @Override
+    public void onDownloadsClicked() {
+        mBinding.downloadsButton.performClick();
+    }
+
+    @Override
+    public void onSettingsClicked() {
+        mBinding.settingsButton.performClick();
+    }
+
+
 
     public void showTabAddedNotification() {
         showNotification(TAB_ADDED_NOTIFICATION_ID, mBinding.tabsButton, R.string.tab_added_notification);

--- a/app/src/main/res/drawable/tray_background_rounded.xml
+++ b/app/src/main/res/drawable/tray_background_rounded.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/asphalt" />
+    <corners android:radius="64dp" />
+</shape>

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -67,6 +67,7 @@ import com.igalia.wolvic.utils.SystemUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Arrays;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
@@ -571,12 +572,14 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
 
     private class PlatformActivityPluginVisionGlass extends PlatformActivityPlugin {
         private final WidgetManagerDelegate mDelegate;
+        private final TrayDelegate mTrayDelegate;
         private WMediaSession.Delegate mMediaSessionDelegate;
         private GestureDetector mGestureDetector;
         private final Context mContext;
 
         PlatformActivityPluginVisionGlass(WidgetManagerDelegate delegate, Context context) {
             mDelegate = delegate;
+            mTrayDelegate = delegate.getTray();
             mContext = context;
             setupPhoneUI();
         }
@@ -632,6 +635,26 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
             mBinding.headlockToggleButton.setChecked(settings.isHeadLockEnabled());
             mBinding.headlockToggleButton.setOnClickListener(v -> {
                 mDelegate.setLockMode(mBinding.headlockToggleButton.isChecked() ? WidgetManagerDelegate.HEAD_LOCK : WidgetManagerDelegate.NO_LOCK);
+            });
+
+            mBinding.newWindowButton.setOnClickListener(v -> {
+                mTrayDelegate.onAddWindowClicked();
+            });
+
+            mBinding.privateButton.setOnClickListener(v -> {
+                mTrayDelegate.onPrivateBrowsingClicked();
+            });
+
+            mBinding.bookmarkButton.setOnClickListener(v -> {
+                mTrayDelegate.onBookmarksClicked();
+            });
+
+            mBinding.downloadsButton.setOnClickListener(v -> {
+                mTrayDelegate.onDownloadsClicked();
+            });
+
+            mBinding.settingsButton.setOnClickListener(v -> {
+                mTrayDelegate.onSettingsClicked();
             });
 
             Slider distanceSlider = findViewById(R.id.distance_slider);

--- a/app/src/visionglass/res/layout/visionglass_layout.xml
+++ b/app/src/visionglass/res/layout/visionglass_layout.xml
@@ -82,11 +82,41 @@
                 style="@style/VoiceSearchButtonStyle" />
 
             <androidx.constraintlayout.widget.Barrier
-                android:id="@+id/barrier"
+                android:id="@+id/toolbar_barrier"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:barrierDirection="bottom"
                 app:constraint_referenced_ids="headlock_toggle_button,realign_button,voice_search_button" />
+
+            <LinearLayout
+                android:id="@+id/tray_buttons"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/toolbar_barrier"
+                style="@style/TrayStyle">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/new_window_button"
+                    android:contentDescription="@string/new_window_tooltip"
+                    style="@style/NewWindowButtonStyle" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/private_button"
+                    style="@style/PrivateWindowButtonStyle" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/bookmark_button"
+                    style="@style/BookmarksButtonStyle" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/downloads_button"
+                    style="@style/DownloadsButtonStyle" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/settings_button"
+                    style="@style/SettingsButtonStyle" />
+
+            </LinearLayout>
 
             <com.google.android.material.slider.Slider
                 android:id="@+id/distance_slider"
@@ -96,7 +126,7 @@
                 android:layout_marginTop="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/barrier" />
+                app:layout_constraintTop_toBottomOf="@id/tray_buttons" />
 
             <FrameLayout
                 android:id="@+id/touchpad_container"

--- a/app/src/visionglass/res/values/themes.xml
+++ b/app/src/visionglass/res/values/themes.xml
@@ -20,6 +20,11 @@
         <item name="cornerSize">32dp</item>
     </style>
 
+    <style name="ShapeAppearanceOverlay.App.Button.Circle" parent="ShapeAppearance.MaterialComponents.MediumComponent">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">50%</item>
+    </style>
+
     <style name="ThemeOverlay.App.Slider" parent="">
         <item name="colorPrimary">@color/white</item>
         <item name="colorOnPrimary">@color/white</item>
@@ -37,11 +42,23 @@
         <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.App.Button.Rounded</item>"
     </style>
 
+    <style name="BaseTrayButton" parent="Widget.MaterialComponents.Button">
+        <item name="android:layout_width">58dp</item>
+        <item name="android:layout_height">58dp</item>
+        <item name="android:backgroundTint">@color/bg_button_checkable</item>
+        <item name="android:layout_margin">4dp</item>
+        <item name="iconGravity">textStart</item>
+        <item name="iconPadding">0dp</item>
+        <item name="iconSize">24dp</item>
+        <item name="iconTint">@color/white</item>
+        <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.App.Button.Circle</item>"
+    </style>
+
     <style name="BaseFooterButton" parent="Widget.MaterialComponents.Button">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">?attr/actionBarSize</item>
         <item name="android:scaleType">fitCenter</item>
-        <item name="android:backgroundTint">@color/asphalt</item>
+        <item name="android:backgroundTint">@color/bg_button_checkable</item>
         <item name="iconGravity">textStart</item>
         <item name="iconPadding">0dp</item>
         <item name="iconTint">@color/white</item>
@@ -96,6 +113,35 @@
         <item name="icon">@drawable/ic_icon_home</item>
         <item name="android:layout_width">64dp</item>
         <item name="android:layout_height">64dp</item>
+    </style>
+
+    <style name="TrayStyle">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:orientation">horizontal</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_margin">8dp</item>
+        <item name="android:background">@drawable/tray_background_rounded</item>
+    </style>
+
+    <style name="NewWindowButtonStyle" parent="BaseTrayButton">"
+        <item name="icon">@drawable/ic_icon_tray_newwindow</item>
+    </style>
+
+    <style name="PrivateWindowButtonStyle" parent="BaseTrayButton">"
+        <item name="icon">@drawable/ic_icon_tray_private_browsing_v2</item>
+    </style>
+
+    <style name="BookmarksButtonStyle" parent="BaseTrayButton">"
+        <item name="icon">@drawable/ic_icon_bookmark</item>
+    </style>
+
+    <style name="DownloadsButtonStyle" parent="BaseTrayButton">"
+        <item name="icon">@drawable/ic_icon_downloads</item>
+    </style>
+
+    <style name="SettingsButtonStyle" parent="BaseTrayButton">"
+        <item name="icon">@drawable/ic_icon_tray_settings_v3</item>
     </style>
 
     <style name="DistanceSliderStyle" parent="Widget.MaterialComponents.Slider">


### PR DESCRIPTION
This change adds to the PhoneUI companion application a Tray widget with a few buttons from the Wolvic's tray (eg, New window, Private Browsing, Bookmarks, Downloads)

These buttons just emulate clicks on Wolvic's tray, which behaves as a Delegate of this new Tray widget.