### PR TITLE
Prevent errors when the custom homepage is an invalid URL

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -738,6 +738,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
     public String getHomeUri() {
         String homepage = SettingsStore.getInstance(mContext).getHomepage();
+        homepage = UrlUtils.urlForText(mContext, homepage, getWSession().getUrlUtilsVisitor());
         if (homepage.equals(mContext.getString(R.string.HOMEPAGE_URL)) && mState.mRegion != null) {
             homepage = homepage + "?region=" + mState.mRegion;
         }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -419,7 +419,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             mSession.loadPrivateBrowsingPage();
 
         } else {
-            mSession.loadUri(SettingsStore.getInstance(getContext()).getHomepage());
+            mSession.loadUri(mSession.getHomeUri());
         }
     }
 


### PR DESCRIPTION
Prevent errors when the stored homepage is not a correct URL, which typically happens because the user forgets to add the protocol ("https://", etc.).

For instance, "example.com" would fail as it is not a proper URL, but with this change it gets correctly loaded as "http://example.com".