### PR TITLE
Dismiss announcements on New Tab

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -41,10 +41,12 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import mozilla.components.concept.fetch.Request;
@@ -271,6 +273,38 @@ public class SettingsStore {
                 Log.d(LOGTAG, "Remote data fetch error for " + endpoint + ": " + e.getLocalizedMessage());
             }
         });
+    }
+
+    public Set<String> getDismissedAnnouncementIds() {
+        Set<String> dismissedIds = new HashSet<>();
+        String json = mPrefs.getString(mContext.getString(R.string.settings_key_dismissed_remote_announcements), "[]");
+        try {
+            JSONArray jsonArray = new JSONArray(json);
+            for (int i = 0; i < jsonArray.length(); i++) {
+                dismissedIds.add(jsonArray.getString(i));
+            }
+        } catch (Exception e) {
+            Log.e(LOGTAG, "Error loading dismissed announcements: " + e.getMessage());
+        }
+        return dismissedIds;
+    }
+
+    public void addDismissedAnnouncementId(String announcementId) {
+        Set<String> dismissedIds = getDismissedAnnouncementIds();
+        if (dismissedIds.contains(announcementId)) {
+            return;
+        }
+
+        dismissedIds.add(announcementId);
+
+        JSONArray jsonArray = new JSONArray();
+        for (String id : dismissedIds) {
+            jsonArray.put(id);
+        }
+
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putString(mContext.getString(R.string.settings_key_dismissed_remote_announcements), jsonArray.toString());
+        editor.apply();
     }
 
     public boolean isCrashReportingEnabled() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/AnnouncementsAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/AnnouncementsAdapter.java
@@ -43,6 +43,7 @@ public class AnnouncementsAdapter extends RecyclerView.Adapter<RecyclerView.View
 
     public interface ClickListener {
         void onClicked(Announcement announcement);
+        void onDismissed(Announcement announcement);
     }
 
     public AnnouncementsAdapter(Context context) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/NewTabView.java
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.GridLayoutManager;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.VRBrowserActivity;
+import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.components.TopSitesAdapter;
 import com.igalia.wolvic.browser.components.TopSitesHelper;
 import com.igalia.wolvic.browser.engine.Session;
@@ -21,6 +22,7 @@ import com.igalia.wolvic.ui.adapters.AnnouncementsAdapter;
 import com.igalia.wolvic.ui.adapters.ExperiencesAdapter;
 import com.igalia.wolvic.ui.adapters.TopSitesAdapterImpl;
 import com.igalia.wolvic.ui.viewmodel.SettingsViewModel;
