### PR TITLE
Add Ukrainian language support

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/LocaleUtils.java
@@ -306,6 +306,8 @@ public class LocaleUtils {
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_danish, locale)));
             locale = new Locale("fi","FI");
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_finnish, locale)));
+            locale = new Locale("uk","UA");
+            put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_ukrainian, locale)));
             locale = new Locale("gl", "ES");
             put(locale.toLanguageTag(), new Language(locale, StringUtils.getStringByLocale(context, R.string.settings_language_galician, locale)));
             locale = new Locale("pt","PT");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,6 +342,13 @@
     the keyboard languages panel list. -->
     <string name="settings_language_korean">Korean</string>
 
+
+    <!-- This string is used to label a radio button in the 'Settings' Voice Search and the Display Language dialogs that, when pressed,
+    changes the app and the language of the speech-recognition-based search to 'Ukrainian'.
+    The string is also used in the keyboard space bar to show the current keyboard language and in
+    the keyboard languages panel list. --> 
+    <string name="settings_language_ukrainian">Ukrainian</string>
+
     <!-- This string is used to label a radio button in the 'Settings' Voice Search and the Display Language dialogs that, when pressed,
     changes the app and the language of the speech-recognition-based search to 'Italian'.
     The string is also used in the keyboard space bar to show the current keyboard language and in

--- a/l10n.toml
+++ b/l10n.toml
@@ -18,6 +18,7 @@ locales = [
   "pl",
   "ru",
   "sv-SE",
+  "uk",
   "zh-CN",
   "zh-TW",
 ]


### PR DESCRIPTION
Adds support for the Ukrainian language in the app. Updates the  LocaleUtils class to include Ukrainian localization, adds the  appropriate string resource for Ukrainian, and modifies the  locales list to recognize Ukrainian as a valid language option.  These changes enhance the app's accessibility for Ukrainian  speakers.

Fix #1191