### PR TITLE
Add announcements to New Tab

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,6 +125,7 @@ android {
         buildConfigField "Float", "DEFAULT_WINDOW_DISTANCE", "0.0f"
         buildConfigField "Boolean", "ENABLE_PAGE_ZOOM", "false"
         buildConfigField "Boolean", "USE_SOUNDPOOL", "true"
+        buildConfigField 'String', 'ANNOUNCEMENTS_ENDPOINT', '"https://igalia.github.io/wolvic/announcements.json"'
         buildConfigField 'String', 'EXPERIENCES_ENDPOINT', '"https://igalia.github.io/wolvic/experiences.json"'
         buildConfigField 'String', 'HEYVR_ENDPOINT', '"https://api.heyvr.io/v1/public/global/feed/featured?limit=50"'
 

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -213,6 +213,9 @@ public class SettingsStore {
         String json = mPrefs.getString(mContext.getString(R.string.settings_key_remote_props), null);
         mSettingsViewModel.setProps(json);
 
+        String announcementsJson = mPrefs.getString(mContext.getString(R.string.settings_key_remote_announcements), null);
+        mSettingsViewModel.setAnnouncements(announcementsJson);
+
         String experiencesJson = mPrefs.getString(mContext.getString(R.string.settings_key_remote_experiences), null);
         mSettingsViewModel.setExperiences(experiencesJson);
 
@@ -224,6 +227,9 @@ public class SettingsStore {
         updateRemoteContent(BuildConfig.PROPS_ENDPOINT,
                 R.string.settings_key_remote_props,
                 mSettingsViewModel::setProps);
+        updateRemoteContent(BuildConfig.ANNOUNCEMENTS_ENDPOINT,
+                R.string.settings_key_remote_announcements,
+                mSettingsViewModel::setAnnouncements);
         updateRemoteContent(BuildConfig.EXPERIENCES_ENDPOINT,
                 R.string.settings_key_remote_experiences,
                 mSettingsViewModel::setExperiences);

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/AnnouncementsAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/AnnouncementsAdapter.java
@@ -1,0 +1,137 @@
+package com.igalia.wolvic.ui.adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.databinding.DataBindingUtil;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.engine.SessionStore;
+import com.igalia.wolvic.databinding.AnnouncementItemBinding;
+import com.igalia.wolvic.utils.Announcement;
+import com.igalia.wolvic.utils.LocaleUtils;
+import com.igalia.wolvic.utils.RemoteAnnouncements;
+import com.igalia.wolvic.utils.StringUtils;
+import com.igalia.wolvic.utils.SystemUtils;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.FormatStyle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class AnnouncementsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private static final String LOGTAG = SystemUtils.createLogtag(AnnouncementsAdapter.class);
+
+    // JSON source uses ISO date format ("2025-12-31")
+    private static final DateTimeFormatter ISO_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE;
+    // Convert to local date format (e.g. "31 December 2025")
+    private static final DateTimeFormatter DISPLAY_FORMAT =
+            DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).withLocale(Locale.getDefault());
+
+    private final Context mContext;
+    private RemoteAnnouncements mRemoteAnnouncements;
+    private final List<Announcement> mAnnouncements = new ArrayList<>();
+    private ClickListener mListener;
+
+    public interface ClickListener {
+        void onClicked(Announcement announcement);
+    }
+
+    public AnnouncementsAdapter(Context context) {
+        mContext = context;
+    }
+
+    public void updateAnnouncements(RemoteAnnouncements remoteAnnouncements) {
+        mRemoteAnnouncements = remoteAnnouncements;
+        mAnnouncements.clear();
+
+        if (remoteAnnouncements != null) {
+            mAnnouncements.addAll(remoteAnnouncements.getAnnouncements());
+        }
+
+        notifyDataSetChanged();
+    }
+
+    public void setClickListener(ClickListener listener) {
+        mListener = listener;
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        AnnouncementItemBinding binding = DataBindingUtil.inflate(
+                LayoutInflater.from(mContext),
+                R.layout.announcement_item,
+                parent,
+                false);
+        return new AnnouncementViewHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        AnnouncementViewHolder viewHolder = (AnnouncementViewHolder) holder;
+        Announcement announcement = mAnnouncements.get(position);
+
+        String languageCode = LocaleUtils.getDisplayLanguage(mContext).getLocale().getLanguage();
+
+        String title = mRemoteAnnouncements.getAnnouncementTitleForLanguage(announcement, languageCode);
+        viewHolder.binding.announcementTitle.setText(title);
+
+        String body = mRemoteAnnouncements.getAnnouncementBodyForLanguage(announcement, languageCode);
+        viewHolder.binding.announcementBody.setText(body);
+
+        try {
+            LocalDate date = LocalDate.parse(announcement.getDate(), ISO_FORMAT);
+            viewHolder.binding.announcementDate.setText(date.format(DISPLAY_FORMAT));
+        } catch (DateTimeParseException e) {
+            viewHolder.binding.announcementDate.setText(announcement.getDate());
+        }
+
+        if (!StringUtils.isEmpty(announcement.getImage())) {
+            viewHolder.binding.announcementImage.setImageResource(R.drawable.empty_drawable);
+            viewHolder.binding.announcementImage.setVisibility(View.VISIBLE);
+            SessionStore.get().getRemoteImageHelper().loadIntoView(
+                    viewHolder.binding.announcementImage,
+                    announcement.getImage(),
+                    false);
+        } else {
+            viewHolder.binding.announcementImage.setVisibility(View.GONE);
+            viewHolder.binding.announcementImage.setImageResource(R.drawable.empty_drawable);
+        }
+
+        if (announcement.getLink() == null) {
+            viewHolder.binding.linkIcon.setVisibility(View.GONE);
+        } else {
+            viewHolder.binding.linkIcon.setVisibility(View.VISIBLE);
+        }
+
+        viewHolder.binding.setAnnouncement(announcement);
+        viewHolder.binding.setListener(mListener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mAnnouncements.size();
+    }
+
+    @Override public long getItemId(int position) {
+        return mAnnouncements.get(position).getId().hashCode();
+    }
+
+    static class AnnouncementViewHolder extends RecyclerView.ViewHolder {
+        final AnnouncementItemBinding binding;
+
+        AnnouncementViewHolder(AnnouncementItemBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/SettingsViewModel.java
@@ -15,6 +15,7 @@ import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WContentBlocking;
 import com.igalia.wolvic.utils.Experience;
+import com.igalia.wolvic.utils.RemoteAnnouncements;
 import com.igalia.wolvic.utils.RemoteExperiences;
 import com.igalia.wolvic.utils.RemoteProperties;
 import com.igalia.wolvic.utils.SystemUtils;
@@ -35,6 +36,7 @@ public class SettingsViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableBoolean> isWebXREnabled;
     private MutableLiveData<String> propsVersionName;
     private MutableLiveData<Map<String, RemoteProperties>> props;
+    private MutableLiveData<RemoteAnnouncements> announcements;
     private MutableLiveData<RemoteExperiences> experiences;
     private MutableLiveData<ObservableBoolean> isWhatsNewVisible;
 
@@ -47,6 +49,7 @@ public class SettingsViewModel extends AndroidViewModel {
         isWebXREnabled = new MutableLiveData<>(new ObservableBoolean(false));
         propsVersionName = new MutableLiveData<>();
         props = new MutableLiveData<>(Collections.emptyMap());
+        announcements = new MutableLiveData<>(new RemoteAnnouncements());
         experiences = new MutableLiveData<>(new RemoteExperiences());
         isWhatsNewVisible = new MutableLiveData<>(new ObservableBoolean(false));
 
@@ -134,6 +137,20 @@ public class SettingsViewModel extends AndroidViewModel {
         return props;
     }
 
+    public void setAnnouncements(String json) {
+        RemoteAnnouncements updatedAnnouncements = null;
+        try {
+            Gson gson = new GsonBuilder().create();
+            updatedAnnouncements = gson.fromJson(json, RemoteAnnouncements.class);
+        } catch (Exception e) {
+            Log.w(LOGTAG, String.valueOf(e.getLocalizedMessage()));
+        } finally {
+            if (updatedAnnouncements != null) {
+                this.announcements.postValue(updatedAnnouncements);
+            }
+        }
+    }
+
     public void setExperiences(String json) {
         if (json == null || json.isEmpty()) {
             return;
@@ -176,6 +193,10 @@ public class SettingsViewModel extends AndroidViewModel {
         } catch (Exception e) {
             Log.w(LOGTAG, "Error processing HeyVR data: " + e.getLocalizedMessage());
         }
+    }
+
+    public MutableLiveData<RemoteAnnouncements> getAnnouncements() {
+        return announcements;
     }
 
     public MutableLiveData<RemoteExperiences> getExperiences() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
@@ -17,6 +17,7 @@ import com.igalia.wolvic.browser.components.TopSitesHelper;
 import com.igalia.wolvic.browser.engine.Session;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.databinding.NewTabBinding;
+import com.igalia.wolvic.ui.adapters.AnnouncementsAdapter;
 import com.igalia.wolvic.ui.adapters.ExperiencesAdapter;
 import com.igalia.wolvic.ui.adapters.TopSitesAdapterImpl;
 import com.igalia.wolvic.ui.viewmodel.SettingsViewModel;
@@ -31,6 +32,7 @@ public class NewTabView extends FrameLayout {
 
     private NewTabBinding mBinding;
     private SettingsViewModel mSettingsViewModel;
+    private AnnouncementsAdapter mAnnouncementsAdapter;
     private TopSitesAdapterImpl mTopSitesAdapter;
     private TopSitesFeature mTopSitesFeature;
     private ExperiencesAdapter mExperiencesAdapter;
@@ -57,6 +59,20 @@ public class NewTabView extends FrameLayout {
         mBinding.setSettingsmodel(mSettingsViewModel);
 
         mBinding.logo.setOnClickListener(v -> openUrl(getContext().getString(R.string.home_page_url)));
+
+        // Announcements
+        mAnnouncementsAdapter = new AnnouncementsAdapter(getContext());
+        mAnnouncementsAdapter.setClickListener(announcement -> {
+            if (announcement.getLink() != null) {
+                openUrl(announcement.getLink());
+            }
+        });
+        mBinding.announcementsList.setAdapter(mAnnouncementsAdapter);
+        mBinding.announcementsList.setHasFixedSize(false);
+
+        mSettingsViewModel.getAnnouncements().observe((VRBrowserActivity) getContext(), remoteAnnouncements -> {
+            mAnnouncementsAdapter.updateAnnouncements(remoteAnnouncements);
+        });
 
         // Top sites
         mTopSitesAdapter = new TopSitesAdapterImpl(mTopSitesClickListener);

--- a/app/src/common/shared/com/igalia/wolvic/utils/RemoteAnnouncements.kt
+++ b/app/src/common/shared/com/igalia/wolvic/utils/RemoteAnnouncements.kt
@@ -1,0 +1,24 @@
+package com.igalia.wolvic.utils
+
+data class Announcement(
+    val id: String,
+    val date: String,
+    val title: Map<String, String>,
+    val body: Map<String, String>,
+    val image: String? = null,
+    val link: String? = null
+)
+
+data class RemoteAnnouncements(
+    var announcements: List<Announcement> = emptyList()
+) {
+    fun getAnnouncementTitleForLanguage(announcement: Announcement, languageCode: String): String =
+        announcement.title[languageCode]
+            ?: announcement.title["en"]
+            ?: ""
+
+    fun getAnnouncementBodyForLanguage(announcement: Announcement, languageCode: String): String =
+        announcement.body[languageCode]
+            ?: announcement.body["en"]
+            ?: ""
+}

--- a/app/src/main/res/layout/announcement_item.xml
+++ b/app/src/main/res/layout/announcement_item.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="announcement"
+            type="com.igalia.wolvic.utils.Announcement" />
+
+        <variable
+            name="listener"
+            type="com.igalia.wolvic.ui.adapters.AnnouncementsAdapter.ClickListener" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="@dimen/announcement_item_width"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:background="@color/asphalt"
+        android:clickable="true"
+        android:elevation="4dp"
+        android:focusable="true"
+        android:foreground="?attr/selectableItemBackground"
+        android:onClick="@{(view) -> listener.onClicked(announcement)}">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/link_icon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_below="@id/announcement_image"
+                android:layout_alignParentEnd="true"
+                android:layout_margin="4dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/mozac_ic_open_in" />
+
+            <ImageView
+                android:id="@+id/announcement_image"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/announcement_item_image_height"
+                android:scaleType="centerCrop"
+                android:src="@drawable/empty_drawable" />
+
+            <TextView
+                android:id="@+id/announcement_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/announcement_image"
+                android:minHeight="32dp"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
+                android:paddingEnd="24dp"
+                android:textColor="@color/library_panel_title_text_color"
+                android:textSize="@dimen/top_site_item_title_text_size"
+                android:textStyle="bold"
+                tools:text="Announcement Title" />
+
+            <TextView
+                android:id="@+id/announcement_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/announcement_title"
+                android:paddingStart="12dp"
+                android:paddingTop="4dp"
+                android:paddingEnd="12dp"
+                android:textColor="@color/library_panel_title_text_color"
+                android:textSize="@dimen/announcement_item_title_text_size"
+                tools:text="Announcement body text here." />
+
+            <TextView
+                android:id="@+id/announcement_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/announcement_body"
+                android:layout_alignParentEnd="true"
+                android:padding="12dp"
+                android:textColor="@color/library_panel_title_text_color"
+                android:textSize="12sp"
+                android:textStyle="italic"
+                tools:text="March 25, 2025" />
+        </RelativeLayout>
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/app/src/main/res/layout/new_tab.xml
+++ b/app/src/main/res/layout/new_tab.xml
@@ -37,6 +37,43 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <!-- Announcements -->
+            <TextView
+                android:id="@+id/announcements_header"
+                android:layout_width="@dimen/announcement_item_header_width"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:gravity="start|center_vertical"
+                android:minHeight="@dimen/experience_header_item_height"
+                android:paddingStart="24dp"
+                android:paddingEnd="24dp"
+                android:text="@string/announcements_title"
+                android:textColor="@color/fog"
+                android:textSize="18sp"
+                android:visibility="@{settingsmodel.announcements.announcements.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/logo" />
+
+            <com.igalia.wolvic.ui.views.ExpandedRecyclerView
+                android:id="@+id/announcements_list"
+                style="@style/customRecyclerViewStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/announcements_title"
+                android:foregroundGravity="center_horizontal"
+                android:nestedScrollingEnabled="false"
+                android:scrollbars="none"
+                android:visibility="@{settingsmodel.announcements.announcements.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                app:customFastScrollEnabled="false"
+                app:layoutManager="com.igalia.wolvic.ui.views.NonScrollingGridLayoutManager"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/announcements_header"
+                app:spanCount="1"
+                tools:itemCount="2"
+                tools:listitem="@layout/announcement_item" />
+
             <!-- Top sites -->
 
             <com.igalia.wolvic.ui.views.ExpandedRecyclerView
@@ -55,7 +92,7 @@
                 app:layoutManager="com.igalia.wolvic.ui.views.NonScrollingGridLayoutManager"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/logo"
+                app:layout_constraintTop_toBottomOf="@id/announcements_list"
                 app:spanCount="8"
                 tools:itemCount="16"
                 tools:listitem="@layout/top_sites_item" />

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -207,6 +207,11 @@
     <dimen name="tray_icon_padding_min">8dp</dimen>
 
     <!-- New Tab -->
+    <dimen name="announcement_item_header_width">576dp</dimen>
+    <dimen name="announcement_item_title_text_size">12sp</dimen>
+    <dimen name="announcement_item_body_text_size">12sp</dimen>
+    <dimen name="announcement_item_image_height">96dp</dimen>
+    <dimen name="announcement_item_width">288dp</dimen>
     <dimen name="top_site_item_height">72dp</dimen>
     <dimen name="top_site_item_width">72dp</dimen>
     <dimen name="top_site_item_title_text_size">12sp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -72,6 +72,7 @@
     <string name="settings_key_downloads_sorting_order" translatable="false">settings_key_downloads_sorting_order</string>
     <string name="settings_key_remote_props_version_name" translatable="false">settings_key_remote_props_version_name</string>
     <string name="settings_key_remote_props" translatable="false">settings_key_remote_props</string>
+    <string name="settings_key_remote_announcements" translatable="false">settings_key_remote_announcements</string>
     <string name="settings_key_remote_experiences" translatable="false">settings_key_remote_experiences</string>
     <string name="settings_key_heyvr_experiences" translatable="false">settings_key_heyvr_experiences</string>
     <string name="settings_key_autocomplete" translatable="false">settings_key_autocomplete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2613,5 +2613,6 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <string name="controller_options_window_selection">Window Selection Method</string>
     <string name="controller_options_click_to_select">Click</string>
     <string name="controller_options_hover_to_select">Hover</string>
+    <string name="announcements_title">Announcements</string>
 
 </resources>


### PR DESCRIPTION
Add an announcements feature to the New Tab UI.

Announcements are defined in the `ANNOUNCEMENTS_ENDPOINT` URL.

The process to fetch and present them is similar to what we do with remote experiences and similar content.

Each announcement includes a title and body text, and optionally an image and a link. Text fields support multiple languages.