### PR TITLE
Suggested experiences in New Tab

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,6 +125,7 @@ android {
         buildConfigField "Float", "DEFAULT_WINDOW_DISTANCE", "0.0f"
         buildConfigField "Boolean", "ENABLE_PAGE_ZOOM", "false"
         buildConfigField "Boolean", "USE_SOUNDPOOL", "true"
+        buildConfigField 'String', 'EXPERIENCES_ENDPOINT', '"https://igalia.github.io/wolvic/experiences.json"'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         resValue 'string', 'app_name', 'Wolvic'
@@ -601,6 +602,7 @@ dependencies {
     implementation libs.androidcomponents.concept.fetch
     implementation libs.androidcomponents.lib.fetch
     implementation libs.androidcomponents.lib.dataprotect
+    implementation libs.androidcomponents.support.images
     implementation libs.androidcomponents.support.rustlog
     implementation libs.androidcomponents.support.rusthttp
     implementation libs.androidcomponents.support.webextensions

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -45,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import mozilla.components.concept.fetch.Request;
 import mozilla.components.concept.fetch.Response;
@@ -212,19 +213,27 @@ public class SettingsStore {
         String json = mPrefs.getString(mContext.getString(R.string.settings_key_remote_props), null);
         mSettingsViewModel.setProps(json);
 
+        String experiencesJson = mPrefs.getString(mContext.getString(R.string.settings_key_remote_experiences), null);
+        mSettingsViewModel.setExperiences(experiencesJson);
+
         mSettingsViewModel.refresh();
 
-        update();
+        updateRemoteContent(BuildConfig.PROPS_ENDPOINT,
+                R.string.settings_key_remote_props,
+                mSettingsViewModel::setProps);
+        updateRemoteContent(BuildConfig.EXPERIENCES_ENDPOINT,
+                R.string.settings_key_remote_experiences,
+                mSettingsViewModel::setExperiences);
     }
 
     /**
      * Synchronizes the remote properties with the settings storage and notifies the model.
      * Any consumer listening to the SettingsViewModel will get notified of the properties updates.
      */
-    private void update() {
+    private void updateRemoteContent(String endpoint, int prefsKey, Consumer<String> onContentAvailable) {
         ((VRBrowserApplication) mContext.getApplicationContext()).getExecutors().backgroundThread().post(() -> {
             Request request = new Request(
-                    BuildConfig.PROPS_ENDPOINT,
+                    endpoint,
                     Request.Method.GET,
                     null,
                     null,
@@ -241,14 +250,13 @@ public class SettingsStore {
                 if (response.getStatus() == 200) {
                     String json = response.getBody().string(StandardCharsets.UTF_8);
                     SharedPreferences.Editor editor = mPrefs.edit();
-                    editor.putString(mContext.getString(R.string.settings_key_remote_props), json);
+                    editor.putString(mContext.getString(prefsKey), json);
                     editor.apply();
-
-                    mSettingsViewModel.setProps(json);
+                    // Once the JSON content has been received, execute the callback.
+                    onContentAvailable.accept(json);
                 }
-
             } catch (IOException e) {
-                Log.d(LOGTAG, "Remote properties error: " + e.getLocalizedMessage());
+                Log.d(LOGTAG, "Remote data fetch error for " + endpoint + ": " + e.getLocalizedMessage());
             }
         });
     }

--- a/app/src/common/shared/com/igalia/wolvic/browser/components/RemoteImagesHelper.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/RemoteImagesHelper.kt
@@ -1,0 +1,124 @@
+package com.igalia.wolvic.browser.components
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.util.Log
+import android.widget.ImageView
+import com.igalia.wolvic.utils.BitmapCache
+import com.igalia.wolvic.utils.SystemUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.isSuccess
+import mozilla.components.support.images.CancelOnDetach
+import mozilla.components.support.images.DesiredSize
+import mozilla.components.support.images.decoder.AndroidImageDecoder
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class RemoteImageHelper(
+    private val context: Context,
+    private val client: Client
+) {
+    private val LOGTAG = SystemUtils.createLogtag(RemoteImageHelper::class.java)
+    private val decoder = AndroidImageDecoder()
+
+    fun loadIntoView(view: ImageView, url: String, private: Boolean = false) {
+        val bitmapCache = BitmapCache.getInstance(context)
+        
+        // Tag the view with the URL to identify the image that it should display.
+        view.tag = url
+
+        // Target size is either the view dimensions or the default if the view is not measured yet.
+        val targetSize = if (view.width > 0 && view.height > 0) {
+            Math.max(view.width, view.height)
+        } else {
+            DEFAULT_TARGET_SIZE
+        }
+
+        // Size guidance for the image decoder.
+        val desiredSize = DesiredSize(
+            targetSize = targetSize,
+            minSize = targetSize / DEFAULT_MIN_MAX_MULTIPLIER,
+            maxSize = targetSize * DEFAULT_MIN_MAX_MULTIPLIER,
+            maxScaleFactor = DEFAULT_MAXIMUM_SCALE_FACTOR
+        )
+
+        // ...and apply it on the main UI thread.
+        val job = CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val cachedBitmap = bitmapCache.getBitmap(url).get()
+
+                if (cachedBitmap != null) {
+                    // If the image is in cache, we can simply apply it (in the Main thread).
+                    withContext(Dispatchers.Main) {
+                        if (url == view.tag) {
+                            view.setImageBitmap(cachedBitmap)
+                        }
+                    }
+                } else {
+                    // Otherwise, we fetch it and decode the image.
+                    val bitmap = fetchAndDecode(url, desiredSize, private)
+
+                    if (bitmap != null) {
+                        bitmapCache.addBitmap(url, bitmap)
+
+                        // Apply the image (in the Main thread).
+                        withContext(Dispatchers.Main) {
+                            if (url == view.tag) {
+                                view.setImageBitmap(bitmap)
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(LOGTAG, "Error loading image: ${e.message}")
+            }
+        }
+
+        // NOTE: To support RecyclerView scrolling, image downloads will continue when views are detached.
+        // If needed, this can be changed with view.addOnAttachStateChangeListener(CancelOnDetach(job))).
+    }
+
+    private fun fetchAndDecode(
+        url: String,
+        desiredSize: DesiredSize,
+        private: Boolean
+    ): Bitmap? {
+        val request = Request(
+            url = url.trim(),
+            method = Request.Method.GET,
+            cookiePolicy = if (private) Request.CookiePolicy.OMIT else Request.CookiePolicy.INCLUDE,
+            connectTimeout = Pair(DEFAULT_CONNECT_TIMEOUT, TimeUnit.SECONDS),
+            readTimeout = Pair(DEFAULT_READ_TIMEOUT, TimeUnit.SECONDS),
+            redirect = Request.Redirect.FOLLOW,
+            useCaches = true,
+            private = private
+        )
+
+        return try {
+            val response = client.fetch(request)
+            if (response.isSuccess) {
+                val data = response.body.useStream { it.readBytes() }
+                decoder.decode(data, desiredSize)
+            } else {
+                response.close()
+                null
+            }
+        } catch (e: IOException) {
+            Log.w(LOGTAG, "Error loading image: ${e.message}")
+            null
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_TARGET_SIZE = 256
+        private const val DEFAULT_MAXIMUM_SCALE_FACTOR = 2.0f
+        private const val DEFAULT_MIN_MAX_MULTIPLIER = 4
+        private const val DEFAULT_CONNECT_TIMEOUT = 5L
+        private const val DEFAULT_READ_TIMEOUT = 20L
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -23,6 +23,7 @@ import com.igalia.wolvic.browser.api.WResult;
 import com.igalia.wolvic.browser.api.WRuntime;
 import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.browser.components.BrowserIconsHelper;
+import com.igalia.wolvic.browser.components.RemoteImageHelper;
 import com.igalia.wolvic.browser.components.WolvicWebExtensionRuntime;
 import com.igalia.wolvic.browser.content.TrackingProtectionStore;
 import com.igalia.wolvic.browser.extensions.BuiltinExtension;
@@ -44,6 +45,7 @@ import mozilla.components.feature.accounts.FxaCapability;
 import mozilla.components.feature.accounts.FxaWebChannelFeature;
 import mozilla.components.feature.webcompat.WebCompatFeature;
 import mozilla.components.feature.webcompat.reporter.WebCompatReporterFeature;
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient;
 import mozilla.components.lib.state.Store;
 
 public class SessionStore implements
@@ -85,6 +87,7 @@ public class SessionStore implements
     private FxaWebChannelFeature mWebChannelsFeature;
     private Store.Subscription mStoreSubscription;
     private BrowserIconsHelper mBrowserIconsHelper;
+    private RemoteImageHelper mRemoteImageHelper;
     private final LinkedHashSet<SessionChangeListener> mSessionChangeListeners;
 
     private SessionStore() {
@@ -135,6 +138,8 @@ public class SessionStore implements
         // Web Extensions initialization
         BUILTIN_WEB_EXTENSIONS.forEach(extension -> BuiltinExtension.install(mWebExtensionRuntime, extension.first, extension.second));
         mBrowserIconsHelper = new BrowserIconsHelper(context, mWebExtensionRuntime, ComponentsAdapter.get().getStore());
+
+        mRemoteImageHelper = new RemoteImageHelper(context, new HttpURLConnectionClient());
 
         WebCompatFeature.INSTANCE.install(mWebExtensionRuntime);
         WebCompatReporterFeature.INSTANCE.install(mWebExtensionRuntime, context.getString(R.string.app_name));
@@ -416,6 +421,11 @@ public class SessionStore implements
     @NonNull
     public BrowserIconsHelper getBrowserIcons() {
         return mBrowserIconsHelper;
+    }
+
+    @NonNull
+    public RemoteImageHelper getRemoteImageHelper() {
+        return mRemoteImageHelper;
     }
 
     public void purgeSessionHistory() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/ExperiencesAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/ExperiencesAdapter.java
@@ -1,0 +1,81 @@
+package com.igalia.wolvic.ui.adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.databinding.DataBindingUtil;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.databinding.ExperienceItemBinding;
+import com.igalia.wolvic.utils.Experience;
+import com.igalia.wolvic.utils.SystemUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExperiencesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private static final String LOGTAG = SystemUtils.createLogtag(ExperiencesAdapter.class);
+
+    private final Context mContext;
+    private final List<Experience> mExperiences = new ArrayList<>();
+    private ClickListener mListener;
+
+    public interface ClickListener {
+        void onClicked(Experience experience);
+    }
+
+    public ExperiencesAdapter(Context context) {
+        mContext = context;
+    }
+
+    public void updateExperiences(List<Experience> experiences) {
+        mExperiences.clear();
+        if (experiences != null) {
+            mExperiences.addAll(experiences);
+        }
+
+        notifyDataSetChanged();
+    }
+
+    public void setClickListener(ClickListener listener) {
+        mListener = listener;
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        ExperienceItemBinding binding = DataBindingUtil.inflate(LayoutInflater.from(mContext), R.layout.experience_item, parent, false);
+
+        return new ExperienceViewHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        ExperienceViewHolder viewHolder = (ExperienceViewHolder) holder;
+        Experience experience = mExperiences.get(position);
+
+        viewHolder.binding.setExperience(experience);
+        viewHolder.binding.setListener(mListener);
+
+        SessionStore.get().getRemoteImageHelper().loadIntoView(viewHolder.binding.thumbnail, experience.getThumbnail(), false);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mExperiences.size();
+    }
+
+    static class ExperienceViewHolder extends RecyclerView.ViewHolder {
+        final ExperienceItemBinding binding;
+
+        ExperienceViewHolder(ExperienceItemBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
@@ -14,6 +14,7 @@ import com.google.gson.reflect.TypeToken;
 import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WContentBlocking;
+import com.igalia.wolvic.utils.RemoteExperiences;
 import com.igalia.wolvic.utils.RemoteProperties;
 import com.igalia.wolvic.utils.SystemUtils;
 
@@ -31,6 +32,7 @@ public class SettingsViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isWebXREnabled;
     private MutableLiveData<String> propsVersionName;
     private MutableLiveData<Map<String, RemoteProperties>> props;
+    private MutableLiveData<RemoteExperiences> experiences;
     private MutableLiveData<ObservableBoolean> isWhatsNewVisible;
 
     public SettingsViewModel(@NonNull Application application) {
@@ -42,6 +44,7 @@ public class SettingsViewModel extends AndroidViewModel {
         isWebXREnabled = new MutableLiveData<>(new ObservableBoolean(false));
         propsVersionName = new MutableLiveData<>();
         props = new MutableLiveData<>(Collections.emptyMap());
+        experiences = new MutableLiveData<>(new RemoteExperiences());
         isWhatsNewVisible = new MutableLiveData<>(new ObservableBoolean(false));
 
         propsVersionName.observeForever(props -> isWhatsNewVisible());
@@ -126,6 +129,21 @@ public class SettingsViewModel extends AndroidViewModel {
 
     public MutableLiveData<Map<String, RemoteProperties>> getProps() {
         return props;
+    }
+
+    public void setExperiences(String json) {
+        try {
+            Gson gson = new GsonBuilder().create();
+            RemoteExperiences experiences = gson.fromJson(json, RemoteExperiences.class);
+            this.experiences.postValue(experiences);
+
+        } catch (Exception e) {
+            Log.w(LOGTAG, String.valueOf(e.getLocalizedMessage()));
+        }
+    }
+
+    public MutableLiveData<RemoteExperiences> getExperiences() {
+        return experiences;
     }
 
     public MutableLiveData<ObservableBoolean> getIsWhatsNewVisible() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
@@ -16,6 +16,7 @@ import com.igalia.wolvic.browser.components.TopSitesHelper;
 import com.igalia.wolvic.browser.engine.Session;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.NewTabBinding;
+import com.igalia.wolvic.ui.adapters.ExperiencesAdapter;
 import com.igalia.wolvic.ui.adapters.TopSitesAdapterImpl;
 import com.igalia.wolvic.ui.viewmodel.SettingsViewModel;
 import com.igalia.wolvic.utils.SystemUtils;
@@ -31,6 +32,7 @@ public class NewTabView extends FrameLayout {
     private SettingsViewModel mSettingsViewModel;
     private TopSitesAdapterImpl mTopSitesAdapter;
     private TopSitesFeature mTopSitesFeature;
+    private ExperiencesAdapter mExperiencesAdapter;
 
     public NewTabView(Context context) {
         super(context);
@@ -63,6 +65,15 @@ public class NewTabView extends FrameLayout {
         TopSitesHelper topSitesHelper = new TopSitesHelper(getContext(), ((VRBrowserActivity) getContext()).getCoroutineScope());
         mTopSitesFeature = topSitesHelper.createFeature(mTopSitesAdapter);
         mTopSitesFeature.start();
+
+        // Experiences
+        mExperiencesAdapter = new ExperiencesAdapter(getContext());
+        mExperiencesAdapter.setClickListener(experience -> openUrl(experience.getUrl()));
+        mBinding.experiencesList.setAdapter(mExperiencesAdapter);
+        mBinding.experiencesList.setHasFixedSize(true);
+        mSettingsViewModel.getExperiences().observe((VRBrowserActivity) getContext(), experiences -> {
+            mExperiencesAdapter.updateExperiences(experiences.getAllExperiences());
+        });
     }
 
     private final TopSitesAdapter.ClickListener mTopSitesClickListener =

--- a/app/src/common/shared/com/igalia/wolvic/utils/RemoteExperiences.kt
+++ b/app/src/common/shared/com/igalia/wolvic/utils/RemoteExperiences.kt
@@ -1,0 +1,35 @@
+package com.igalia.wolvic.utils
+
+data class Experience(
+    val title: String,
+    val thumbnail: String,
+    val url: String,
+    val device: String
+)
+
+data class Category(
+    val translations: Map<String, String>,
+    val items: List<Experience>
+)
+
+data class RemoteExperiences(
+    val categories: Map<String, Category> = emptyMap()
+) {
+    fun getCategoryNames(): List<String> =
+        categories.keys.toList()
+
+    fun getExperiencesForCategory(category: String): List<Experience> =
+        categories[category]?.items ?: emptyList()
+
+    fun getAllExperiences(): List<Experience> =
+        categories.values.flatMap { it.items }
+
+    fun getTranslationsForCategory(category: String): Map<String, String> =
+        categories[category]?.translations ?: emptyMap()
+
+    // If the translation is not available, return the English name or the category's id
+    fun getCategoryNameForLanguage(category: String, languageCode: String): String? =
+        categories[category]?.translations?.get(languageCode)
+            ?: categories[category]?.translations?.get("en")
+            ?: category
+}

--- a/app/src/main/res/layout/experience_item.xml
+++ b/app/src/main/res/layout/experience_item.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="experience"
+            type="com.igalia.wolvic.utils.Experience" />
+
+        <variable
+            name="listener"
+            type="com.igalia.wolvic.ui.adapters.ExperiencesAdapter.ClickListener" />
+    </data>
+
+    <FrameLayout
+        android:layout_width="@dimen/experience_item_width"
+        android:layout_height="@dimen/experience_item_height"
+        android:addStatesFromChildren="true"
+        android:clickable="true"
+        android:focusable="true"
+        android:onClick="@{(view) ->  listener.onClicked(experience)}"
+        android:padding="2dp">
+
+        <RelativeLayout
+            android:id="@+id/layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/asphalt">
+
+            <ImageView
+                android:id="@+id/thumbnail"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center_vertical"
+                android:scaleType="centerCrop"
+                android:src="@drawable/empty_drawable" />
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:background="@color/text_shadow"
+                android:padding="4dp"
+                android:singleLine="true"
+                android:text="@{experience.title}"
+                android:textColor="@color/library_panel_title_text_color"
+                android:textSize="@dimen/top_site_item_title_text_size"
+                android:textStyle="bold"
+                tools:text="Experience Name" />
+
+        </RelativeLayout>
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/new_tab.xml
+++ b/app/src/main/res/layout/new_tab.xml
@@ -60,6 +60,28 @@
                 tools:itemCount="16"
                 tools:listitem="@layout/top_sites_item" />
 
+            <!-- Experiences -->
+
+            <com.igalia.wolvic.ui.views.ExpandedRecyclerView
+                android:id="@+id/experiences_list"
+                style="@style/customRecyclerViewStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:layout_marginTop="32dp"
+                android:contentDescription="Experiences"
+                android:nestedScrollingEnabled="false"
+                android:scrollbars="none"
+                app:customFastScrollEnabled="false"
+                app:layoutManager="com.igalia.wolvic.ui.views.NonScrollingGridLayoutManager"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/top_sites_list"
+                app:spanCount="4"
+                tools:itemCount="12"
+                android:layout_marginBottom="32dp"
+                tools:listitem="@layout/experience_item" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </com.igalia.wolvic.ui.views.CustomScrollView>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -211,6 +211,10 @@
     <dimen name="top_site_item_width">72dp</dimen>
     <dimen name="top_site_item_title_text_size">12sp</dimen>
     <dimen name="top_site_item_url_text_size">12sp</dimen>
+    <dimen name="experience_item_height">96dp</dimen>
+    <dimen name="experience_item_width">144dp</dimen>
+    <dimen name="experience_item_title_text_size">12sp</dimen>
+    <dimen name="experience_item_url_text_size">12sp</dimen>
 
     <!-- Library -->
     <dimen name="library_item_row_height">38dp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -72,6 +72,7 @@
     <string name="settings_key_downloads_sorting_order" translatable="false">settings_key_downloads_sorting_order</string>
     <string name="settings_key_remote_props_version_name" translatable="false">settings_key_remote_props_version_name</string>
     <string name="settings_key_remote_props" translatable="false">settings_key_remote_props</string>
+    <string name="settings_key_remote_experiences" translatable="false">settings_key_remote_experiences</string>
     <string name="settings_key_autocomplete" translatable="false">settings_key_autocomplete</string>
     <string name="settings_key_webgl_out_of_process" translatable="false">settings_key_webgl_out_of_processe</string>
     <string name="settings_key_prefs_last_reset_version_code" translatable="false">settings_key_prefs_last_reset_version_code</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ androidcomponents-concept-engine = { module = "org.mozilla.components:concept-en
 androidcomponents-concept-fetch = { module = "org.mozilla.components:concept-fetch", version.ref = "androidComponents" }
 androidcomponents-lib-fetch = { module = "org.mozilla.components:lib-fetch-httpurlconnection", version.ref = "androidComponents" }
 androidcomponents-lib-dataprotect = { module = "org.mozilla.components:lib-dataprotect", version.ref = "androidComponents" }
+androidcomponents-support-images = { module = "org.mozilla.components:support-images", version.ref = "androidComponents" }
 androidcomponents-support-rustlog = { module = "org.mozilla.components:support-rustlog", version.ref = "androidComponents" }
 androidcomponents-support-rusthttp = { module = "org.mozilla.components:support-rusthttp", version.ref = "androidComponents" }
 androidcomponents-support-webextensions = { module = "org.mozilla.components:support-webextensions", version.ref = "androidComponents" }


### PR DESCRIPTION
This PR builds on https://github.com/Igalia/wolvic/pull/1802

Download the list of remote experiences in JSON format and display it in the New Tab view.

The list is based on the content of out existing homepage, with some small changes to make it easier to process and display. This process is very similar to how props.json is managed.

This change also adds a utility class to download and display remote images asynchronously.