### PR TITLE
"Sticky" lock mode

### DIFF
--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -105,7 +105,7 @@ private:
 #endif
   vrb::Matrix GetActiveControllerOrientation() const;
   void ThrottledWindowDistanceComputation(const vrb::Matrix& reorientTransform);
-  vrb::Matrix CalculateStickyLockTransform();
+  float CalculateStickyLockWidgetsYaw();
   State& m;
   BrowserWorld() = delete;
   VRB_NO_DEFAULTS(BrowserWorld)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -49,7 +49,7 @@ public:
   void EndFrame();
   void TriggerHapticFeedback(const float aPulseDuration, const float aPulseIntensity, const int aControllerId);
   void TogglePassthrough();
-  enum class LockMode { NO_LOCK, HEAD, CONTROLLER };
+  enum class LockMode { NO_LOCK, HEAD, CONTROLLER, STICKY };
   void SetLockMode(LockMode);
   void SetTemporaryFilePath(const std::string& aPath);
   void UpdateEnvironment();
@@ -105,6 +105,7 @@ private:
 #endif
   vrb::Matrix GetActiveControllerOrientation() const;
   void ThrottledWindowDistanceComputation(const vrb::Matrix& reorientTransform);
+  vrb::Matrix CalculateStickyLockTransform();
   State& m;
   BrowserWorld() = delete;
   VRB_NO_DEFAULTS(BrowserWorld)

--- a/app/src/main/cpp/Widget.h
+++ b/app/src/main/cpp/Widget.h
@@ -82,6 +82,7 @@ public:
   void SetProxifyLayer(const bool aValue);
   void LayoutQuadWithCylinderParent(const WidgetPtr& aParent);
   void RecenterYawInCylinderLayer(const vrb::Matrix& reorientMatrix);
+  void GetAngularBoundsFromCenter(float& aStartAngle, float& aEndAngle) const;
 protected:
   struct State;
   Widget(State& aState, vrb::RenderContextPtr& aContext);


### PR DESCRIPTION
Add sticky lock mode to keep windows in the user's field of view.

This lock mode calculates the boundaries of visible windows relative to the user's FOV and applies minimal rotation adjustments when necessary to keep as much content visible as possible.

When the content edge moves outside the FOV, the view may rotate to bring it back within the FOV boundary.

This provides the freedom to look at different parts of the content while keeping the UI always within the user's view.