### PR TITLE
[VisionGlass] Disable some PhoneUI buttons in WebXR sessions

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
+++ b/app/src/common/shared/com/igalia/wolvic/PlatformActivityPlugin.java
@@ -8,6 +8,8 @@ public abstract class PlatformActivityPlugin {
         void onPlatformScrollEvent(float distanceX, float distanceY);
     }
     abstract void onVideoAvailabilityChange();
+    abstract void onPresentingImmersiveChange(boolean isPresentingImmersive);
+
     abstract boolean onBackPressed();
     void registerListener(PlatformActivityPluginListener listener) {
         if (mListeners == null)

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -43,6 +43,7 @@ import androidx.fragment.app.FragmentController;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelStore;
 import androidx.lifecycle.ViewModelStoreOwner;
 import androidx.preference.PreferenceManager;
@@ -234,7 +235,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     LinkedList<WorldClickListener> mWorldClickListeners;
     LinkedList<WebXRListener> mWebXRListeners;
     LinkedList<Runnable> mBackHandlers;
-    private boolean mIsPresentingImmersive = false;
+    private final MutableLiveData<Boolean> mIsPresentingImmersive = new MutableLiveData<>(false);
     private Thread mUiThread;
     private LinkedList<Pair<Object, Float>> mBrightnessQueue;
     private Pair<Object, Float> mCurrentBrightness;
@@ -337,6 +338,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mBrightnessQueue = new LinkedList<>();
         mCurrentBrightness = Pair.create(null, 1.0f);
         mWidgets = new ConcurrentHashMap<>();
+
+        mIsPresentingImmersive.observe(this, this::onPresentingImmersiveChange);
 
         super.onCreate(savedInstanceState);
 
@@ -491,6 +494,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mWindows.restoreSessions();
     }
 
