### PR TITLE
Fix a crash on suspended sessions

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -738,7 +738,9 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
     public String getHomeUri() {
         String homepage = SettingsStore.getInstance(mContext).getHomepage();
-        homepage = UrlUtils.urlForText(mContext, homepage, getWSession().getUrlUtilsVisitor());
+        if (getWSession() != null) {
+            homepage = UrlUtils.urlForText(mContext, homepage, getWSession().getUrlUtilsVisitor());
+        }
         if (homepage.equals(mContext.getString(R.string.HOMEPAGE_URL)) && mState.mRegion != null) {
             homepage = homepage + "?region=" + mState.mRegion;
         }


### PR DESCRIPTION
Fix a NULL-pointer crash that happens when a restored Session has not been fully initialized yet and its associated WSession is still empty.