### PR TITLE
Integrate HeyVR experiences in New Tab

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,7 @@ android {
         buildConfigField "Boolean", "ENABLE_PAGE_ZOOM", "false"
         buildConfigField "Boolean", "USE_SOUNDPOOL", "true"
         buildConfigField 'String', 'EXPERIENCES_ENDPOINT', '"https://igalia.github.io/wolvic/experiences.json"'
+        buildConfigField 'String', 'HEYVR_ENDPOINT', '"https://api.heyvr.io/v1/public/global/feed/featured?limit=50"'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         resValue 'string', 'app_name', 'Wolvic'

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -216,6 +216,9 @@ public class SettingsStore {
         String experiencesJson = mPrefs.getString(mContext.getString(R.string.settings_key_remote_experiences), null);
         mSettingsViewModel.setExperiences(experiencesJson);
 
+        String heyVRJson = mPrefs.getString(mContext.getString(R.string.settings_key_heyvr_experiences), null);
+        mSettingsViewModel.setHeyVRExperiences(heyVRJson);
+
         mSettingsViewModel.refresh();
 
         updateRemoteContent(BuildConfig.PROPS_ENDPOINT,
@@ -224,6 +227,9 @@ public class SettingsStore {
         updateRemoteContent(BuildConfig.EXPERIENCES_ENDPOINT,
                 R.string.settings_key_remote_experiences,
                 mSettingsViewModel::setExperiences);
+        updateRemoteContent(BuildConfig.HEYVR_ENDPOINT,
+                R.string.settings_key_heyvr_experiences,
+                mSettingsViewModel::setHeyVRExperiences);
     }
 
     /**

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
@@ -14,12 +14,15 @@ import com.google.gson.reflect.TypeToken;
 import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WContentBlocking;
+import com.igalia.wolvic.utils.Experience;
 import com.igalia.wolvic.utils.RemoteExperiences;
 import com.igalia.wolvic.utils.RemoteProperties;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class SettingsViewModel extends AndroidViewModel {
@@ -132,16 +135,46 @@ public class SettingsViewModel extends AndroidViewModel {
     }
 
     public void setExperiences(String json) {
-        RemoteExperiences updatedExperiences = null;
+        if (json == null || json.isEmpty()) {
+            return;
+        }
+
         try {
             Gson gson = new GsonBuilder().create();
-            updatedExperiences = gson.fromJson(json, RemoteExperiences.class);
-        } catch (Exception e) {
-            Log.w(LOGTAG, String.valueOf(e.getLocalizedMessage()));
-        } finally {
-            if (updatedExperiences != null) {
-                this.experiences.postValue(updatedExperiences);
+            RemoteExperiences newExperiences = gson.fromJson(json, RemoteExperiences.class);
+
+            RemoteExperiences currentExperiences = this.experiences.getValue();
+            if (currentExperiences == null) {
+                // Initialize a new experiences object if one doesn't exist yet.
+                this.experiences.postValue(newExperiences);
+            } else {
+                currentExperiences.setRemoteExperiences(newExperiences);
+                this.experiences.postValue(currentExperiences);
             }
+        } catch (Exception e) {
+            Log.w(LOGTAG, "Error processing experiences data: " + e.getLocalizedMessage());
+        }
+    }
+
+    public void setHeyVRExperiences(String json) {
+        if (json == null || json.isEmpty()) {
+            return;
+        }
+
+        try {
+            Gson gson = new GsonBuilder().create();
+            Experience[] experiencesArray = gson.fromJson(json, Experience[].class);
+            List<Experience> heyVRExperiences = Arrays.asList(experiencesArray);
+
+            RemoteExperiences currentExperiences = this.experiences.getValue();
+            if (currentExperiences == null) {
+                // Initialize a new experiences object if one doesn't exist yet.
+                currentExperiences = new RemoteExperiences();
+            }
+            currentExperiences.setHeyVRExperiences(heyVRExperiences);
+            this.experiences.postValue(currentExperiences);
+        } catch (Exception e) {
+            Log.w(LOGTAG, "Error processing HeyVR data: " + e.getLocalizedMessage());
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
@@ -8,6 +8,7 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.GridLayoutManager;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
@@ -70,9 +71,13 @@ public class NewTabView extends FrameLayout {
         mExperiencesAdapter = new ExperiencesAdapter(getContext());
         mExperiencesAdapter.setClickListener(experience -> openUrl(experience.getUrl()));
         mBinding.experiencesList.setAdapter(mExperiencesAdapter);
-        mBinding.experiencesList.setHasFixedSize(true);
+        // The grid items have different sizes and span a different nr of cells.
+        mBinding.experiencesList.setHasFixedSize(false);
+        GridLayoutManager layoutManager = (GridLayoutManager) mBinding.experiencesList.getLayoutManager();
+        layoutManager.setSpanSizeLookup(mExperiencesAdapter.getSpanSizeLookup(layoutManager.getSpanCount()));
+
         mSettingsViewModel.getExperiences().observe((VRBrowserActivity) getContext(), experiences -> {
-            mExperiencesAdapter.updateExperiences(experiences.getAllExperiences());
+            mExperiencesAdapter.updateExperiences(experiences);
         });
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/utils/RemoteExperiences.kt
+++ b/app/src/common/shared/com/igalia/wolvic/utils/RemoteExperiences.kt
@@ -13,8 +13,13 @@ data class Category(
 )
 
 data class RemoteExperiences(
-    val categories: Map<String, Category> = emptyMap()
+    var categories: Map<String, Category> = emptyMap()
 ) {
+    companion object {
+        const val CATEGORY_HEYVR = "heyvr"
+        const val CATEGORY_HEYVR_DISPLAY_NAME = "HeyVR"
+    }
+
     fun getCategoryNames(): List<String> =
         categories.keys.toList()
 
@@ -32,4 +37,27 @@ data class RemoteExperiences(
         categories[category]?.translations?.get(languageCode)
             ?: categories[category]?.translations?.get("en")
             ?: category
+
+    fun setRemoteExperiences(regularExperiences: RemoteExperiences) {
+        // preserve the existing HeyVR category
+        val heyVRCategory = categories[CATEGORY_HEYVR]
+
+        val updatedCategories = regularExperiences.categories.toMutableMap()
+
+        if (heyVRCategory != null) {
+            updatedCategories[CATEGORY_HEYVR] = heyVRCategory
+        }
+
+        categories = updatedCategories
+    }
+
+    fun setHeyVRExperiences(heyVRExperiences: List<Experience>) {
+        val translations = mapOf("en" to CATEGORY_HEYVR_DISPLAY_NAME)
+
+        val heyVRCategory = Category(translations, heyVRExperiences)
+
+        categories = categories.toMutableMap().apply {
+            put(CATEGORY_HEYVR, heyVRCategory)
+        }
+    }
 }

--- a/app/src/main/res/layout/experience_header_item.xml
+++ b/app/src/main/res/layout/experience_header_item.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="title"
+            type="String" />
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="@dimen/experience_header_item_height"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp">
+
+        <TextView
+            android:id="@+id/header_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:text="@{title}"
+            android:textColor="@color/fog"
+            android:textSize="18sp"
+            tools:text="Games" />
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -213,6 +213,7 @@
     <dimen name="top_site_item_url_text_size">12sp</dimen>
     <dimen name="experience_item_height">96dp</dimen>
     <dimen name="experience_item_width">144dp</dimen>
+    <dimen name="experience_header_item_height">48dp</dimen>
     <dimen name="experience_item_title_text_size">12sp</dimen>
     <dimen name="experience_item_url_text_size">12sp</dimen>
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -73,6 +73,7 @@
     <string name="settings_key_remote_props_version_name" translatable="false">settings_key_remote_props_version_name</string>
     <string name="settings_key_remote_props" translatable="false">settings_key_remote_props</string>
     <string name="settings_key_remote_experiences" translatable="false">settings_key_remote_experiences</string>
+    <string name="settings_key_heyvr_experiences" translatable="false">settings_key_heyvr_experiences</string>
     <string name="settings_key_autocomplete" translatable="false">settings_key_autocomplete</string>
     <string name="settings_key_webgl_out_of_process" translatable="false">settings_key_webgl_out_of_processe</string>
     <string name="settings_key_prefs_last_reset_version_code" translatable="false">settings_key_prefs_last_reset_version_code</string>


### PR DESCRIPTION
This PR builds on https://github.com/Igalia/wolvic/pull/1804

Add support for displaying HeyVR content alongside regular experiences by integrating with the HeyVR API endpoint.

RemoteExperiences supports our two data sources (Wolvic and HeyVR) so we are able to update content from one without overwriting the content from the other.

SettingsViewModel handles updates from both data sources, parsing and storing the downloaded JSON content.

SettingsStore fetches JSON data from the HeyVR endpoint.

The upper layers (adapter, recycler view, etc.) are able to continue displaying this data without any changes.