### PR TITLE
Hide native UI panels when changing sessions

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -1265,22 +1265,18 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             mViewModel.setIsDesktopMode(mSession.getUaMode() == WSessionSettings.USER_AGENT_MODE_DESKTOP);
 
             if (hidePanel) {
-                if (oldSession != null) {
-                    onCurrentSessionChange(oldSession.getWSession(), aSession.getWSession());
-                } else {
-                    onCurrentSessionChange(null, aSession.getWSession());
-                }
+                hideNewTabPanel(true);
+                hideLibraryPanel(true);
+                onCurrentSessionChange((oldSession != null ? oldSession.getWSession() : null), aSession.getWSession());
             }
 
             for (WindowListener listener: mListeners) {
                 listener.onSessionChanged(oldSession, aSession);
             }
-        }
-        mCaptureOnPageStop = false;
-
-        if (hidePanel) {
+        } else if (hidePanel) {
             closeLibrary();
         }
+        mCaptureOnPageStop = false;
     }
 
     public void setDrmUsed(boolean isEnabled) {


### PR DESCRIPTION
Hide the native UI panels, like New Tab, when changing the session associated to a WindowWidget.

This fixes a crash when switching between two separate sessions, both displaying the New Tab UI.

Fixes https://github.com/Igalia/wolvic/issues/1841