### PR TITLE
Use hover to activate windows

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -75,6 +75,11 @@ public class SettingsStore {
     public static final int TABS_LOCATION_HORIZONTAL = 1;
     public static final int TABS_LOCATION_VERTICAL = 2;
 
+    @IntDef(value = {WINDOW_SELECTION_METHOD_CLICK, WINDOW_SELECTION_METHOD_HOVER})
+    public @interface WindowSelectionMethod {}
+    public static final int WINDOW_SELECTION_METHOD_CLICK = 0;
+    public static final int WINDOW_SELECTION_METHOD_HOVER = 1;
+
     private Context mContext;
     private SharedPreferences mPrefs;
     private SettingsViewModel mSettingsViewModel;
@@ -141,6 +146,7 @@ public class SettingsStore {
     }
     public final static WindowSizePreset WINDOW_SIZE_PRESET_DEFAULT = WindowSizePreset.PRESET_0;
 
+    public final static @WindowSelectionMethod int WINDOW_SELECTION_METHOD_DEFAULT = WINDOW_SELECTION_METHOD_HOVER;
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static int SCROLL_DIRECTION_DEFAULT = 0;
     public final static String ENV_DEFAULT = "cyberpunk";
@@ -584,6 +590,17 @@ public class SettingsStore {
     public void setEnvironment(String aEnv) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putString(mContext.getString(R.string.settings_key_env), aEnv);
+        editor.apply();
+    }
+
+    @WindowSelectionMethod
+    public int getWindowSelectionMethod() {
+        return mPrefs.getInt(mContext.getString(R.string.settings_key_window_selection_method), WINDOW_SELECTION_METHOD_DEFAULT);
+    }
+
+    public void setWindowSelectionMethod(int method) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putInt(mContext.getString(R.string.settings_key_window_selection_method), method);
         editor.apply();
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -850,16 +850,19 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return mWidgetPlacement;
     }
 
