### PR TITLE
[Vision Glass] Remove redundant bindings initialisation

### DIFF
--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -282,7 +282,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
 
         ContextThemeWrapper themedContext = new ContextThemeWrapper(this, R.style.Theme_WolvicPhone);
         LayoutInflater themedInflater = getLayoutInflater().cloneInContext(themedContext);
-        mBinding = DataBindingUtil.setContentView(this, R.layout.visionglass_layout);
         mBinding = DataBindingUtil.inflate(themedInflater, R.layout.visionglass_layout, null, false);
         setContentView(mBinding.getRoot());
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);


### PR DESCRIPTION
Remove a redundant line that initialises the bindings unnecessarily, as the next line will initialise them again with the correct theme.