### PR TITLE
Descriptive tab titles for local pages

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/components/BrowserIconsHelper.kt
+++ b/app/src/common/shared/com/igalia/wolvic/browser/components/BrowserIconsHelper.kt
@@ -2,7 +2,9 @@ package com.igalia.wolvic.browser.components
 
 import android.content.Context
 import android.widget.ImageView
+import com.igalia.wolvic.R
 import com.igalia.wolvic.browser.engine.EngineProvider
+import com.igalia.wolvic.utils.UrlUtils
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.state.store.BrowserStore
@@ -11,7 +13,8 @@ import mozilla.components.concept.engine.Engine
 // Small helper class to simplify getting favicons.
 class BrowserIconsHelper(context: Context, engine: Engine, store: BrowserStore) {
 
-    private val browserIcons: BrowserIcons;
+    private val browserIcons: BrowserIcons
+    private val aboutPageFavicon = R.mipmap.ic_launcher
 
     init {
         browserIcons =
@@ -24,8 +27,12 @@ class BrowserIconsHelper(context: Context, engine: Engine, store: BrowserStore) 
         url: String,
         size: IconRequest.Size = IconRequest.Size.DEFAULT
     ) {
-        val request = IconRequest(url, size, emptyList(), null, false)
-        browserIcons.loadIntoView(view, request, null, null)
+        if (UrlUtils.isAboutPage(url)) {
+            view.setImageResource(aboutPageFavicon)
+        } else {
+            val request = IconRequest(url, size, emptyList(), null, false)
+            browserIcons.loadIntoView(view, request, null, null)
+        }
     }
 
     fun loadIntoView(

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
@@ -148,14 +148,9 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
             return;
         }
 
-        if (url == null || UrlUtils.isAboutPage(url)) {
-            mSubtitle.setText(null);
-            mFavicon.setImageDrawable(null);
-        } else {
-            mSubtitle.setText(UrlUtils.stripProtocol(mSession.getCurrentUri()));
-            SessionStore.get().getBrowserIcons().loadIntoView(
-                    mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
-        }
+        mSubtitle.setText(UrlUtils.isAboutPage(url) ? "" : UrlUtils.stripProtocol(url));
+        SessionStore.get().getBrowserIcons().loadIntoView(
+                mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
     }
 
     private String getTitleForDisplay(String url, String title) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
@@ -20,6 +20,7 @@ import com.igalia.wolvic.browser.engine.Session;
 import com.igalia.wolvic.browser.engine.SessionStore;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WindowWidget;
+import com.igalia.wolvic.ui.widgets.Windows;
 import com.igalia.wolvic.utils.StringUtils;
 import com.igalia.wolvic.utils.UrlUtils;
 
@@ -102,10 +103,7 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
 
             String title = mSession.getCurrentTitle();
             String uri = mSession.getCurrentUri();
-            if (StringUtils.isEmpty(title)) {
-                title = UrlUtils.stripCommonSubdomains(UrlUtils.getHost(uri));
-            }
-            mTitle.setText(title);
+            mTitle.setText(getTitleForDisplay(uri, title));
             mSubtitle.setText(UrlUtils.stripProtocol(uri));
 
             SessionStore.get().getBrowserIcons().loadIntoView(
@@ -141,7 +139,7 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
         if (mSession == null || mSession.getWSession() != session) {
             return;
         }
-        mTitle.setText(title);
+        mTitle.setText(getTitleForDisplay(mSession.getCurrentUri(), title));
     }
 
     @Override
@@ -150,7 +148,7 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
             return;
         }
 
-        if (url == null) {
+        if (url == null || UrlUtils.isAboutPage(url)) {
             mSubtitle.setText(null);
             mFavicon.setImageDrawable(null);
         } else {
@@ -158,6 +156,14 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
             SessionStore.get().getBrowserIcons().loadIntoView(
                     mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
         }
+    }
+
+    private String getTitleForDisplay(String url, String title) {
+        Windows.ContentType contentType = UrlUtils.getContentType(url);
+        if (contentType == Windows.ContentType.WEB_CONTENT) {
+            return StringUtils.isEmpty(title) ? UrlUtils.stripCommonSubdomains(UrlUtils.getHost(url)) : title;
+        }
+        return getContext().getString(contentType.titleResId);
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.preference.PreferenceManager;
 
 import com.google.gson.Gson;
@@ -167,20 +168,22 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     private ConnectivityReceiver mConnectivityReceived;
 
     public enum ContentType {
-        WEB_CONTENT(""),
-        BOOKMARKS(UrlUtils.ABOUT_BOOKMARKS),
-        WEB_APPS(UrlUtils.ABOUT_WEBAPPS),
-        HISTORY(UrlUtils.ABOUT_HISTORY),
-        DOWNLOADS(UrlUtils.ABOUT_DOWNLOADS),
-        ADDONS(UrlUtils.ABOUT_ADDONS),
-        NOTIFICATIONS(UrlUtils.ABOUT_NOTIFICATIONS),
-        NEW_TAB(UrlUtils.ABOUT_NEWTAB);
+        WEB_CONTENT("", android.R.string.untitled),
+        BOOKMARKS(UrlUtils.ABOUT_BOOKMARKS, R.string.url_bookmarks_title),
+        WEB_APPS(UrlUtils.ABOUT_WEBAPPS, R.string.web_apps_title),
+        HISTORY(UrlUtils.ABOUT_HISTORY, R.string.history_title),
+        DOWNLOADS(UrlUtils.ABOUT_DOWNLOADS, R.string.url_downloads_title),
+        ADDONS(UrlUtils.ABOUT_ADDONS, R.string.url_addons_title),
+        NOTIFICATIONS(UrlUtils.ABOUT_NOTIFICATIONS, R.string.notifications_title),
+        NEW_TAB(UrlUtils.ABOUT_NEWTAB, R.string.url_new_tab_title);
 
         @NonNull
         public final String URL;
+        public final @StringRes int titleResId;
 
-        ContentType(@NonNull String url) {
+        ContentType(@NonNull String url, int titleResId) {
             this.URL = url;
+            this.titleResId = titleResId;
         }
 
         public boolean isLibraryContent() {


### PR DESCRIPTION
Display an informative title in the tabs bar for local pages.

We associate a title resource ID with each Windows.ContentType and use it when updating the tabs bar UI.

Fixes: https://github.com/Igalia/wolvic/issues/1833