### PR TITLE
[VisionGlass] Restart activity when unplugging the glasses

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -789,15 +789,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                 @Override
                 public void onDisplayRemoved(int displayId) {
                     Log.d(LOGTAG, "display listener: onDisplayRemoved displayId = " + displayId);
-                    // When the display changes due to disconnection we are forced to recreate the presentation.
-                    // This means that we're forced to recreate all the native resources, which is not really
-                    // possible with the current architecture (for example widgets are only created when
-                    // the application is created). So we play safe and restart the activity instead.
-                    if (mActivePresentation != null && !isFinishing()) {
-                        runVRBrowserActivityCallback(activity -> activity.saveState());
-                        SystemUtils.restart(getApplicationContext());
-                        return;
-                    }
                     callUpdateIfIsPresentation(displayId);
                 }
             };
@@ -882,6 +873,20 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                     drawGL();
                 }
             });
+        }
+
+        @Override
+        public void onDisplayRemoved() {
+            super.onDisplayRemoved();
+            if (mActivePresentation == null || isFinishing())
+                return;
+
+            // When the display changes due to disconnection we are forced to recreate the presentation.
+            // This means that we're forced to recreate all the native resources, which is not really
+            // possible with the current architecture (for example widgets are only created when
+            // the application is created). So we play safe and restart the activity instead.
+            runVRBrowserActivityCallback(activity -> activity.saveState());
+            SystemUtils.restart(getApplicationContext());
         }
     }
 

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -789,6 +789,15 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                 @Override
                 public void onDisplayRemoved(int displayId) {
                     Log.d(LOGTAG, "display listener: onDisplayRemoved displayId = " + displayId);
+                    // When the display changes due to disconnection we are forced to recreate the presentation.
+                    // This means that we're forced to recreate all the native resources, which is not really
+                    // possible with the current architecture (for example widgets are only created when
+                    // the application is created). So we play safe and restart the activity instead.
+                    if (mActivePresentation != null && !isFinishing()) {
+                        runVRBrowserActivityCallback(activity -> activity.saveState());
+                        SystemUtils.restart(getApplicationContext());
+                        return;
+                    }
                     callUpdateIfIsPresentation(displayId);
                 }
             };

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -789,6 +789,15 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                 @Override
                 public void onDisplayRemoved(int displayId) {
                     Log.d(LOGTAG, "display listener: onDisplayRemoved displayId = " + displayId);
+                    // When the display changes due to disconnection we are forced to recreate the presentation.
+                    // This means that we're forced to recreate all the native resources, which is not really
+                    // possible with the current architecture (for example widgets are only created when
+                    // the application is created). So we play safe and restart the activity instead.
+                    if (mActivePresentation != null && !isFinishing()) {
+                        runVRBrowserActivityCallback(activity -> activity.saveState());
+                        SystemUtils.restart(getApplicationContext());
+                        return;
+                    }
                     callUpdateIfIsPresentation(displayId);
                 }
             };
@@ -873,20 +882,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                     drawGL();
                 }
             });
-        }
-
-        @Override
-        public void onDisplayRemoved() {
-            super.onDisplayRemoved();
-            if (mActivePresentation == null || isFinishing())
-                return;
-
-            // When the display changes due to disconnection we are forced to recreate the presentation.
-            // This means that we're forced to recreate all the native resources, which is not really
-            // possible with the current architecture (for example widgets are only created when
-            // the application is created). So we play safe and restart the activity instead.
-            runVRBrowserActivityCallback(activity -> activity.saveState());
-            SystemUtils.restart(getApplicationContext());
         }
     }
 

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -793,7 +793,7 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
                     // This means that we're forced to recreate all the native resources, which is not really
                     // possible with the current architecture (for example widgets are only created when
                     // the application is created). So we play safe and restart the activity instead.
-                    if (mActivePresentation != null && !isFinishing()) {
+                    if (mActivePresentation != null && !isFinishing() && mPresentationDisplay.getDisplayId() == displayId) {
                         runVRBrowserActivityCallback(activity -> activity.saveState());
                         SystemUtils.restart(getApplicationContext());
                         return;


### PR DESCRIPTION
Then the glasses are desconnected the Display of the Presentation is destroyed.  Creating another Presentation is mandatory on reconnecting because the Display would be different. This means the native machinery is no longer valid. The RenderContext is using a different thread than the one that is using the new GLSurfaceView of the new Presentation.

We'd have to recreate the whole BrowserWorld. Unfortunately this means that we'd have to re-run all the application creation Java code because among other things, we create the Widgets there. As this is all very coupled, there is no easy way to do that outside the application creation code flow.

This means that the only way to get Wolvic running on disconnection is basically to restart the activity. The process is a bit slow because we need to initialize everything again but it's safe and we also ensure that the state is saved and recreated before restarting.

Fixes #1764