### PR TITLE
Specific dimensions for MagicLeap

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -397,6 +397,10 @@ android {
             buildConfigField "Boolean", "WEBVIEW_IN_PHONE_UI", "true"
             buildConfigField "Boolean", "CN_FIRST_RUN_IN_PHONE_UI", "true"
         }
+
+        magicleap {
+            dimension "store"
+        }
     }
 
     variantFilter { variant ->
@@ -421,6 +425,10 @@ android {
 
         // MetaStore only apply to oculusvr builds.
         if (store == 'metaStore' && !platform.startsWith('oculusvr'))
+            variant.setIgnore(true);
+
+        // MagicLeap only for AOSP x64 builds.
+        if (store == 'magicleap' && (platform != 'aosp' || abi != 'x64'))
             variant.setIgnore(true);
         
     }

--- a/app/src/aospMagicleap/res/values/dimen.xml
+++ b/app/src/aospMagicleap/res/values/dimen.xml
@@ -1,0 +1,11 @@
+<resources>
+    <item name="window_world_width" format="float" type="dimen">3.0</item>
+    <item name="window_world_z_min" format="float" type="dimen">-3.5</item>
+    <item name="window_world_z_max" format="float" type="dimen">-4.5</item>
+
+    <item name="browser_children_z_distance" format="float" type="dimen">0.5</item>
+    <item name="tray_world_z" format="float" type="dimen">-2.5</item>
+    <item name="keyboard_z" format="float" type="dimen">-2.5</item>
+    <item name="settings_world_z" format="float" type="dimen">-2.5</item>
+    <item name="media_controls_world_z" format="float" type="item">1.5</item>
+</resources>


### PR DESCRIPTION
Add "magicleap" as one of our "store" build dimensions. It will only be used for AOSP platform builds.

Add specific dimension values for MagicLeap devices.