### PR TITLE
Adjust navigation taking New Tab into account

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -1172,7 +1172,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
             }
         }
 
-        if (mContext.getString(R.string.about_private_browsing).equalsIgnoreCase(uri)) {
+        if (UrlUtils.isPrivateUrl(uri) || mContext.getString(R.string.about_private_browsing).equalsIgnoreCase(uri)) {
             return WResult.deny();
         }
 
@@ -1211,10 +1211,6 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
                     result.complete(allowed.get() ? WAllowOrDeny.ALLOW : WAllowOrDeny.DENY);
                 }
             }
-        }
-
-        if (UrlUtils.isAboutPage(aRequest.uri)) {
-            return WResult.deny();
         }
 
         return result;

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
@@ -37,6 +37,7 @@ public class WindowViewModel extends AndroidViewModel {
     private int mURLWebsiteColor;
 
     private MutableLiveData<Spannable> url;
+    private MutableLiveData<Spannable> urlForwardFromNewTab;
     private MutableLiveData<String> hint;
     private MutableLiveData<ObservableBoolean> isWindowVisible;
     private MutableLiveData<Windows.WindowPlacement> placement;
@@ -54,7 +55,9 @@ public class WindowViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isActiveWindow;
     private MediatorLiveData<ObservableBoolean> isTitleBarVisible;
     private MutableLiveData<Windows.ContentType> currentContentType;
+    private MutableLiveData<Windows.ContentType> lastContentType;
     private MediatorLiveData<ObservableBoolean> isNativeContentVisible;
+    private MutableLiveData<ObservableBoolean> backToNewTabEnabled;
     private MutableLiveData<ObservableBoolean> isLoading;
     private MutableLiveData<ObservableBoolean> isMicrophoneEnabled;
     private MutableLiveData<ObservableBoolean> isBookmarked;
@@ -65,6 +68,7 @@ public class WindowViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isPopUpAvailable;
     private MutableLiveData<ObservableBoolean> isPopUpBlocked;
     private MutableLiveData<ObservableBoolean> canGoForward;
+    private MutableLiveData<ObservableBoolean> canGoForwardFromNewTab;
     private MutableLiveData<ObservableBoolean> canGoBack;
     private MutableLiveData<ObservableBoolean> isInVRVideo;
     private MutableLiveData<ObservableBoolean> autoEnteredVRVideo;
@@ -93,6 +97,7 @@ public class WindowViewModel extends AndroidViewModel {
         mURLWebsiteColor = typedValue.data;
 
         url = new MutableLiveData<>(new SpannableString(""));
+        urlForwardFromNewTab = new MutableLiveData<>(new SpannableString(""));
         hint = new MutableLiveData<>("");
         isWindowVisible = new MutableLiveData<>(new ObservableBoolean(true));
         placement = new MutableLiveData<>(Windows.WindowPlacement.FRONT);
@@ -135,11 +140,15 @@ public class WindowViewModel extends AndroidViewModel {
         isTitleBarVisible.setValue(new ObservableBoolean(true));
 
         currentContentType = new MutableLiveData<>(Windows.ContentType.WEB_CONTENT);
+        lastContentType = new MutableLiveData<>(Windows.ContentType.WEB_CONTENT);
+
         isNativeContentVisible = new MediatorLiveData<>();
         isNativeContentVisible.addSource(currentContentType, contentType ->
                 isNativeContentVisible.setValue(new ObservableBoolean(contentType != Windows.ContentType.WEB_CONTENT))
         );
         isNativeContentVisible.setValue(new ObservableBoolean(currentContentType.getValue() != Windows.ContentType.WEB_CONTENT));
+
+        backToNewTabEnabled = new MutableLiveData<>(new ObservableBoolean(false));
 
         isLoading = new MutableLiveData<>(new ObservableBoolean(false));
         isMicrophoneEnabled = new MutableLiveData<>(new ObservableBoolean(true));
@@ -151,6 +160,7 @@ public class WindowViewModel extends AndroidViewModel {
         isPopUpAvailable = new MutableLiveData<>(new ObservableBoolean(false));
         isPopUpBlocked = new MutableLiveData<>(new ObservableBoolean(false));
         canGoForward = new MutableLiveData<>(new ObservableBoolean(false));
+        canGoForwardFromNewTab = new MutableLiveData<>(new ObservableBoolean(false));
         canGoBack = new MutableLiveData<>(new ObservableBoolean(false));
         isInVRVideo = new MutableLiveData<>(new ObservableBoolean(false));
         autoEnteredVRVideo = new MutableLiveData<>(new ObservableBoolean(false));
@@ -260,8 +270,11 @@ public class WindowViewModel extends AndroidViewModel {
         @Override
         public void onChanged(Spannable aUrl) {
             String url = aUrl.toString();
-            if (isNativeContentVisible.getValue().get()) {
+            if (isNativeContentVisible.getValue().get() && currentContentType.getValue() != Windows.ContentType.NEW_TAB) {
                 url = getApplication().getString(R.string.url_library_title);
+
+            } else if (currentContentType.getValue() == Windows.ContentType.NEW_TAB) {
+                url = getApplication().getString(R.string.url_new_tab_title);
 
             } else {
                 if (UrlUtils.isPrivateAboutPage(getApplication(), url) ||
@@ -357,6 +370,7 @@ public class WindowViewModel extends AndroidViewModel {
 
     public void refresh() {
         url.postValue(url.getValue());
+        urlForwardFromNewTab.postValue(urlForwardFromNewTab.getValue());
         hint.postValue(getHintValue());
         isWindowVisible.postValue(isWindowVisible.getValue());
         placement.postValue(placement.getValue());
@@ -373,6 +387,7 @@ public class WindowViewModel extends AndroidViewModel {
         isPopUpAvailable.postValue(isPopUpAvailable.getValue());
         isPopUpBlocked.postValue(isPopUpBlocked.getValue());
         canGoForward.postValue(canGoForward.getValue());
+        canGoForwardFromNewTab.postValue(canGoForwardFromNewTab.getValue());
         canGoBack.postValue(canGoBack.getValue());
         isInVRVideo.postValue(isInVRVideo.getValue());
         autoEnteredVRVideo.postValue(autoEnteredVRVideo.getValue());
@@ -395,10 +410,18 @@ public class WindowViewModel extends AndroidViewModel {
         return url;
     }
 
+    public MutableLiveData<Spannable> getUrlForwardFromNewTab() {
+        if (urlForwardFromNewTab == null) {
+            urlForwardFromNewTab = new MutableLiveData<>(new SpannableString(""));
+        }
+        return urlForwardFromNewTab;
+    }
+
     public void setUrl(@Nullable String url) {
         if (url == null) {
             return;
         }
+
         setUrl(new SpannableString(url));
     }
 
@@ -442,9 +465,15 @@ public class WindowViewModel extends AndroidViewModel {
                 spannable.setSpan(color1, 0, index + 3, 0);
                 spannable.setSpan(color2, index + 3, aURL.length(), 0);
                 this.url.postValue(spannable);
+                if (currentContentType.getValue() == Windows.ContentType.WEB_CONTENT && lastContentType.getValue() == Windows.ContentType.NEW_TAB  && !aURL.startsWith("about")) {
+                    urlForwardFromNewTab.postValue(spannable);
+                }
 
             } else {
                 this.url.postValue(url);
+                if (currentContentType.getValue() == Windows.ContentType.WEB_CONTENT && lastContentType.getValue() == Windows.ContentType.NEW_TAB  && !aURL.startsWith("about")) {
+                    urlForwardFromNewTab.postValue(url);
+                }
             }
         }
     }
@@ -455,8 +484,11 @@ public class WindowViewModel extends AndroidViewModel {
     }
 
     private String getHintValue() {
-        if (isNativeContentVisible.getValue().get()) {
+        if (isNativeContentVisible.getValue().get() && currentContentType.getValue() != Windows.ContentType.NEW_TAB) {
             return getApplication().getString(R.string.url_library_title);
+
+        } else if (currentContentType.getValue() == Windows.ContentType.NEW_TAB) {
+            return getApplication().getString(R.string.url_new_tab_title);
 
         } else {
             return getApplication().getString(R.string.search_placeholder);
@@ -597,6 +629,11 @@ public class WindowViewModel extends AndroidViewModel {
     }
 
     public void setCurrentContentType(Windows.ContentType contentType) {
+        // No need to store lastContentType when we switch content types in library
+        if (!currentContentType.getValue().isLibraryContent() || !contentType.isLibraryContent()) {
+            lastContentType.postValue(currentContentType.getValue());
+        }
+
         currentContentType.postValue(contentType);
     }
 
@@ -605,8 +642,21 @@ public class WindowViewModel extends AndroidViewModel {
         return currentContentType;
     }
 
+    public MutableLiveData<Windows.ContentType> getLastContentType() {
+        return lastContentType;
+    }
+
     public MutableLiveData<ObservableBoolean> getIsNativeContentVisible() {
         return isNativeContentVisible;
+    }
+
+    public void enableBackToNewTab(boolean backToNewTabEnabled) {
+        this.backToNewTabEnabled.postValue(new ObservableBoolean(backToNewTabEnabled));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getBackToNewTabEnabled() {
+        return backToNewTabEnabled;
     }
 
     @NonNull
@@ -697,6 +747,15 @@ public class WindowViewModel extends AndroidViewModel {
 
     public void setCanGoForward(boolean canGoForward) {
         this.canGoForward.postValue(new ObservableBoolean(canGoForward));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getCanGoForwardFromNewTab() {
+        return canGoForwardFromNewTab;
+    }
+
+    public void setCanGoForwardFromNewTab(boolean canGoForwardFromNewTab) {
+        this.canGoForwardFromNewTab.postValue(new ObservableBoolean(canGoForwardFromNewTab));
     }
 
     @NonNull

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/WindowViewModel.java
@@ -37,8 +37,7 @@ public class WindowViewModel extends AndroidViewModel {
     private int mURLWebsiteColor;
 
     private MutableLiveData<Spannable> url;
-    private MutableLiveData<Spannable> urlForwardFromNewTab;
-    private MutableLiveData<String> hint;
+    private MediatorLiveData<String> hint;
     private MutableLiveData<ObservableBoolean> isWindowVisible;
     private MutableLiveData<Windows.WindowPlacement> placement;
     private MutableLiveData<ObservableBoolean> isOnlyWindow;
@@ -55,9 +54,7 @@ public class WindowViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isActiveWindow;
     private MediatorLiveData<ObservableBoolean> isTitleBarVisible;
     private MutableLiveData<Windows.ContentType> currentContentType;
-    private MutableLiveData<Windows.ContentType> lastContentType;
     private MediatorLiveData<ObservableBoolean> isNativeContentVisible;
-    private MutableLiveData<ObservableBoolean> backToNewTabEnabled;
     private MutableLiveData<ObservableBoolean> isLoading;
     private MutableLiveData<ObservableBoolean> isMicrophoneEnabled;
     private MutableLiveData<ObservableBoolean> isBookmarked;
@@ -68,7 +65,6 @@ public class WindowViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isPopUpAvailable;
     private MutableLiveData<ObservableBoolean> isPopUpBlocked;
     private MutableLiveData<ObservableBoolean> canGoForward;
-    private MutableLiveData<ObservableBoolean> canGoForwardFromNewTab;
     private MutableLiveData<ObservableBoolean> canGoBack;
     private MutableLiveData<ObservableBoolean> isInVRVideo;
     private MutableLiveData<ObservableBoolean> autoEnteredVRVideo;
@@ -97,8 +93,6 @@ public class WindowViewModel extends AndroidViewModel {
         mURLWebsiteColor = typedValue.data;
 
         url = new MutableLiveData<>(new SpannableString(""));
-        urlForwardFromNewTab = new MutableLiveData<>(new SpannableString(""));
-        hint = new MutableLiveData<>("");
         isWindowVisible = new MutableLiveData<>(new ObservableBoolean(true));
         placement = new MutableLiveData<>(Windows.WindowPlacement.FRONT);
         isOnlyWindow = new MutableLiveData<>(new ObservableBoolean(false));
@@ -140,15 +134,16 @@ public class WindowViewModel extends AndroidViewModel {
         isTitleBarVisible.setValue(new ObservableBoolean(true));
 
         currentContentType = new MutableLiveData<>(Windows.ContentType.WEB_CONTENT);
-        lastContentType = new MutableLiveData<>(Windows.ContentType.WEB_CONTENT);
-
         isNativeContentVisible = new MediatorLiveData<>();
         isNativeContentVisible.addSource(currentContentType, contentType ->
                 isNativeContentVisible.setValue(new ObservableBoolean(contentType != Windows.ContentType.WEB_CONTENT))
         );
         isNativeContentVisible.setValue(new ObservableBoolean(currentContentType.getValue() != Windows.ContentType.WEB_CONTENT));
-
-        backToNewTabEnabled = new MutableLiveData<>(new ObservableBoolean(false));
+        hint = new MediatorLiveData<>("");
+        hint.addSource(currentContentType, contentType -> {
+            hint.postValue(getHintValue());
+        });
+        hint.setValue(getHintValue());
 
         isLoading = new MutableLiveData<>(new ObservableBoolean(false));
         isMicrophoneEnabled = new MutableLiveData<>(new ObservableBoolean(true));
@@ -160,7 +155,6 @@ public class WindowViewModel extends AndroidViewModel {
         isPopUpAvailable = new MutableLiveData<>(new ObservableBoolean(false));
         isPopUpBlocked = new MutableLiveData<>(new ObservableBoolean(false));
         canGoForward = new MutableLiveData<>(new ObservableBoolean(false));
-        canGoForwardFromNewTab = new MutableLiveData<>(new ObservableBoolean(false));
         canGoBack = new MutableLiveData<>(new ObservableBoolean(false));
         isInVRVideo = new MutableLiveData<>(new ObservableBoolean(false));
         autoEnteredVRVideo = new MutableLiveData<>(new ObservableBoolean(false));
@@ -270,10 +264,11 @@ public class WindowViewModel extends AndroidViewModel {
         @Override
         public void onChanged(Spannable aUrl) {
             String url = aUrl.toString();
-            if (isNativeContentVisible.getValue().get() && currentContentType.getValue() != Windows.ContentType.NEW_TAB) {
+            Windows.ContentType contentType = UrlUtils.getContentType(url);
+            if (contentType.isLibraryContent()) {
                 url = getApplication().getString(R.string.url_library_title);
 
-            } else if (currentContentType.getValue() == Windows.ContentType.NEW_TAB) {
+            } else if (contentType == Windows.ContentType.NEW_TAB) {
                 url = getApplication().getString(R.string.url_new_tab_title);
 
             } else {
@@ -326,7 +321,7 @@ public class WindowViewModel extends AndroidViewModel {
             if (UrlUtils.isPrivateAboutPage(getApplication(), url) ||
                     (UrlUtils.isDataUri(url) && isPrivateSession.getValue().get()) ||
                     UrlUtils.isHomeUri(getApplication(), aUrl.toString()) ||
-                    isNativeContentVisible.getValue().get() ||
+                    UrlUtils.getContentType(url) != Windows.ContentType.WEB_CONTENT ||
                     UrlUtils.isBlankUri(getApplication(), aUrl.toString())) {
                 navigationBarUrl.postValue("");
 
@@ -353,7 +348,6 @@ public class WindowViewModel extends AndroidViewModel {
                                     isWebXRUsed.getValue().get()
                             )
             ));
-            hint.postValue(getHintValue());
         }
     };
 
@@ -370,7 +364,6 @@ public class WindowViewModel extends AndroidViewModel {
 
     public void refresh() {
         url.postValue(url.getValue());
-        urlForwardFromNewTab.postValue(urlForwardFromNewTab.getValue());
         hint.postValue(getHintValue());
         isWindowVisible.postValue(isWindowVisible.getValue());
         placement.postValue(placement.getValue());
@@ -387,7 +380,6 @@ public class WindowViewModel extends AndroidViewModel {
         isPopUpAvailable.postValue(isPopUpAvailable.getValue());
         isPopUpBlocked.postValue(isPopUpBlocked.getValue());
         canGoForward.postValue(canGoForward.getValue());
-        canGoForwardFromNewTab.postValue(canGoForwardFromNewTab.getValue());
         canGoBack.postValue(canGoBack.getValue());
         isInVRVideo.postValue(isInVRVideo.getValue());
         autoEnteredVRVideo.postValue(autoEnteredVRVideo.getValue());
@@ -410,18 +402,10 @@ public class WindowViewModel extends AndroidViewModel {
         return url;
     }
 
-    public MutableLiveData<Spannable> getUrlForwardFromNewTab() {
-        if (urlForwardFromNewTab == null) {
-            urlForwardFromNewTab = new MutableLiveData<>(new SpannableString(""));
-        }
-        return urlForwardFromNewTab;
-    }
-
     public void setUrl(@Nullable String url) {
         if (url == null) {
             return;
         }
-
         setUrl(new SpannableString(url));
     }
 
@@ -465,15 +449,9 @@ public class WindowViewModel extends AndroidViewModel {
                 spannable.setSpan(color1, 0, index + 3, 0);
                 spannable.setSpan(color2, index + 3, aURL.length(), 0);
                 this.url.postValue(spannable);
-                if (currentContentType.getValue() == Windows.ContentType.WEB_CONTENT && lastContentType.getValue() == Windows.ContentType.NEW_TAB  && !aURL.startsWith("about")) {
-                    urlForwardFromNewTab.postValue(spannable);
-                }
 
             } else {
                 this.url.postValue(url);
-                if (currentContentType.getValue() == Windows.ContentType.WEB_CONTENT && lastContentType.getValue() == Windows.ContentType.NEW_TAB  && !aURL.startsWith("about")) {
-                    urlForwardFromNewTab.postValue(url);
-                }
             }
         }
     }
@@ -484,7 +462,7 @@ public class WindowViewModel extends AndroidViewModel {
     }
 
     private String getHintValue() {
-        if (isNativeContentVisible.getValue().get() && currentContentType.getValue() != Windows.ContentType.NEW_TAB) {
+        if (currentContentType.getValue().isLibraryContent()) {
             return getApplication().getString(R.string.url_library_title);
 
         } else if (currentContentType.getValue() == Windows.ContentType.NEW_TAB) {
@@ -629,11 +607,6 @@ public class WindowViewModel extends AndroidViewModel {
     }
 
     public void setCurrentContentType(Windows.ContentType contentType) {
-        // No need to store lastContentType when we switch content types in library
-        if (!currentContentType.getValue().isLibraryContent() || !contentType.isLibraryContent()) {
-            lastContentType.postValue(currentContentType.getValue());
-        }
-
         currentContentType.postValue(contentType);
     }
 
@@ -642,21 +615,8 @@ public class WindowViewModel extends AndroidViewModel {
         return currentContentType;
     }
 
-    public MutableLiveData<Windows.ContentType> getLastContentType() {
-        return lastContentType;
-    }
-
     public MutableLiveData<ObservableBoolean> getIsNativeContentVisible() {
         return isNativeContentVisible;
-    }
-
-    public void enableBackToNewTab(boolean backToNewTabEnabled) {
-        this.backToNewTabEnabled.postValue(new ObservableBoolean(backToNewTabEnabled));
-    }
-
-    @NonNull
-    public MutableLiveData<ObservableBoolean> getBackToNewTabEnabled() {
-        return backToNewTabEnabled;
     }
 
     @NonNull
@@ -747,15 +707,6 @@ public class WindowViewModel extends AndroidViewModel {
 
     public void setCanGoForward(boolean canGoForward) {
         this.canGoForward.postValue(new ObservableBoolean(canGoForward));
-    }
-
-    @NonNull
-    public MutableLiveData<ObservableBoolean> getCanGoForwardFromNewTab() {
-        return canGoForwardFromNewTab;
-    }
-
-    public void setCanGoForwardFromNewTab(boolean canGoForwardFromNewTab) {
-        this.canGoForwardFromNewTab.postValue(new ObservableBoolean(canGoForwardFromNewTab));
     }
 
     @NonNull

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
@@ -1,0 +1,42 @@
+package com.igalia.wolvic.ui.views;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+
+import androidx.databinding.DataBindingUtil;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.VRBrowserActivity;
+import com.igalia.wolvic.databinding.NewTabBinding;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+
+public class NewTabView extends FrameLayout {
+
+    private WidgetManagerDelegate mWidgetManager;
+
+    private NewTabBinding mBinding;
+
+    public NewTabView(Context context) {
+        super(context);
+        initialize();
+    }
+
+    protected void initialize() {
+        mWidgetManager = ((VRBrowserActivity) getContext());
+        updateUI();
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.new_tab, this, true);
+        mBinding.setLifecycleOwner((VRBrowserActivity) getContext());
+
+        mBinding.executePendingBindings();
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/BookmarksView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/BookmarksView.java
@@ -192,9 +192,6 @@ public class BookmarksView extends LibraryView implements BookmarksStore.Bookmar
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
-
-            WindowWidget window = mWidgetManager.getFocusedWindow();
-            window.hidePanel();
         }
 
         @Override
@@ -263,9 +260,6 @@ public class BookmarksView extends LibraryView implements BookmarksStore.Bookmar
                             mAccounts.setOrigin(Accounts.LoginOrigin.BOOKMARKS, sessionId);
 
                             TelemetryService.Tabs.openedCounter(TelemetryService.Tabs.TabSource.FXA_LOGIN);
-
-                            WindowWidget window = mWidgetManager.getFocusedWindow();
-                            window.hidePanel();
                         }
 
                     }, mUIThreadExecutor).exceptionally(throwable -> {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/DownloadsView.java
@@ -203,9 +203,6 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                 }
             } else {
                 SessionStore.get().getActiveSession().loadUri(item.getOutputFileUriAsString());
-
-                WindowWidget window = mWidgetManager.getFocusedWindow();
-                window.hidePanel();
             }
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/HistoryView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/HistoryView.java
@@ -194,9 +194,6 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
-
-            WindowWidget window = mWidgetManager.getFocusedWindow();
-            window.hidePanel();
         }
 
         @Override
@@ -267,9 +264,6 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
                             mAccounts.setOrigin(Accounts.LoginOrigin.HISTORY, sessionId);
 
                             TelemetryService.Tabs.openedCounter(TelemetryService.Tabs.TabSource.FXA_LOGIN);
-
-                            WindowWidget window = mWidgetManager.getFocusedWindow();
-                            window.hidePanel();
                         }
 
                     }, mUIThreadExecutor).exceptionally(throwable -> {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
@@ -189,6 +189,7 @@ public class LibraryPanel extends FrameLayout {
         mController = controller;
     }
 
+    @NonNull
     public Windows.ContentType getSelectedPanelType() {
         if (mCurrentView == mBookmarksView) {
             return Windows.ContentType.BOOKMARKS;

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/LibraryPanel.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -108,7 +107,7 @@ public class LibraryPanel extends FrameLayout {
             @Override
             public void onClose(@NonNull View view) {
                 requestFocus();
-                mWidgetManager.getFocusedWindow().hidePanel();
+                mWidgetManager.getFocusedWindow().closeLibrary();
             }
 
             @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/SystemNotificationsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/SystemNotificationsView.java
@@ -120,9 +120,6 @@ public class SystemNotificationsView extends LibraryView implements SystemNotifi
             if (action.getType() == SystemNotification.Action.OPEN_URL && action.getUrl() != null) {
                 Session session = SessionStore.get().getActiveSession();
                 session.loadUri(action.getUrl());
-
-                WindowWidget window = mWidgetManager.getFocusedWindow();
-                window.hidePanel();
             } else if (action.getType() == SystemNotification.Action.OPEN_APP_PAGE) {
                 Intent intent;
                 if (action.getAction() == null) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/library/WebAppsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/library/WebAppsView.java
@@ -139,9 +139,6 @@ public class WebAppsView extends LibraryView implements WebAppsStore.WebAppsList
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getStartUrl());
-
-            WindowWidget window = mWidgetManager.getFocusedWindow();
-            window.hidePanel();
         }
 
         @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/NavigationBarWidget.java
@@ -15,9 +15,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
-import android.graphics.PorterDuff;
 import android.graphics.Rect;
-import android.graphics.drawable.Drawable;
 import androidx.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -247,8 +245,6 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
             if (getSession().canGoBack()) {
                 getSession().goBack();
-            } else if (mViewModel.getBackToNewTabEnabled().getValue().get()) {
-                getSession().loadUri(UrlUtils.ABOUT_NEWTAB);
             }
 
             if (mAudio != null) {
@@ -259,18 +255,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
 
         mBinding.navigationBarNavigation.forwardButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
-            if (mViewModel.getCanGoForwardFromNewTab().getValue().get()) {
-                String forwardUrl = mViewModel.getUrlForwardFromNewTab().getValue().toString();
-                getSession().loadUri(forwardUrl);
-
-                mAttachedWindow.hideNewTab();
-
-                mViewModel.setCurrentContentType(Windows.ContentType.WEB_CONTENT);
-                mViewModel.setUrl(forwardUrl);
-                mViewModel.setCanGoForwardFromNewTab(false);
-            } else {
-                getSession().goForward();
-            }
+            getSession().goForward();
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -1362,8 +1347,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             @Override
             public void onFindInPage() {
                 hideMenu();
-                mAttachedWindow.hidePanel();
-
+                mAttachedWindow.closeLibrary();
                 mViewModel.setIsFindInPage(true);
             }
 
@@ -1406,7 +1390,7 @@ public class NavigationBarWidget extends UIWidget implements WSession.Navigation
             public void onAddons() {
                 hideMenu();
 
-                mAttachedWindow.showLibraryPanel(Windows.ContentType.ADDONS);
+                mAttachedWindow.showLibrary(Windows.ContentType.ADDONS);
             }
 
             @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TitleBarWidget.java
@@ -22,6 +22,7 @@ import com.igalia.wolvic.VRBrowserActivity;
 import com.igalia.wolvic.databinding.TitleBarBinding;
 import com.igalia.wolvic.ui.viewmodel.WindowViewModel;
 import com.igalia.wolvic.utils.DeviceType;
+import com.igalia.wolvic.utils.UrlUtils;
 
 public class TitleBarWidget extends UIWidget {
 
@@ -155,7 +156,9 @@ public class TitleBarWidget extends UIWidget {
         }
 
         if (mAttachedWindow.getSession() != null) {
-            mViewModel.setUrl(mAttachedWindow.getSession().getCurrentUri());
+            String url = mAttachedWindow.getSession().getCurrentUri();
+            mViewModel.setUrl(url);
+            mViewModel.setCurrentContentType(UrlUtils.getContentType(url));
         }
     };
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -621,10 +621,10 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
     private Observer<Windows.ContentType> mCurrentContentTypeObserver = contentType -> {
         // Prevent a race condition in case the animation runs faster than the data binding.
-        mBinding.bookmarksButton.setActiveMode(contentType != Windows.ContentType.WEB_CONTENT && contentType != Windows.ContentType.DOWNLOADS);
+        mBinding.bookmarksButton.setActiveMode(contentType != Windows.ContentType.WEB_CONTENT && contentType != Windows.ContentType.NEW_TAB && contentType != Windows.ContentType.DOWNLOADS);
         mBinding.downloadsButton.setActiveMode(contentType == Windows.ContentType.DOWNLOADS);
 
-        if (contentType == Windows.ContentType.WEB_CONTENT) {
+        if (contentType == Windows.ContentType.WEB_CONTENT || contentType == Windows.ContentType.NEW_TAB) {
             animateButtonPadding(mBinding.bookmarksButton, mMaxPadding, ICON_ANIMATION_DURATION);
             animateButtonPadding(mBinding.downloadsButton, mMaxPadding, ICON_ANIMATION_DURATION);
         } else if (contentType == Windows.ContentType.DOWNLOADS) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -63,6 +63,7 @@ import com.igalia.wolvic.downloads.DownloadsManager;
 import com.igalia.wolvic.telemetry.TelemetryService;
 import com.igalia.wolvic.ui.adapters.WebApp;
 import com.igalia.wolvic.ui.viewmodel.WindowViewModel;
+import com.igalia.wolvic.ui.views.NewTabView;
 import com.igalia.wolvic.ui.views.library.LibraryPanel;
 import com.igalia.wolvic.ui.widgets.dialogs.PromptDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.SelectionActionWidget;
@@ -136,6 +137,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private Session mSession;
     private int mWindowId;
     private LibraryPanel mLibrary;
+    private NewTabView mNewTab;
     private Windows.WindowPlacement mWindowPlacement = Windows.WindowPlacement.FRONT;
     private Windows.WindowPlacement mWindowPlacementBeforeFullscreen = Windows.WindowPlacement.FRONT;
     private float mMaxWindowScale = 3;
@@ -222,7 +224,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.getIsFullscreen().observe((VRBrowserActivity) getContext(), observableBoolean -> onIsFullscreenChanged(observableBoolean.get()));
 
         mLibrary = new LibraryPanel(aContext);
-        mLibrary.setController(this::showPanel);
+        mLibrary.setController(this::showLibraryPanel);
+        mNewTab = new NewTabView(aContext);
 
         SessionStore.get().getBookmarkStore().addListener(mBookmarksListener);
 
@@ -507,31 +510,30 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return mWidgetPlacement.height;
     }
 
+    @NonNull
     public Windows.ContentType getSelectedPanel() {
         return mLibrary.getSelectedPanelType();
     }
 
     private void hideLibraryPanel() {
-        if (mViewModel.getIsNativeContentVisible().getValue().get()) {
+        if (getCurrentContentType().isLibraryContent()) {
             hidePanel(true);
         }
     }
 
     Runnable mRestoreFirstPaint;
 
-    public void showPanel(Windows.ContentType panelType) {
-        if (panelType == Windows.ContentType.WEB_CONTENT) {
-            hidePanel();
-        } else {
-            showPanel(panelType, true);
-        }
+    public void showLibraryPanel(Windows.ContentType panelType) {
+        assert panelType != Windows.ContentType.NEW_TAB && panelType != Windows.ContentType.WEB_CONTENT && panelType != Windows.ContentType.NOTIFICATIONS;
+        showLibraryPanel(panelType, true);
     }
 
-    private void showPanel(Windows.ContentType contentType, boolean switchSurface) {
+    private void showLibraryPanel(Windows.ContentType contentType, boolean switchSurface) {
         if (mLibrary == null) {
             return;
         }
 
+        hideNewTab(true);
         mViewModel.setIsFindInPage(false);
         mViewModel.setCurrentContentType(contentType);
         mViewModel.setUrl(contentType.URL);
@@ -539,12 +541,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             setView(mLibrary, switchSurface);
             mLibrary.selectPanel(contentType);
             mLibrary.onShow();
-            if (mRestoreFirstPaint == null && !isFirstPaintReady() && (mFirstDrawCallback != null) && (mSurface != null)) {
-                final Runnable firstDrawCallback = mFirstDrawCallback;
+            if (mRestoreFirstPaint == null) {
                 onFirstContentfulPaint(mSession.getWSession());
                 mRestoreFirstPaint = () -> {
                     setFirstPaintReady(false);
-                    setFirstDrawCallback(firstDrawCallback);
+                    if (mFirstDrawCallback != null) {
+                        final Runnable firstDrawCallback = mFirstDrawCallback;
+                        setFirstDrawCallback(firstDrawCallback);
+                    }
                     if (mWidgetManager != null) {
                         mWidgetManager.updateWidget(WindowWidget.this);
                     }
@@ -552,6 +556,32 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             }
         } else if (mView == mLibrary) {
             mLibrary.selectPanel(contentType);
+        }
+    }
+
+    public void showNewTab() {
+        if (mNewTab != null) {
+            mViewModel.setIsFindInPage(false);
+            mViewModel.setCurrentContentType(Windows.ContentType.NEW_TAB);
+            mViewModel.setUrl(Windows.ContentType.NEW_TAB.URL);
+            setView(mNewTab, true);
+            if (mRestoreFirstPaint == null) {
+                onFirstContentfulPaint(mSession.getWSession());
+                mRestoreFirstPaint = () -> {
+                    setFirstPaintReady(false);
+                    if (mFirstDrawCallback != null) {
+                        final Runnable firstDrawCallback = mFirstDrawCallback;
+                        setFirstDrawCallback(firstDrawCallback);
+                    }
+                    if (mWidgetManager != null) {
+                        mWidgetManager.updateWidget(WindowWidget.this);
+                    }
+                };
+            }
+        }
+        if (mViewModel.getBackToNewTabEnabled().getValue().get()) {
+            mViewModel.enableBackToNewTab(false);
+            mViewModel.setCanGoForwardFromNewTab(true);
         }
     }
 
@@ -563,8 +593,31 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         if (mView != null && mLibrary != null) {
             unsetView(mLibrary, switchSurface);
             mLibrary.onHide();
+        }
+        if (switchSurface && mRestoreFirstPaint != null) {
+            mRestoreFirstPaint.run();
+            mRestoreFirstPaint = null;
+        }
+        if (mViewModel.getLastContentType().getValue() == Windows.ContentType.NEW_TAB) {
+            showNewTab();
+        } else {
             mViewModel.setCurrentContentType(Windows.ContentType.WEB_CONTENT);
             mViewModel.setUrl(mSession.getCurrentUri());
+        }
+    }
+
+    // Only use this when you want the back button to go back to New Tab.
+    // If you don't, use hideNewTab(true) instead.
+    public void hideNewTab() {
+        if (mViewModel.getCurrentContentType().getValue() == Windows.ContentType.NEW_TAB) {
+            mViewModel.enableBackToNewTab(true);
+            hideNewTab(true);
+        }
+    }
+
+    private void hideNewTab(boolean switchSurface) {
+        if (mView != null && mNewTab != null) {
+            unsetView(mNewTab, switchSurface);
         }
         if (switchSurface && mRestoreFirstPaint != null) {
             mRestoreFirstPaint.run();
@@ -2042,24 +2095,31 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         Uri uri = Uri.parse(aRequest.uri);
         if (UrlUtils.isAboutPage(uri.toString())) {
-            if(UrlUtils.isBookmarksUrl(uri.toString())) {
-                showPanel(Windows.ContentType.BOOKMARKS);
+           if(UrlUtils.isBookmarksUrl(uri.toString())) {
+               showLibraryPanel(Windows.ContentType.BOOKMARKS);
 
             } else if (UrlUtils.isHistoryUrl(uri.toString())) {
-                showPanel(Windows.ContentType.HISTORY);
+               showLibraryPanel(Windows.ContentType.HISTORY);
 
             } else if (UrlUtils.isDownloadsUrl(uri.toString())) {
-                showPanel(Windows.ContentType.DOWNLOADS);
+               showLibraryPanel(Windows.ContentType.DOWNLOADS);
 
             } else if (UrlUtils.isAddonsUrl(uri.toString())) {
-                showPanel(Windows.ContentType.ADDONS);
+               showLibraryPanel(Windows.ContentType.ADDONS);
+
+            } else if (UrlUtils.isNewTabUrl(uri.toString())) {
+               showNewTab();
 
             } else {
-                hideLibraryPanel();
-            }
+               hideLibraryPanel();
+               hideNewTab();
+           }
 
         } else {
             hideLibraryPanel();
+            hideNewTab();
+            mViewModel.setCurrentContentType(Windows.ContentType.WEB_CONTENT);
+            mViewModel.setUrl(uri.toString());
         }
 
         if ("file".equalsIgnoreCase(uri.getScheme())) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -210,7 +210,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
                 .get(String.valueOf(hashCode()), WindowViewModel.class);
         mViewModel.setIsPrivateSession(mSession.isPrivateMode());
-        mViewModel.setUrl(mSession.getCurrentUri());
+        String url = mSession.getCurrentUri();
+        mViewModel.setUrl(url);
+        mViewModel.setCurrentContentType(UrlUtils.getContentType(url));
         mViewModel.setIsDesktopMode(mSession.getUaMode() == WSessionSettings.USER_AGENT_MODE_DESKTOP);
 
         // re-center the front window when its height changes
@@ -224,7 +226,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.getIsFullscreen().observe((VRBrowserActivity) getContext(), observableBoolean -> onIsFullscreenChanged(observableBoolean.get()));
 
         mLibrary = new LibraryPanel(aContext);
-        mLibrary.setController(this::showLibraryPanel);
+        mLibrary.setController(this::showLibrary);
         mNewTab = new NewTabView(aContext);
 
         SessionStore.get().getBookmarkStore().addListener(mBookmarksListener);
@@ -341,7 +343,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     protected void onDismiss() {
         if (mViewModel.getIsNativeContentVisible().getValue().get()) {
             if (!mLibrary.onBack()) {
-                hidePanel();
+                this.closeLibrary();
             }
 
         } else {
@@ -515,17 +517,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return mLibrary.getSelectedPanelType();
     }
 
-    private void hideLibraryPanel() {
-        if (getCurrentContentType().isLibraryContent()) {
-            hidePanel(true);
-        }
-    }
-
     Runnable mRestoreFirstPaint;
 
-    public void showLibraryPanel(Windows.ContentType panelType) {
-        assert panelType != Windows.ContentType.NEW_TAB && panelType != Windows.ContentType.WEB_CONTENT && panelType != Windows.ContentType.NOTIFICATIONS;
-        showLibraryPanel(panelType, true);
+    public void showLibrary(Windows.ContentType panelType) {
+        if (panelType.isLibraryContent()) {
+            showLibraryPanel(panelType, true);
+        } else {
+            Log.w(LOGTAG, "Tried to open library panel with wrong content type: " + panelType);
+        }
     }
 
     private void showLibraryPanel(Windows.ContentType contentType, boolean switchSurface) {
@@ -533,7 +532,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             return;
         }
 
-        hideNewTab(true);
+        hideNewTabPanel(true);
         mViewModel.setIsFindInPage(false);
         mViewModel.setCurrentContentType(contentType);
         mViewModel.setUrl(contentType.URL);
@@ -559,12 +558,42 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
-    public void showNewTab() {
-        if (mNewTab != null) {
-            mViewModel.setIsFindInPage(false);
-            mViewModel.setCurrentContentType(Windows.ContentType.NEW_TAB);
-            mViewModel.setUrl(Windows.ContentType.NEW_TAB.URL);
-            setView(mNewTab, true);
+    public void closeLibrary() {
+        hideLibraryPanel(true);
+
+        mViewModel.setUrl(mSession.getCurrentUri());
+        Windows.ContentType contentType = UrlUtils.getContentType(mSession.getCurrentUri());
+        mViewModel.setCurrentContentType(contentType);
+
+        if (contentType == Windows.ContentType.NEW_TAB) {
+            showNewTabPanel(true);
+        } else if (contentType.isLibraryContent()) {
+            showLibrary(contentType);
+        } else {
+            hideNewTabPanel(true);
+        }
+    }
+
+    private void hideLibraryPanel(boolean switchSurface) {
+        if (mView != null && mLibrary != null && mView == mLibrary) {
+            unsetView(mLibrary, switchSurface);
+            mLibrary.onHide();
+
+            if (switchSurface && mRestoreFirstPaint != null) {
+                mRestoreFirstPaint.run();
+                mRestoreFirstPaint = null;
+            }
+        }
+    }
+
+    private void showNewTabPanel(boolean switchSurface) {
+        if (mNewTab == null) {
+            return;
+        }
+        hideLibraryPanel(true);
+        mViewModel.setIsFindInPage(false);
+        if (mView == null) {
+            setView(mNewTab, switchSurface);
             if (mRestoreFirstPaint == null) {
                 onFirstContentfulPaint(mSession.getWSession());
                 mRestoreFirstPaint = () -> {
@@ -579,49 +608,15 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 };
             }
         }
-        if (mViewModel.getBackToNewTabEnabled().getValue().get()) {
-            mViewModel.enableBackToNewTab(false);
-            mViewModel.setCanGoForwardFromNewTab(true);
-        }
     }
 
-    public void hidePanel() {
-        hidePanel(true);
-    }
-
-    private void hidePanel(boolean switchSurface) {
-        if (mView != null && mLibrary != null) {
-            unsetView(mLibrary, switchSurface);
-            mLibrary.onHide();
-        }
-        if (switchSurface && mRestoreFirstPaint != null) {
-            mRestoreFirstPaint.run();
-            mRestoreFirstPaint = null;
-        }
-        if (mViewModel.getLastContentType().getValue() == Windows.ContentType.NEW_TAB) {
-            showNewTab();
-        } else {
-            mViewModel.setCurrentContentType(Windows.ContentType.WEB_CONTENT);
-            mViewModel.setUrl(mSession.getCurrentUri());
-        }
-    }
-
-    // Only use this when you want the back button to go back to New Tab.
-    // If you don't, use hideNewTab(true) instead.
-    public void hideNewTab() {
-        if (mViewModel.getCurrentContentType().getValue() == Windows.ContentType.NEW_TAB) {
-            mViewModel.enableBackToNewTab(true);
-            hideNewTab(true);
-        }
-    }
-
-    private void hideNewTab(boolean switchSurface) {
-        if (mView != null && mNewTab != null) {
+    private void hideNewTabPanel(boolean switchSurface) {
+        if (mView != null && mNewTab != null && mView == mNewTab) {
             unsetView(mNewTab, switchSurface);
-        }
-        if (switchSurface && mRestoreFirstPaint != null) {
-            mRestoreFirstPaint.run();
-            mRestoreFirstPaint = null;
+            if (switchSurface && mRestoreFirstPaint != null) {
+                mRestoreFirstPaint.run();
+                mRestoreFirstPaint = null;
+            }
         }
     }
 
@@ -1271,7 +1266,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mCaptureOnPageStop = false;
 
         if (hidePanel) {
-            hideLibraryPanel();
+            closeLibrary();
         }
     }
 
@@ -1711,17 +1706,17 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private NavigationBarWidget.NavigationListener mNavigationBarListener = new NavigationBarWidget.NavigationListener() {
         @Override
         public void onBack() {
-            hideLibraryPanel();
+            closeLibrary();
         }
 
         @Override
         public void onForward() {
-            hideLibraryPanel();
+            closeLibrary();
         }
 
         @Override
         public void onReload() {
-            hideLibraryPanel();
+            closeLibrary();
         }
 
         @Override
@@ -1731,7 +1726,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         @Override
         public void onHome() {
-            hideLibraryPanel();
+            closeLibrary();
         }
     };
 
@@ -2062,6 +2057,18 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.setIsWebApp(false);
         mViewModel.setIsFindInPage(false);
 
+        Windows.ContentType contentType = UrlUtils.getContentType(url);
+        mViewModel.setCurrentContentType(contentType);
+
+        if (contentType == Windows.ContentType.NEW_TAB) {
+            showNewTabPanel(true);
+        } else if (contentType.isLibraryContent()) {
+            showLibraryPanel(contentType, true);
+        } else {
+            hideLibraryPanel(true);
+            hideNewTabPanel(true);
+        }
+
         if (StringUtils.isEmpty(url)) {
             mViewModel.setIsBookmarked(false);
 
@@ -2093,35 +2100,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     WResult<WAllowOrDeny> onLoadRequest(WSession aSession, @NonNull LoadRequest aRequest) {
         final WResult<WAllowOrDeny> result = WResult.create();
 
-        Uri uri = Uri.parse(aRequest.uri);
-        if (UrlUtils.isAboutPage(uri.toString())) {
-           if(UrlUtils.isBookmarksUrl(uri.toString())) {
-               showLibraryPanel(Windows.ContentType.BOOKMARKS);
-
-            } else if (UrlUtils.isHistoryUrl(uri.toString())) {
-               showLibraryPanel(Windows.ContentType.HISTORY);
-
-            } else if (UrlUtils.isDownloadsUrl(uri.toString())) {
-               showLibraryPanel(Windows.ContentType.DOWNLOADS);
-
-            } else if (UrlUtils.isAddonsUrl(uri.toString())) {
-               showLibraryPanel(Windows.ContentType.ADDONS);
-
-            } else if (UrlUtils.isNewTabUrl(uri.toString())) {
-               showNewTab();
-
-            } else {
-               hideLibraryPanel();
-               hideNewTab();
-           }
-
-        } else {
-            hideLibraryPanel();
-            hideNewTab();
-            mViewModel.setCurrentContentType(Windows.ContentType.WEB_CONTENT);
-            mViewModel.setUrl(uri.toString());
+        Windows.ContentType contentType = UrlUtils.getContentType(aRequest.uri);
+        if (contentType.isLibraryContent()) {
+            showLibrary(contentType);
+            result.complete(WAllowOrDeny.DENY);
+            return result;
         }
 
+        Uri uri = Uri.parse(aRequest.uri);
         if ("file".equalsIgnoreCase(uri.getScheme())) {
             // Check that we have permission to open the file, otherwise try to request it.
             File file = new File(uri.getPath());

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -98,6 +98,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         int textureHeight;
         float worldWidth;
         int tabIndex = -1;
+
         // NOTE: Enum values may be null when deserialized by GSON.
         ContentType contentType = ContentType.WEB_CONTENT;
 
@@ -120,7 +121,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             tabIndex = aTabIndex;
             if (aWindow.isNativeContentVisible()) {
                 contentType = aWindow.getSelectedPanel();
-
+            } else if (aWindow.getCurrentContentType() == ContentType.NEW_TAB) {
+                contentType = ContentType.NEW_TAB;
             } else {
                 contentType = ContentType.WEB_CONTENT;
             }
@@ -171,13 +173,28 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         HISTORY(UrlUtils.ABOUT_HISTORY),
         DOWNLOADS(UrlUtils.ABOUT_DOWNLOADS),
         ADDONS(UrlUtils.ABOUT_ADDONS),
-        NOTIFICATIONS(UrlUtils.ABOUT_NOTIFICATIONS);
+        NOTIFICATIONS(UrlUtils.ABOUT_NOTIFICATIONS),
+        NEW_TAB(UrlUtils.ABOUT_NEWTAB);
 
         @NonNull
         public final String URL;
+
         ContentType(@NonNull String url) {
             this.URL = url;
         }
+
+        public boolean isLibraryContent() {
+            switch (this) {
+                case BOOKMARKS:
+                case WEB_APPS:
+                case HISTORY:
+                case DOWNLOADS:
+                case ADDONS:
+                    return true;
+                default:
+                    return false;
+            }
+        };
     }
 
     public enum WindowPlacement{
@@ -396,6 +413,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                     break;
                 case ADDONS:
                     newWindow.getSession().loadUri(UrlUtils.ABOUT_ADDONS);
+                    break;
+                case NEW_TAB:
+                    newWindow.getSession().loadUri(UrlUtils.ABOUT_NEWTAB);
                     break;
                 case WEB_CONTENT:
                     break;
@@ -645,7 +665,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     private void closeLibraryPanelInFocusedWindowIfNeeded() {
-        if (!mFocusedWindow.isNativeContentVisible())
+        if (!mFocusedWindow.getCurrentContentType().isLibraryContent())
             return;
         mFocusedWindow.hidePanel();
     }
@@ -1237,7 +1257,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (mFocusedWindow.getCurrentContentType() == ContentType.BOOKMARKS) {
             mFocusedWindow.hidePanel();
         } else {
-            mFocusedWindow.showPanel(ContentType.BOOKMARKS);
+            mFocusedWindow.showLibraryPanel(ContentType.BOOKMARKS);
         }
     }
 
@@ -1246,7 +1266,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (mFocusedWindow.getCurrentContentType() == ContentType.DOWNLOADS) {
             mFocusedWindow.hidePanel();
         } else {
-            mFocusedWindow.showPanel(ContentType.DOWNLOADS);
+            mFocusedWindow.showLibraryPanel(ContentType.DOWNLOADS);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -190,6 +190,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 case HISTORY:
                 case DOWNLOADS:
                 case ADDONS:
+                case NOTIFICATIONS:
                     return true;
                 default:
                     return false;
@@ -432,7 +433,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         WindowWidget leftWindow = getLeftWindow();
         WindowWidget rightWindow = getRightWindow();
 
-        aWindow.hidePanel();
+        aWindow.closeLibrary();
 
         if (leftWindow == aWindow) {
             removeWindow(leftWindow);
@@ -667,7 +668,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     private void closeLibraryPanelInFocusedWindowIfNeeded() {
         if (!mFocusedWindow.getCurrentContentType().isLibraryContent())
             return;
-        mFocusedWindow.hidePanel();
+        mFocusedWindow.closeLibrary();
     }
 
     public void enterPrivateMode() {
@@ -1255,18 +1256,18 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     @Override
     public void onBookmarksClicked() {
         if (mFocusedWindow.getCurrentContentType() == ContentType.BOOKMARKS) {
-            mFocusedWindow.hidePanel();
+            mFocusedWindow.closeLibrary();
         } else {
-            mFocusedWindow.showLibraryPanel(ContentType.BOOKMARKS);
+            mFocusedWindow.showLibrary(ContentType.BOOKMARKS);
         }
     }
 
     @Override
     public void onDownloadsClicked() {
         if (mFocusedWindow.getCurrentContentType() == ContentType.DOWNLOADS) {
-            mFocusedWindow.hidePanel();
+            mFocusedWindow.closeLibrary();
         } else {
-            mFocusedWindow.showLibraryPanel(ContentType.DOWNLOADS);
+            mFocusedWindow.showLibrary(ContentType.DOWNLOADS);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -418,12 +418,13 @@ class DisplayOptionsView extends SettingsView {
     }
 
     private void setHomepage(String newHomepage) {
-        if (mBinding.homepageEdit.getVisibility() == VISIBLE) {
-            mBinding.homepageEdit.setOnClickListener(null);
-            mBinding.homepageEdit.setFirstText(newHomepage);
-            SettingsStore.getInstance(getContext()).setHomepage(newHomepage);
-            mBinding.homepageEdit.setOnClickListener(mHomepageListener);
+        if (mBinding.homepageEdit.getVisibility() != VISIBLE) {
+            return;
         }
+        mBinding.homepageEdit.setOnClickListener(null);
+        mBinding.homepageEdit.setFirstText(newHomepage);
+        SettingsStore.getInstance(getContext()).setHomepage(newHomepage);
+        mBinding.homepageEdit.setOnClickListener(mHomepageListener);
     }
 
     private void setUaMode(int checkId, boolean doApply) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -219,7 +219,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
-            mWidgetManager.getFocusedWindow().showPanel(Windows.ContentType.ADDONS);
+            mWidgetManager.getFocusedWindow().showLibraryPanel(Windows.ContentType.ADDONS);
             onDismiss();
         });
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -219,7 +219,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
-            mWidgetManager.getFocusedWindow().showLibraryPanel(Windows.ContentType.ADDONS);
+            mWidgetManager.getFocusedWindow().showLibrary(Windows.ContentType.ADDONS);
             onDismiss();
         });
 

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -188,6 +188,12 @@ public class UrlUtils {
         return url != null && url.equalsIgnoreCase(ABOUT_BOOKMARKS);
     }
 
+    public static final String ABOUT_NEWTAB = "about://newtab";
+
+    public static boolean isNewTabUrl(@Nullable String url) {
+        return url != null && url.equalsIgnoreCase(ABOUT_NEWTAB);
+    }
+
     public static final String ABOUT_DOWNLOADS = "about://downloads";
 
     public static boolean isDownloadsUrl(@Nullable String url) {
@@ -246,7 +252,7 @@ public class UrlUtils {
 
     public static boolean isAboutPage(@Nullable String url) {
         return isHistoryUrl(url) || isBookmarksUrl(url) || isDownloadsUrl(url) || isAddonsUrl(url) ||
-                isWebAppsUrl(url) || isNotificationsUrl(url) || isPrivateUrl(url);
+                isWebAppsUrl(url) || isNotificationsUrl(url) || isPrivateUrl(url) || isNewTabUrl(url);
     }
 
     public static boolean isContentFeed(Context aContext, @Nullable String url) {

--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -18,6 +18,7 @@ import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.search.SearchEngineWrapper;
 import com.igalia.wolvic.telemetry.TelemetryService;
+import com.igalia.wolvic.ui.widgets.Windows;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -257,7 +258,28 @@ public class UrlUtils {
 
     public static boolean isContentFeed(Context aContext, @Nullable String url) {
         String feed = aContext.getString(R.string.HOMEPAGE_URL);
-        return UrlUtils.getHost(feed).equalsIgnoreCase(UrlUtils.getHost(url));
+        return UrlUtils.isNewTabUrl(url) || UrlUtils.getHost(feed).equalsIgnoreCase(UrlUtils.getHost(url));
+    }
+
+    public static Windows.ContentType getContentType(String url) {
+        if (StringUtils.isEmpty(url)) {
+            return Windows.ContentType.WEB_CONTENT;
+        } else if (isBookmarksUrl(url)) {
+            return Windows.ContentType.BOOKMARKS;
+        } else if (isWebAppsUrl(url)) {
+            return Windows.ContentType.WEB_APPS;
+        } else if (isHistoryUrl(url)) {
+            return Windows.ContentType.HISTORY;
+        } else if (isDownloadsUrl(url)) {
+            return Windows.ContentType.DOWNLOADS;
+        } else if (isAddonsUrl(url)) {
+            return Windows.ContentType.ADDONS;
+        } else if (isNotificationsUrl(url)) {
+            return Windows.ContentType.NOTIFICATIONS;
+        } else if (isNewTabUrl(url)) {
+            return Windows.ContentType.NEW_TAB;
+        }
+        return Windows.ContentType.WEB_CONTENT;
     }
 
     public static String getHost(String uri) {

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -5,6 +5,7 @@
         <import type="android.view.View" />
         <import type="com.igalia.wolvic.BuildConfig"/>
         <import type="com.igalia.wolvic.ui.widgets.Windows.WindowPlacement"/>
+        <import type="com.igalia.wolvic.ui.widgets.Windows.ContentType" />
         <variable
             name="viewmodel"
             type="com.igalia.wolvic.ui.viewmodel.WindowViewModel" />
@@ -36,7 +37,7 @@
             android:src="@drawable/ic_icon_back"
             android:tint="@color/midnight"
             android:tooltipText="@string/back_tooltip"
-            android:enabled="@{viewmodel.canGoBack}"
+            android:enabled="@{viewmodel.canGoBack || viewmodel.backToNewTabEnabled}"
             app:privateMode="@{viewmodel.isPrivateSession}" />
 
         <com.igalia.wolvic.ui.views.UIButton
@@ -46,7 +47,7 @@
             android:layout_weight="0"
             android:src="@drawable/ic_icon_forward"
             android:tooltipText="@string/forward_tooltip"
-            android:enabled="@{viewmodel.canGoForward}"
+            android:enabled="@{viewmodel.canGoForward || viewmodel.canGoForwardFromNewTab}"
             app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <RelativeLayout
@@ -62,6 +63,7 @@
                 android:src="@{viewmodel.isLoading ? @drawable/ic_icon_exit : @drawable/ic_icon_reload}"
                 android:padding="@{viewmodel.isLoading ? @dimen/nav_button_padding : @dimen/nav_button_progress_padding}"
                 android:tooltipText="@{viewmodel.isLoading ? @string/stop_tooltip : @string/refresh_tooltip}"
+                android:enabled="@{!viewmodel.isNativeContentVisible &amp;&amp; viewmodel.currentContentType != ContentType.NEW_TAB}"
                 app:privateMode="@{viewmodel.isPrivateSession}" />
 
             <ProgressBar

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -37,7 +37,7 @@
             android:src="@drawable/ic_icon_back"
             android:tint="@color/midnight"
             android:tooltipText="@string/back_tooltip"
-            android:enabled="@{viewmodel.canGoBack || viewmodel.backToNewTabEnabled}"
+            android:enabled="@{viewmodel.canGoBack}"
             app:privateMode="@{viewmodel.isPrivateSession}" />
 
         <com.igalia.wolvic.ui.views.UIButton
@@ -47,7 +47,7 @@
             android:layout_weight="0"
             android:src="@drawable/ic_icon_forward"
             android:tooltipText="@string/forward_tooltip"
-            android:enabled="@{viewmodel.canGoForward || viewmodel.canGoForwardFromNewTab}"
+            android:enabled="@{viewmodel.canGoForward}"
             app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <RelativeLayout

--- a/app/src/main/res/layout/new_tab.xml
+++ b/app/src/main/res/layout/new_tab.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/void_color">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/favicon"
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                android:layout_gravity="center"
+                app:srcCompat="@drawable/ff_logo" />
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -38,6 +38,13 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
+                <com.igalia.wolvic.ui.views.settings.RadioGroupSetting
+                    android:id="@+id/homepage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/developer_options_homepage"
+                    app:options="@array/developer_options_homepage" />
+
                 <com.igalia.wolvic.ui.views.settings.SingleEditSetting
                     android:id="@+id/homepage_edit"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -194,7 +194,7 @@
                 style="@style/trayButtonMiddleTheme"
                 android:src="@drawable/ic_icon_bookmark"
                 android:tooltipText="@{viewmodel.currentContentType == ContentType.BOOKMARKS ? @string/close_bookmarks_tooltip : @string/open_bookmarks_tooltip}"
-                app:activeMode="@{viewmodel.currentContentType != ContentType.WEB_CONTENT &amp;&amp; viewmodel.currentContentType != ContentType.DOWNLOADS}"
+                app:activeMode="@{viewmodel.currentContentType != ContentType.WEB_CONTENT &amp;&amp; viewmodel.currentContentType != ContentType.NEW_TAB &amp;&amp; viewmodel.currentContentType != ContentType.DOWNLOADS}"
                 app:clipDrawable="@drawable/ic_icon_library_clip"
                 app:tooltipDensity="@dimen/tray_tooltip_density"
                 app:tooltipLayout="@layout/tooltip_tray"

--- a/app/src/main/res/values/options_values.xml
+++ b/app/src/main/res/values/options_values.xml
@@ -101,6 +101,12 @@
         <item>2</item>
     </integer-array>
 
+    <!-- Homepage Setting Options -->
+    <string-array name="developer_options_homepage" translatable="false">
+        <item>@string/developer_options_homepage_new_tab</item>
+        <item>@string/developer_options_homepage_wolvic</item>
+        <item>@string/developer_options_homepage_other</item>
+    </string-array>
 
     <!-- Tracking Options -->
     <string-array name="privacy_options_tracking" translatable="false">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -621,6 +621,15 @@
     <!-- This string is used to label the radio buttons that set the default size of windows. -->
     <string name="window_size_preset">%1$d×%2$d</string>
 
+    <!-- This string is used to label the homepage radio button that sets the homepage to be Wolvic homepage. -->
+    <string name="developer_options_homepage_wolvic">wolvic.com</string>
+
+    <!-- This string is used to label the homepage radio button that sets the homepage to be the New Tab page. -->
+    <string name="developer_options_homepage_new_tab">New Tab</string>
+
+    <!-- This string is used to label the homepage radio button that allows users to set the homepage they want. -->
+    <string name="developer_options_homepage_other">Other</string>
+
     <!-- This string is used to label a set of radio buttons that allow the user to change the
          User-Agent (UA) string of the browser. -->
     <string name="developer_options_ua_mode">User-Agent Mode</string>
@@ -1975,6 +1984,9 @@
 
     <!-- This string is displayed in the URL bar when the user is in the Library panel -->
     <string name="url_library_title">Library</string>
+
+    <!-- This string is displayed in the URL bar when the user is in the New Tab view -->
+    <string name="url_new_tab_title">New Tab</string>
 
     <!-- This string is displayed in the Clear button on top of the window when in private mode. It only appears
          when there is one window left. When clicked, it closes the private session -->


### PR DESCRIPTION
This PR builds on the work of @haanhvu at https://github.com/Igalia/wolvic/pull/1574

Use WindowWidget.onLocationChange() to decide whether the New Tab, the Library, or Web content should be shown.

By passing the responsibility of keeping track of navigation to the session, we are able to remove many of the bugs caused by the interaction between the New Tab and the Web content.

The library is not part of that navigation, which was already the case before.

Rename WindowWidget.showLibraryPanel() and hidePanel() to showLibrary() and closeLibrary() for clarity.

Remove explicit calls to hide the Library, since these will be managed internally by WindowWidget.

Remove unneeded fields in the WindowViewModel, since we will use the session to keep track of back and forward navigation.