### PR TITLE
Fix first paint restoration in WindowWidget

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -549,14 +549,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             setView(mLibrary, switchSurface, VIEW_BRIGHTNESS_DIMMED);
             mLibrary.selectPanel(contentType);
             mLibrary.onShow();
-            if (mRestoreFirstPaint == null) {
+            if (mRestoreFirstPaint == null && !isFirstPaintReady() && (mFirstDrawCallback != null) && (mSurface != null)) {
+                final Runnable firstDrawCallback = mFirstDrawCallback;
                 onFirstContentfulPaint(mSession.getWSession());
                 mRestoreFirstPaint = () -> {
                     setFirstPaintReady(false);
-                    if (mFirstDrawCallback != null) {
-                        final Runnable firstDrawCallback = mFirstDrawCallback;
-                        setFirstDrawCallback(firstDrawCallback);
-                    }
+                    setFirstDrawCallback(firstDrawCallback);
                     if (mWidgetManager != null) {
                         mWidgetManager.updateWidget(WindowWidget.this);
                     }
@@ -603,14 +601,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.setIsFindInPage(false);
         if (mView == null) {
             setView(mNewTab, switchSurface, VIEW_BRIGHTNESS_UNCHANGED);
-            if (mRestoreFirstPaint == null) {
+            if (mRestoreFirstPaint == null && !isFirstPaintReady() && (mFirstDrawCallback != null) && (mSurface != null)) {
+                final Runnable firstDrawCallback = mFirstDrawCallback;
                 onFirstContentfulPaint(mSession.getWSession());
                 mRestoreFirstPaint = () -> {
                     setFirstPaintReady(false);
-                    if (mFirstDrawCallback != null) {
-                        final Runnable firstDrawCallback = mFirstDrawCallback;
-                        setFirstDrawCallback(firstDrawCallback);
-                    }
+                    setFirstDrawCallback(firstDrawCallback);
                     if (mWidgetManager != null) {
                         mWidgetManager.updateWidget(WindowWidget.this);
                     }


### PR DESCRIPTION
Restores the previous behavior for first paint handling in showLibraryPanel and showNewTabPanel by adding back additional checks.

This prevents graphical issues on Vision Glass and other systems.