### PR TITLE
Organize experiences in New Tab into categories

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
@@ -8,6 +8,7 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.GridLayoutManager;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
@@ -70,9 +71,13 @@ public class NewTabView extends FrameLayout {
         mExperiencesAdapter = new ExperiencesAdapter(getContext());
         mExperiencesAdapter.setClickListener(experience -> openUrl(experience.getUrl()));
         mBinding.experiencesList.setAdapter(mExperiencesAdapter);
-        mBinding.experiencesList.setHasFixedSize(true);
+        // The grid items have different sizes and span a different nr of cells.
+        mBinding.experiencesList.setHasFixedSize(false);
+        GridLayoutManager layoutManager = (GridLayoutManager) mBinding.experiencesList.getLayoutManager();
+        layoutManager.setSpanSizeLookup(mExperiencesAdapter.getSpanSizeLookup(layoutManager.getSpanCount()));
+
         mSettingsViewModel.getExperiences().observe((VRBrowserActivity) getContext(), experiences -> {
-            mExperiencesAdapter.updateExperiences(experiences.getAllExperiences());
+            mExperiencesAdapter.updateExperiences(experiences);
         });
     }
 

--- a/app/src/main/res/layout/experience_header_item.xml
+++ b/app/src/main/res/layout/experience_header_item.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="title"
+            type="String" />
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="@dimen/experience_header_item_height"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp">
+
+        <TextView
+            android:id="@+id/header_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:text="@{title}"
+            android:textColor="@color/fog"
+            android:textSize="18sp"
+            tools:text="Games" />
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -213,6 +213,7 @@
     <dimen name="top_site_item_url_text_size">12sp</dimen>
     <dimen name="experience_item_height">96dp</dimen>
     <dimen name="experience_item_width">144dp</dimen>
+    <dimen name="experience_header_item_height">48dp</dimen>
     <dimen name="experience_item_title_text_size">12sp</dimen>
     <dimen name="experience_item_url_text_size">12sp</dimen>
 


### PR DESCRIPTION
This PR builds on https://github.com/Igalia/wolvic/pull/1803

Organize the suggested experiences in the New Tab view into categories.

Individual experience items are displayed on grids, separated by headers with the title of each category.

The title of the category follows the current language (if supported).