### PR TITLE
SingleEditSetting only calls the listener on save

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/settings/SingleEditSetting.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/settings/SingleEditSetting.java
@@ -118,13 +118,17 @@ public class SingleEditSetting extends RelativeLayout {
             mAudio.playSound(AudioEngine.Sound.CLICK);
         }
 
+        // If the edit field was visible when the click happened, this is a "save" action.
+        boolean isCurrentlyEditing = mEdit1.getVisibility() == View.VISIBLE;
+
         mText1.setVisibility(mEdit1.getVisibility());
         mEdit1.setVisibility(mEdit1.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
         @StringRes int buttonText = mEdit1.getVisibility() == View.VISIBLE ?
                 R.string.developer_options_save : R.string.developer_options_edit;
         mButton.setText(buttonText);
 
-        if (mListener != null) {
+        // Only call the listener when the user clicked the "save" button.
+        if (isCurrentlyEditing && mListener != null) {
             mListener.onClick(v);
         }
 
@@ -156,7 +160,7 @@ public class SingleEditSetting extends RelativeLayout {
         mEdit1.setHint(hint);
     }
 
-    public void setOnClickListener(OnClickListener aListener) {
+    public void setOnSaveClickedListener(OnClickListener aListener) {
         mListener = aListener;
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/DisplayOptionsView.java
@@ -117,19 +117,19 @@ class DisplayOptionsView extends SettingsView {
         mBinding.homepageEdit.setHint1(getContext().getString(R.string.homepage_hint, getContext().getString(R.string.app_name)));
         mBinding.homepageEdit.setDefaultFirstValue(mDefaultHomepageUrl);
         mBinding.homepageEdit.setFirstText(SettingsStore.getInstance(getContext()).getHomepage());
-        mBinding.homepageEdit.setOnClickListener(mHomepageListener);
+        mBinding.homepageEdit.setOnSaveClickedListener(mHomepageListener);
         setHomepage(SettingsStore.getInstance(getContext()).getHomepage());
 
         mBinding.densityEdit.setHint1(String.valueOf(SettingsStore.DISPLAY_DENSITY_DEFAULT));
         mBinding.densityEdit.setDefaultFirstValue(String.valueOf(SettingsStore.DISPLAY_DENSITY_DEFAULT));
         mBinding.densityEdit.setFirstText(Float.toString(SettingsStore.getInstance(getContext()).getDisplayDensity()));
-        mBinding.densityEdit.setOnClickListener(mDensityListener);
+        mBinding.densityEdit.setOnSaveClickedListener(mDensityListener);
         setDisplayDensity(SettingsStore.getInstance(getContext()).getDisplayDensity());
 
         mBinding.dpiEdit.setHint1(String.valueOf(SettingsStore.DISPLAY_DPI_DEFAULT));
         mBinding.dpiEdit.setDefaultFirstValue(String.valueOf(SettingsStore.DISPLAY_DPI_DEFAULT));
         mBinding.dpiEdit.setFirstText(Integer.toString(SettingsStore.getInstance(getContext()).getDisplayDpi()));
-        mBinding.dpiEdit.setOnClickListener(mDpiListener);
+        mBinding.dpiEdit.setOnSaveClickedListener(mDpiListener);
         setDisplayDpi(SettingsStore.getInstance(getContext()).getDisplayDpi());
     }
 
@@ -421,10 +421,10 @@ class DisplayOptionsView extends SettingsView {
         if (mBinding.homepageEdit.getVisibility() != VISIBLE) {
             return;
         }
-        mBinding.homepageEdit.setOnClickListener(null);
+        mBinding.homepageEdit.setOnSaveClickedListener(null);
         mBinding.homepageEdit.setFirstText(newHomepage);
         SettingsStore.getInstance(getContext()).setHomepage(newHomepage);
-        mBinding.homepageEdit.setOnClickListener(mHomepageListener);
+        mBinding.homepageEdit.setOnSaveClickedListener(mHomepageListener);
     }
 
     private void setUaMode(int checkId, boolean doApply) {
@@ -457,7 +457,7 @@ class DisplayOptionsView extends SettingsView {
     }
 
     private boolean setDisplayDensity(float newDensity) {
-        mBinding.densityEdit.setOnClickListener(null);
+        mBinding.densityEdit.setOnSaveClickedListener(null);
         boolean restart = false;
         float prevDensity = SettingsStore.getInstance(getContext()).getDisplayDensity();
         if (newDensity <= 0) {
@@ -468,13 +468,13 @@ class DisplayOptionsView extends SettingsView {
             restart = true;
         }
         mBinding.densityEdit.setFirstText(Float.toString(newDensity));
-        mBinding.densityEdit.setOnClickListener(mDensityListener);
+        mBinding.densityEdit.setOnSaveClickedListener(mDensityListener);
 
         return restart;
     }
 
     private boolean setDisplayDpi(int newDpi) {
-        mBinding.dpiEdit.setOnClickListener(null);
+        mBinding.dpiEdit.setOnSaveClickedListener(null);
         boolean restart = false;
         int prevDpi = SettingsStore.getInstance(getContext()).getDisplayDpi();
         if (newDpi < SettingsStore.DISPLAY_DPI_MIN || newDpi > SettingsStore.DISPLAY_DPI_MAX) {
@@ -485,7 +485,7 @@ class DisplayOptionsView extends SettingsView {
             restart = true;
         }
         mBinding.dpiEdit.setFirstText(Integer.toString(newDpi));
-        mBinding.dpiEdit.setOnClickListener(mDpiListener);
+        mBinding.dpiEdit.setOnSaveClickedListener(mDpiListener);
 
         return restart;
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/FxAAccountOptionsView.java
@@ -86,7 +86,7 @@ class FxAAccountOptionsView extends SettingsView {
         mBinding.deviceNameEdit.setHint1(DeviceType.getDeviceName(getContext()));
         mBinding.deviceNameEdit.setDefaultFirstValue(DeviceType.getDeviceName(getContext()));
         mBinding.deviceNameEdit.setFirstText(SettingsStore.getInstance(getContext()).getDeviceName());
-        mBinding.deviceNameEdit.setOnClickListener(mDeviceNameListener);
+        mBinding.deviceNameEdit.setOnSaveClickedListener(mDeviceNameListener);
         setDeviceName(SettingsStore.getInstance(getContext()).getDeviceName(), false);
 
         mBinding.setIsSyncing(mAccounts.isSyncing());
@@ -213,7 +213,7 @@ class FxAAccountOptionsView extends SettingsView {
     }
 
     private void setDeviceName(String newDeviceName, boolean doApply) {
-        mBinding.deviceNameEdit.setOnClickListener(null);
+        mBinding.deviceNameEdit.setOnSaveClickedListener(null);
         if (newDeviceName.isEmpty()) {
             newDeviceName = DeviceType.getDeviceName(getContext());
         }
@@ -235,7 +235,7 @@ class FxAAccountOptionsView extends SettingsView {
             }
         }
         mBinding.deviceNameEdit.setFirstText(newDeviceName);
-        mBinding.deviceNameEdit.setOnClickListener(mDeviceNameListener);
+        mBinding.deviceNameEdit.setOnSaveClickedListener(mDeviceNameListener);
     }
 
     void updateCurrentAccountState() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LoginEditOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/LoginEditOptionsView.java
@@ -70,13 +70,13 @@ class LoginEditOptionsView extends SettingsView {
 
         mBinding.usernameEdit.setHint1(getContext().getString(R.string.username_hint));
         mBinding.usernameEdit.setFirstText(mLogin.getUsername());
-        mBinding.usernameEdit.setOnClickListener(mUsernameListener);
+        mBinding.usernameEdit.setOnSaveClickedListener(mUsernameListener);
         setUsername(mLogin.getUsername());
 
         mBinding.passwordEdit.setHint1(getContext().getString(R.string.password_hint));
         mBinding.passwordEdit.setFirstText(mLogin.getPassword());
         mBinding.passwordEdit.setPasswordToggleVisibility(View.VISIBLE);
-        mBinding.passwordEdit.setOnClickListener(mPasswordListener);
+        mBinding.passwordEdit.setOnSaveClickedListener(mPasswordListener);
         setPassword(mLogin.getPassword());
     }
 
@@ -135,9 +135,9 @@ class LoginEditOptionsView extends SettingsView {
     };
 
     private void setUsername(String username) {
-        mBinding.usernameEdit.setOnClickListener(null);
+        mBinding.usernameEdit.setOnSaveClickedListener(null);
         mBinding.usernameEdit.setFirstText(username);
-        mBinding.usernameEdit.setOnClickListener(mUsernameListener);
+        mBinding.usernameEdit.setOnSaveClickedListener(mUsernameListener);
         final Login newLogin = mLogin.copy(
                 mLogin.getGuid(),
                 username,
@@ -167,9 +167,9 @@ class LoginEditOptionsView extends SettingsView {
 
         } else {
             mBinding.passwordError.setVisibility(View.GONE);
-            mBinding.passwordEdit.setOnClickListener(null);
+            mBinding.passwordEdit.setOnSaveClickedListener(null);
             mBinding.passwordEdit.setFirstText(password);
-            mBinding.passwordEdit.setOnClickListener(mPasswordListener);
+            mBinding.passwordEdit.setOnSaveClickedListener(mPasswordListener);
             final Login newLogin = mLogin.copy(
                     mLogin.getGuid(),
                     mLogin.getUsername(),


### PR DESCRIPTION
SingleEditSetting used to call the same listener when the user clicked both the "Edit" and "Save" buttons, which caused unexpected data updates.

With this change, the listener is only called when the "Save" button is clicked.