+    private void focusWindow() {
+        updateBorder();
+        // The handlers will set this window as active.
+        for (WindowListener listener: mListeners)
+            listener.onFocusRequest(this);
+    }
+
     @Override
     public void handleTouchEvent(MotionEvent aEvent) {
         if (aEvent.getAction() == MotionEvent.ACTION_DOWN) {
             if (!mActive) {
                 mClickedAfterFocus = true;
-                updateBorder();
-                // Focus this window
-                for (WindowListener listener: mListeners) {
-                    listener.onFocusRequest(this);
-                }
+                focusWindow();
             }
         } else if (aEvent.getAction() == MotionEvent.ACTION_UP || aEvent.getAction() == MotionEvent.ACTION_CANCEL) {
             mClickedAfterFocus = false;
@@ -890,7 +893,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void handleHoverEvent(MotionEvent aEvent) {
         if (aEvent.getAction() == MotionEvent.ACTION_HOVER_ENTER) {
             mHovered = true;
-            updateBorder();
+            if (SettingsStore.getInstance(getContext()).getWindowSelectionMethod() == SettingsStore.WINDOW_SELECTION_METHOD_HOVER)
+                focusWindow();
         } else if (aEvent.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
             mHovered = false;
             updateBorder();

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -50,6 +50,10 @@ class ControllerOptionsView extends SettingsView {
         // Footer
         mBinding.footerLayout.setFooterButtonClickListener(v -> resetOptions());
 
+        int selectionMethod = SettingsStore.getInstance(getContext()).getWindowSelectionMethod();
+        mBinding.windowSelectionRadio.setOnCheckedChangeListener(mWindowSelectionMethodListener);
+        setWindowSelectionMethod(mBinding.windowSelectionRadio.getIdForValue(selectionMethod), false);
+
         int color = SettingsStore.getInstance(getContext()).getPointerColor();
         mBinding.pointerColorRadio.setOnCheckedChangeListener(mPointerColorListener);
         setPointerColor(mBinding.pointerColorRadio.getIdForValue(color), false);
@@ -79,6 +83,9 @@ class ControllerOptionsView extends SettingsView {
     }
 
     private void resetOptions() {
+        if (!mBinding.windowSelectionRadio.getValueForId(mBinding.windowSelectionRadio.getCheckedRadioButtonId()).equals(SettingsStore.WINDOW_SELECTION_METHOD_DEFAULT)) {
+            setWindowSelectionMethod(mBinding.windowSelectionRadio.getIdForValue(SettingsStore.WINDOW_SELECTION_METHOD_DEFAULT), true);
+        }
         if (!mBinding.pointerColorRadio.getValueForId(mBinding.pointerColorRadio.getCheckedRadioButtonId()).equals(SettingsStore.POINTER_COLOR_DEFAULT_DEFAULT)) {
             setPointerColor(mBinding.pointerColorRadio.getIdForValue(SettingsStore.POINTER_COLOR_DEFAULT_DEFAULT), true);
         }
@@ -89,6 +96,16 @@ class ControllerOptionsView extends SettingsView {
         setHapticFeedbackEnabled(SettingsStore.HAPTIC_FEEDBACK_ENABLED, true);
         setPointerMode(SettingsStore.POINTER_MODE_DEFAULT, true);
         setHandTrackingEnabled(true, true);
+    }
+
+    private void setWindowSelectionMethod(int checkedId, boolean doApply) {
+        mBinding.windowSelectionRadio.setOnCheckedChangeListener(null);
+        mBinding.windowSelectionRadio.setChecked(checkedId, doApply);
+        mBinding.windowSelectionRadio.setOnCheckedChangeListener(mWindowSelectionMethodListener);
+
+        if (doApply) {
+            SettingsStore.getInstance(getContext()).setWindowSelectionMethod((int)mBinding.windowSelectionRadio.getValueForId(checkedId));
+        }
     }
 
     private void setPointerColor(int checkedId, boolean doApply) {
@@ -153,6 +170,10 @@ class ControllerOptionsView extends SettingsView {
             mWidgetManager.setHandTrackingEnabled(value);
         }
     }
+
+    private RadioGroupSetting.OnCheckedChangeListener mWindowSelectionMethodListener = (radioGroup, checkedId, doApply) -> {
+        setWindowSelectionMethod(checkedId, doApply);
+    };
 
     private RadioGroupSetting.OnCheckedChangeListener mPointerColorListener = (radioGroup, checkedId, doApply) -> {
         setPointerColor(checkedId, doApply);

--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -73,6 +73,15 @@
                     app:description="@string/controller_options_handtracking" />
 
                 <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
+                    android:id="@+id/window_selection_radio"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/controller_options_window_selection"
+                    app:layout="@layout/setting_radio_group_v"
+                    app:options="@array/controller_options_window_selection"
+                    app:values="@array/controller_options_window_selection_values" />
+
+                <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
                     android:id="@+id/pointer_color_radio"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -31,6 +31,7 @@
     <string name="settings_key_display_dpi" translatable="false">settings_display_dpi</string>
     <string name="settings_key_device_name" translatable="false">settings_device_name</string>
     <string name="settings_key_env" translatable="false">settings_env</string>
+    <string name="settings_key_window_selection_method" translatable="false">settings_window_selection_method</string>
     <string name="settings_key_pointer_color" translatable="false">settings_pointer_color</string>
     <string name="settings_key_scroll_direction" translatable="false">settings_scroll_direction</string>
     <string name="settings_key_msaa" translatable="false">settings_gfx_msaa_v3</string>

--- a/app/src/main/res/values/options_values.xml
+++ b/app/src/main/res/values/options_values.xml
@@ -135,4 +135,15 @@
         <item>2</item>
         <item>3</item>
     </integer-array>
+
+    <integer-array name="controller_options_window_selection" translatable="true">
+        <item>@string/controller_options_click_to_select</item>
+        <item>@string/controller_options_hover_to_select</item>
+    </integer-array>
+
+    <integer-array name="controller_options_window_selection_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2591,5 +2591,8 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <string name="developer_options_pointer_mode_tracked_eye">With eye tracking</string>
     <string name="eye_tracking_permission_title">Eye Tracking Permissions</string>
     <string name="eye_tracking_permission_message">Enabling eye tracking for browsing the web poses significant privacy risks. This technology captures where and how long a user looks at specific parts of a webpage, revealing intimate details about their interests and emotional reactions. Advertisers and third parties can exploit this data for intrusive marketing and profiling. Moreover, eye movement patterns could infer sensitive information such as medical conditions, cognitive states, or personal habits. Therefore, it is crucial to consider the privacy implications before granting access to eye tracking information to webpages.</string>
+    <string name="controller_options_window_selection">Window Selection Method</string>
+    <string name="controller_options_click_to_select">Click</string>
+    <string name="controller_options_hover_to_select">Hover</string>
 
 </resources>


### PR DESCRIPTION
When in multiwindow mode, users need to click on the browser windows to explicitly set them as active and thus, move widgets like the URL bar or the navigation bar next to the selected window.

In order to improve it, we can do that automatically just by hovering the window. This will be the new default as it looks like it's a better behaviour in general, at least more comfortable. However, as it's a breaking change, we are adding a setting to the controller settings to revert to the previous behaviour of click-to-select.