### PR TITLE
Add null value check for target URI

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -937,7 +937,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         }
 
         // If there is a target URI we open it
-        if (targetUri != null) {
+        if (targetUri != null && !targetUri.toString().isEmpty()) {
             Log.d(LOGTAG, "Loading URI from intent: " + targetUri);
 
             int location = Windows.OPEN_IN_FOREGROUND;


### PR DESCRIPTION
When launching the APK from the launcher on PFDM MR devices, the incoming intent contains a URL key, but the value is empty. Add a check for emptiness here, and if the value is empty, still launch the default homepage.