### PR TITLE
Create the fullscreen observer after ithe listeners array initalization

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -214,12 +214,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         // re-center the front window when its height changes
         mViewModel.getHeight().observe((VRBrowserActivity) getContext(), observableInt -> centerFrontWindowIfNeeded());
 
-        mViewModel.getIsFullscreen().observe((VRBrowserActivity) getContext(), observableBoolean -> onIsFullscreenChanged(observableBoolean.get()));
-
         mUIThreadExecutor = ((VRBrowserApplication)getContext().getApplicationContext()).getExecutors().mainThread();
 
         mListeners = new CopyOnWriteArrayList<>();
         setupListeners(mSession);
+
+        mViewModel.getIsFullscreen().observe((VRBrowserActivity) getContext(), observableBoolean -> onIsFullscreenChanged(observableBoolean.get()));
 
         mLibrary = new LibraryPanel(aContext);
         mLibrary.setController(this::showPanel);


### PR DESCRIPTION
The commit 406a611 cause a crash due to the WindowWidget's mListeners attribute was not initialized the fist time the onIsFullscreeen callback.

We were creating an observer for the isFullScreen MutalbleLive field and the onIsFullscreen is the callback of such observer. When the observer is created, the callback is called with the current value of the MutableLive object. We were creating the observer before the mListeners field was initialized.

This PR fixes the crash by moving the observer creation after completely the mListeners initialization.