### PR TITLE
Make "Clear History" dialog taller

### DIFF
--- a/app/src/main/res/layout/clear_history_dialog.xml
+++ b/app/src/main/res/layout/clear_history_dialog.xml
@@ -2,14 +2,25 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
-        android:id="@+id/clearHistoryRadio"
+    <com.igalia.wolvic.ui.views.CustomScrollView
+        android:id="@+id/scrollbar"
+        style="@style/customScrollViewStyle"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_marginTop="10dp"
-        app:layout="@layout/setting_radio_group_v"
-        app:description="@string/history_clear_time_range"
-        app:options="@array/clear_cache_options"
-        app:values="@array/clear_cache_options_values" />
+        android:layout_marginBottom="10dp"
+        android:paddingStart="0dp"
+        android:paddingEnd="30dp">
+
+        <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
+            android:id="@+id/clearHistoryRadio"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:description="@string/history_clear_time_range"
+            app:layout="@layout/setting_radio_group_v"
+            app:options="@array/clear_cache_options"
+            app:values="@array/clear_cache_options_values" />
+
+    </com.igalia.wolvic.ui.views.CustomScrollView>
 
 </layout>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -272,7 +272,7 @@
 
     <!-- General 2nd level settings dimensions -->
     <dimen name="settings_dialog_width">600dp</dimen>
-    <dimen name="settings_dialog_height">360dp</dimen>
+    <dimen name="settings_dialog_height">400dp</dimen>
 
     <!-- Privacy settings -->
     <dimen name="privacy_options_height">490dp</dimen>


### PR DESCRIPTION
Make the "Clear History" dialog slightly taller
so all options can be visible.

Fixes https://github.com/Igalia/wolvic/issues/1853