+    private void onPresentingImmersiveChange(boolean presenting) {
+        if (mPlatformPlugin != null) {
+            mPlatformPlugin.onPresentingImmersiveChange(presenting);
+        }
+    }
+
     private void attachToWindow(@NonNull WindowWidget aWindow, @Nullable WindowWidget aPrevWindow) {
         mPermissionDelegate.setParentWidgetHandle(aWindow.getHandle());
         mNavigationBar.attachToWindow(aWindow);
@@ -627,7 +636,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     protected void onPause() {
-        if (mIsPresentingImmersive) {
+        if (mIsPresentingImmersive.getValue()) {
             // This needs to be sync to ensure that WebVR is correctly paused.
             // Also prevents a deadlock in onDestroy when the BrowserWidget is released.
             exitImmersiveSync();
@@ -1034,7 +1043,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         if (mPlatformPlugin != null && mPlatformPlugin.onBackPressed()) {
             return;
         }
-        if (mIsPresentingImmersive) {
+        if (mIsPresentingImmersive.getValue()) {
             queueRunnable(this::exitImmersiveNative);
             return;
         }
@@ -1305,7 +1314,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         if (Thread.currentThread() == mUiThread) {
             return;
         }
-        mIsPresentingImmersive = true;
+        mIsPresentingImmersive.postValue(true);
         runOnUiThread(() -> {
             mWindows.enterImmersiveMode();
             for (WebXRListener listener: mWebXRListeners) {
@@ -1334,7 +1343,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         if (Thread.currentThread() == mUiThread) {
             return;
         }
-        mIsPresentingImmersive = false;
+        mIsPresentingImmersive.postValue(false);
         TelemetryService.stopImmersive();
 
         if (mLaunchImmersive) {
@@ -1498,7 +1507,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 return;
             }
             // Don't block poorly performing immersive pages.
-            if (mIsPresentingImmersive) {
+            if (mIsPresentingImmersive.getValue()) {
                 return;
             }
             WindowWidget window = mWindows.getFocusedWindow();
@@ -1898,7 +1907,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public boolean isWebXRPresenting() {
-        return mIsPresentingImmersive;
+        return mIsPresentingImmersive.getValue();
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/BindingAdapters.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/BindingAdapters.java
@@ -43,6 +43,12 @@ public class BindingAdapters {
         view.setVisibility(show ? View.VISIBLE : View.INVISIBLE);
     }
 
+    @BindingAdapter("dimmingEnabled")
+    public static void setDimmingEnabled(@NonNull View view, boolean enabled) {
+        view.setAlpha(enabled ? 1.0f : 0.3f);
+        view.setEnabled(enabled);
+    }
+
     @BindingAdapter("typeface")
     public static void setTypeface(@NonNull TextView v, @NonNull String style) {
         switch (style) {

--- a/app/src/visionglass/java/com/igalia/wolvic/PhoneUIViewModel.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PhoneUIViewModel.java
@@ -13,6 +13,8 @@ public class PhoneUIViewModel extends ViewModel {
 
     private final MutableLiveData<ConnectionState> mConnectionState = new MutableLiveData<>(ConnectionState.DISCONNECTED);
     private final MutableLiveData<Boolean> mIsPlayingMedia = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> mIsPresentingImmersive = new MutableLiveData<>(false);
+
 
     public LiveData<ConnectionState> getConnectionState() {
         return mConnectionState;
@@ -51,6 +53,14 @@ public class PhoneUIViewModel extends ViewModel {
 
     public LiveData<Boolean> getIsPlayingMedia() {
         return mIsPlayingMedia;
+    }
+
+    public LiveData<Boolean> getIsPresentingImmersive() {
+        return mIsPresentingImmersive;
+    }
+
+    public void updateIsPresentingImmersive(boolean isPresentingImmersive) {
+        mIsPresentingImmersive.postValue(isPresentingImmersive);
     }
 
     public void updateIsPlayingMedia(boolean isPlayingMedia) {

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -615,6 +615,11 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
             });
         }
 
+        @Override
+        public void onPresentingImmersiveChange(boolean isPresentingImmersive) {
+            mViewModel.updateIsPresentingImmersive(isPresentingImmersive);
+        }
+
         private Media getActiveMedia() {
             assert mDelegate.getWindows() != null;
             assert mDelegate.getWindows().getFocusedWindow() != null;

--- a/app/src/visionglass/res/layout/visionglass_layout.xml
+++ b/app/src/visionglass/res/layout/visionglass_layout.xml
@@ -64,6 +64,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/realign_button"
                 app:layout_constraintTop_toTopOf="parent"
+                app:dimmingEnabled="@{!viewModel.isPresentingImmersive}"
                 style="@style/HeadlockToggleButtonStyle" />
 
             <com.igalia.wolvic.AlignDynamicButton
@@ -71,6 +72,7 @@
                 app:layout_constraintStart_toEndOf="@id/headlock_toggle_button"
                 app:layout_constraintEnd_toStartOf="@id/voice_search_button"
                 app:layout_constraintTop_toTopOf="parent"
+                app:dimmingEnabled="@{!viewModel.isPresentingImmersive}"
                 style="@style/RealignButtonStyle" />
 
             <com.google.android.material.button.MaterialButton
@@ -79,6 +81,7 @@
                 app:layout_constraintStart_toEndOf="@id/realign_button"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                app:dimmingEnabled="@{!viewModel.isPresentingImmersive}"
                 style="@style/VoiceSearchButtonStyle" />
 
             <androidx.constraintlayout.widget.Barrier
@@ -90,13 +93,10 @@
 
             <com.google.android.material.slider.Slider
                 android:id="@+id/distance_slider"
-                style="@style/DistanceSliderStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/barrier" />
+                app:dimmingEnabled="@{!viewModel.isPresentingImmersive}"
+                style="@style/DistanceSliderStyle" />
 
             <FrameLayout
                 android:id="@+id/touchpad_container"
@@ -187,6 +187,7 @@
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/home_button"
                     android:contentDescription="@string/home_tooltip"
+                    app:dimmingEnabled="@{!viewModel.isPresentingImmersive}"
                     style="@style/HomeButtonStyle" />
 
             </LinearLayout>

--- a/app/src/visionglass/res/values/themes.xml
+++ b/app/src/visionglass/res/values/themes.xml
@@ -99,6 +99,9 @@
     </style>
 
     <style name="DistanceSliderStyle" parent="Widget.MaterialComponents.Slider">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">16dp</item>
         <item name="materialThemeOverlay">@style/ThemeOverlay.App.Slider</item>
         <item name="android:valueFrom">0.0</item>
         <item name="android:valueTo">100.0</item>


### PR DESCRIPTION
During Immersive sessions we would need to avoid clicks on some of the widgets provided by the PhoneUI.

This PR introduces a new BindingAdapter "dimmingEnabled" to apply a dimming visual effect on a widget and disable its input methods.

Additionally, the mIsPresentingImmersive field of the VRBBrowserActivity class has become a LiveMutable object, so that we can observe its changes and trigger the dimming actions in the PlatformActivity, if implemented.

Finally, the PR adds the new bindingAdapter in the corresponding elements of the visionglass_layout.xml; specifically, we are going to disable all the UI elements, but the Touchpad and the Back button.