### PR TITLE
Set the clear color for Web browser windows

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -1,5 +1,6 @@
 package com.igalia.wolvic.browser.api.impl;
 
+import android.graphics.Color;
 import android.graphics.Matrix;
 import android.util.Base64;
 import android.view.ViewGroup;
@@ -9,7 +10,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.igalia.wolvic.browser.SettingsStore;
-import com.igalia.wolvic.browser.api.WAutocomplete;
 import com.igalia.wolvic.browser.api.WContentBlocking;
 import com.igalia.wolvic.browser.api.WDisplay;
 import com.igalia.wolvic.browser.api.WMediaSession;
@@ -56,6 +56,7 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     private TabImpl mTab;
     private ReadyCallback mReadyCallback = new ReadyCallback();
     private UrlUtilsVisitor mUrlUtilsVisitor;
+    private int mClearColor = Color.WHITE;
 
     private class ReadyCallback implements RuntimeImpl.Callback {
         @Override
@@ -288,6 +289,17 @@ public class SessionImpl implements WSession, DownloadManagerBridge.Delegate {
     @Override
     public WPanZoomController getPanZoomController() {
         return mPanZoomController;
+    }
+
+    @Override
+    public void setClearColor(int color) {
+        mClearColor = color;
+        // TODO implement for Chromium
+    }
+
+    @Override
+    public int getClearColor() {
+        return mClearColor;
     }
 
     @Override

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/SessionImpl.java
@@ -1,5 +1,6 @@
 package com.igalia.wolvic.browser.api.impl;
 
+import android.graphics.Color;
 import android.graphics.Matrix;
 
 import androidx.annotation.NonNull;
@@ -39,6 +40,7 @@ public class SessionImpl implements WSession {
     private PanZoomControllerImpl mPanZoomController;
     private Method mGeckoLocationMethod;
     private UrlUtilsVisitor mUrlUtilsVisitor;
+    private int mClearColor = Color.WHITE;
 
     // The difference between "Mobile" and "VR" matches GeckoViewSettings.jsm
     private static final String WOLVIC_USER_AGENT_MOBILE = GeckoSession.getDefaultUserAgent() + " Wolvic/" + BuildConfig.VERSION_NAME;
@@ -237,6 +239,17 @@ public class SessionImpl implements WSession {
     @Override
     public WPanZoomController getPanZoomController() {
         return mPanZoomController;
+    }
+
+    @Override
+    public void setClearColor(int color) {
+        mClearColor = color;
+        mSession.getCompositorController().setClearColor(mClearColor);
+    }
+
+    @Override
+    public int getClearColor() {
+        return mClearColor;
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -2822,6 +2822,20 @@ public interface WSession {
     @NonNull
     WPanZoomController getPanZoomController();
 
+    /**
+     * Sets the clear color used when rendering the session.
+     * This color will be visible before content is rendered.
+     *
+     * @param color The clear color to set, in ARGB format. Default white.
+     */
+    void setClearColor(int color);
+
+    /**
+     * The current clear color.
+     *
+     * @return The current clear color, in ARGB format.
+     */
+    int getClearColor();
 
     /**
      * Set the content callback handler. This will replace the current handler.

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -575,6 +575,12 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         WSession session = WFactory.createSession(settings);
         setupSessionListeners(session);
 
+        if (settings.getUsePrivateMode()) {
+            session.setClearColor(mContext.getColor(R.color.window_private_clear_color));
+        } else {
+            session.setClearColor(mContext.getColor(R.color.window_blank_clear_color));
+        }
+
         return session;
     }
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -44,6 +44,6 @@
     <color name="smoke">#f5f6fa</color>
     <color name="window_border_hover">@color/azure</color>
     <color name="window_border_click">#2bd2ee</color>
-    <color name="window_blank_clear_color">#5d5d5d</color>
+    <color name="window_blank_clear_color">@color/void_color</color>
     <color name="window_private_clear_color">#331a50</color>
 </resources>


### PR DESCRIPTION
Add API to control the clear color displayed by the session before content is rendered.

The functionality is implemented for Gecko, but Chromium needs further changes at the native library level.

Set different clear colors for regular and private browsing.