### PR TITLE
Add New Tab JSON classes to proguard

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -54,6 +54,11 @@
 -keep class com.igalia.wolvic.browser.engine.** {*;} # Keep state clases used by gson.
 -keep class com.igalia.wolvic.utils.RemoteProperties {*;} # Keep state clases used by gson.
 -keep class com.igalia.wolvic.utils.Environment {*;} # Keep state clases used by gson.
+-keep class com.igalia.wolvic.utils.RemoteExperiences {*;} # Keep remote experience classes used by gson.
+-keep class com.igalia.wolvic.utils.Category {*;} # Keep remote experience classes used by gson.
+-keep class com.igalia.wolvic.utils.Experience {*;} # Keep remote experience classes used by gson.
+-keep class com.igalia.wolvic.utils.RemoteAnnouncements {*;} # Keep announcement classes used by gson.
+-keep class com.igalia.wolvic.utils.Announcement {*;} # Keep announcement classes used by gson.
 -keep class com.google.gson.reflect.TypeToken { *; }    # Keep this specific gson class
 -keep class * extends com.google.gson.reflect.TypeToken # and its descendants.
 


### PR DESCRIPTION
We define several classes that are used to parse the JSON files containing the experiences and announcements in the New Tab. These classes need to be explicitly added to ProGuard rules so they are available in release builds.