+import com.igalia.wolvic.utils.Announcement;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import mozilla.components.feature.top.sites.TopSite;
@@ -62,15 +64,11 @@ public class NewTabView extends FrameLayout {
 
         // Announcements
         mAnnouncementsAdapter = new AnnouncementsAdapter(getContext());
-        mAnnouncementsAdapter.setClickListener(announcement -> {
-            if (announcement.getLink() != null) {
-                openUrl(announcement.getLink());
-            }
-        });
+        mAnnouncementsAdapter.setClickListener(mAnnouncementsClickListener);
         mBinding.announcementsList.setAdapter(mAnnouncementsAdapter);
         mBinding.announcementsList.setHasFixedSize(false);
 
-        mSettingsViewModel.getAnnouncements().observe((VRBrowserActivity) getContext(), remoteAnnouncements -> {
+        mSettingsViewModel.getVisibleAnnouncements().observe((VRBrowserActivity) getContext(), remoteAnnouncements -> {
             mAnnouncementsAdapter.updateAnnouncements(remoteAnnouncements);
         });
 
@@ -96,6 +94,21 @@ public class NewTabView extends FrameLayout {
             mExperiencesAdapter.updateExperiences(experiences);
         });
     }
+
+    private final AnnouncementsAdapter.ClickListener mAnnouncementsClickListener = new AnnouncementsAdapter.ClickListener() {
+        @Override
+        public void onClicked(Announcement announcement) {
+            if (announcement.getLink() != null) {
+                openUrl(announcement.getLink());
+            }
+        }
+
+        @Override
+        public void onDismissed(@NonNull Announcement announcement) {
+            SettingsStore.getInstance(getContext()).addDismissedAnnouncementId(announcement.getId());
+            mSettingsViewModel.updateVisibleAnnouncements();
+        }
+    };
 
     private final TopSitesAdapter.ClickListener mTopSitesClickListener =
             new TopSitesAdapter.ClickListener() {

--- a/app/src/main/res/layout/announcement_item.xml
+++ b/app/src/main/res/layout/announcement_item.xml
@@ -28,32 +28,52 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
+            <RelativeLayout
+                android:id="@+id/top_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true">
+
+                <ImageView
+                    android:id="@+id/announcement_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/announcement_item_image_height"
+                    android:layout_centerInParent="true"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/empty_drawable" />
+
+                <com.igalia.wolvic.ui.views.UIButton
+                    android:id="@+id/dismiss_button"
+                    style="?attr/headerBarButtonStyle"
+                    android:layout_alignParentTop="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_margin="4dp"
+                    android:onClick="@{(view) -> listener.onDismissed(announcement)}"
+                    android:src="@drawable/ic_icon_exit"
+                    android:tint="@color/midnight" />
+            </RelativeLayout>
+
             <ImageView
                 android:id="@+id/link_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:layout_below="@id/announcement_image"
+                android:layout_below="@id/top_content"
                 android:layout_alignParentEnd="true"
-                android:layout_margin="4dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="12dp"
                 android:scaleType="fitCenter"
                 android:src="@drawable/mozac_ic_open_in" />
-
-            <ImageView
-                android:id="@+id/announcement_image"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/announcement_item_image_height"
-                android:scaleType="centerCrop"
-                android:src="@drawable/empty_drawable" />
 
             <TextView
                 android:id="@+id/announcement_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/announcement_image"
+                android:layout_below="@id/top_content"
                 android:minHeight="32dp"
                 android:paddingStart="12dp"
                 android:paddingTop="12dp"
-                android:paddingEnd="24dp"
+                android:paddingEnd="36dp"
                 android:textColor="@color/library_panel_title_text_color"
                 android:textSize="@dimen/top_site_item_title_text_size"
                 android:textStyle="bold"

--- a/app/src/main/res/layout/new_tab.xml
+++ b/app/src/main/res/layout/new_tab.xml
@@ -50,7 +50,7 @@
                 android:text="@string/announcements_title"
                 android:textColor="@color/fog"
                 android:textSize="18sp"
-                android:visibility="@{settingsmodel.announcements.announcements.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                android:visibility="@{settingsmodel.visibleAnnouncements.announcements.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/logo" />
@@ -64,7 +64,7 @@
                 android:foregroundGravity="center_horizontal"
                 android:nestedScrollingEnabled="false"
                 android:scrollbars="none"
-                android:visibility="@{settingsmodel.announcements.announcements.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                android:visibility="@{settingsmodel.visibleAnnouncements.announcements.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
                 app:customFastScrollEnabled="false"
                 app:layoutManager="com.igalia.wolvic.ui.views.NonScrollingGridLayoutManager"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -73,6 +73,7 @@
     <string name="settings_key_remote_props_version_name" translatable="false">settings_key_remote_props_version_name</string>
     <string name="settings_key_remote_props" translatable="false">settings_key_remote_props</string>
     <string name="settings_key_remote_announcements" translatable="false">settings_key_remote_announcements</string>
+    <string name="settings_key_dismissed_remote_announcements" translatable="false">settings_key_dismissed_remote_announcements</string>
     <string name="settings_key_remote_experiences" translatable="false">settings_key_remote_experiences</string>
     <string name="settings_key_heyvr_experiences" translatable="false">settings_key_heyvr_experiences</string>
     <string name="settings_key_autocomplete" translatable="false">settings_key_autocomplete</string>


### PR DESCRIPTION
Add onDismissed to AnnouncementsAdapter.ClickListener and call it when the user clicks on the "close" button on the announcement.

SettingsStore keeps a list of dismissed announcements so we can avoid showing those that the user has already closed.

SettingsViewModel.visibleAnnouncements contains a filtered list of announcements, making it easier to keep the UI up to date.

Update layout of announcement item.