### PR TITLE
feat(locales): add Ukrainian language support to l10n.toml

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -18,6 +18,7 @@ locales = [
   "pl",
   "ru",
   "sv-SE",
+  "uk",
   "zh-CN",
   "zh-TW",
 ]


### PR DESCRIPTION
Adds "uk" to the list of supported locales in l10n.toml to enhance  language accessibility for Ukrainian users and allow select Ukrainian language.