### PR TITLE
Fix resource leaks when switching between tabs

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -549,14 +549,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             setView(mLibrary, switchSurface, VIEW_BRIGHTNESS_DIMMED);
             mLibrary.selectPanel(contentType);
             mLibrary.onShow();
-            if (mRestoreFirstPaint == null) {
+            if (mRestoreFirstPaint == null && !isFirstPaintReady() && (mFirstDrawCallback != null) && (mSurface != null)) {
+                final Runnable firstDrawCallback = mFirstDrawCallback;
                 onFirstContentfulPaint(mSession.getWSession());
                 mRestoreFirstPaint = () -> {
                     setFirstPaintReady(false);
-                    if (mFirstDrawCallback != null) {
-                        final Runnable firstDrawCallback = mFirstDrawCallback;
-                        setFirstDrawCallback(firstDrawCallback);
-                    }
+                    setFirstDrawCallback(firstDrawCallback);
                     if (mWidgetManager != null) {
                         mWidgetManager.updateWidget(WindowWidget.this);
                     }
@@ -603,14 +601,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mViewModel.setIsFindInPage(false);
         if (mView == null) {
             setView(mNewTab, switchSurface, VIEW_BRIGHTNESS_UNCHANGED);
-            if (mRestoreFirstPaint == null) {
+            if (mRestoreFirstPaint == null && !isFirstPaintReady() && (mFirstDrawCallback != null) && (mSurface != null)) {
+                final Runnable firstDrawCallback = mFirstDrawCallback;
                 onFirstContentfulPaint(mSession.getWSession());
                 mRestoreFirstPaint = () -> {
                     setFirstPaintReady(false);
-                    if (mFirstDrawCallback != null) {
-                        final Runnable firstDrawCallback = mFirstDrawCallback;
-                        setFirstDrawCallback(firstDrawCallback);
-                    }
+                    setFirstDrawCallback(firstDrawCallback);
                     if (mWidgetManager != null) {
                         mWidgetManager.updateWidget(WindowWidget.this);
                     }


### PR DESCRIPTION
Fix a race condition that creates a resource leak which ends up crashing the application.

When we switch between two tabs showing the New Tab we first request a new Surface for the new session, followed by a Surface for the native UI.

However, both Surfaces might arrive once the native UI is already in place. In that case, both Surfaces will be applied to the native UI while the browser session keeps a reference to the Surface that belonged to the previous session, which might cause errors.

To fix this, when displaying the native UI we will clear `mSurface` after pausing the compositor when displaying the native UI.

Additionally, we move `setupListeners()` towards the end of `setSession()` because it will cause session listeners to be called synchronously with the new values and we need to have a consistent state at that point.

Fixes https://github.com/Igalia/wolvic/issues/1841
