### PR TITLE
Fix initial transparency of Web content layer

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -44,6 +44,6 @@
     <color name="smoke">#f5f6fa</color>
     <color name="window_border_hover">@color/azure</color>
     <color name="window_border_click">#2bd2ee</color>
-    <color name="window_blank_clear_color">#5d5d5d</color>
+    <color name="window_blank_clear_color">@color/void_color</color>
     <color name="window_private_clear_color">#331a50</color>
 </resources>

--- a/app/src/openxr/cpp/OpenXRLayers.h
+++ b/app/src/openxr/cpp/OpenXRLayers.h
@@ -93,7 +93,10 @@ public:
     }
 
     for (auto& xrLayer : xrLayers) {
-      xrLayer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+      // Only set alpha blending if the clear color isn't fully opaque and the layer is composited.
+      xrLayer.layerFlags = (layer->GetClearColor().HasAlpha() && IsComposited()) ?
+                           XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
+
       xrLayer.space = aSpace;
       xrLayer.next = XR_NULL_HANDLE;
 
@@ -125,7 +128,7 @@ public:
 
   virtual bool IsDrawRequested() const override {
     return layer->IsDrawRequested() &&
-       ((IsSwapChainReady() && IsComposited()) || layer->GetClearColor().Alpha() > 9999999999999.0f); // TODO: remove
+       ((IsSwapChainReady() && IsComposited()) || layer->GetClearColor().Alpha() >= 1.0f);
   }
 
   bool GetDrawInFront() const override {


### PR DESCRIPTION
This PR is a first step towards fixing the problem that the window containing Web content appears transparent for a few seconds (issue https://github.com/Igalia/wolvic/issues/1766).

The problem seems to be related to the fact that we are enabling alpha blending for that layer even though it already has an opaque clear colour.

However, changing that XR flag is not enough to fully fix the issue: initially the layer appears completely black, followed by the expected clear color (but too bright).