### PR TITLE
Prevent null pointer exceptions when getting the UrlUtilsVisitor

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -738,8 +738,9 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
     public String getHomeUri() {
         String homepage = SettingsStore.getInstance(mContext).getHomepage();
-        if (getWSession() != null) {
-            homepage = UrlUtils.urlForText(mContext, homepage, getWSession().getUrlUtilsVisitor());
+        WSession wSession = getWSession();
+        if (wSession != null) {
+            homepage = UrlUtils.urlForText(mContext, homepage, wSession.getUrlUtilsVisitor());
         }
         if (homepage.equals(mContext.getString(R.string.HOMEPAGE_URL)) && mState.mRegion != null) {
             homepage = homepage + "?region=" + mState.mRegion;

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -738,7 +738,9 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
 
     public String getHomeUri() {
         String homepage = SettingsStore.getInstance(mContext).getHomepage();
-        homepage = UrlUtils.urlForText(mContext, homepage, getWSession().getUrlUtilsVisitor());
+        if (getWSession() != null) {
+            homepage = UrlUtils.urlForText(mContext, homepage, getWSession().getUrlUtilsVisitor());
+        }
         if (homepage.equals(mContext.getString(R.string.HOMEPAGE_URL)) && mState.mRegion != null) {
             homepage = homepage + "?region=" + mState.mRegion;
         }


### PR DESCRIPTION
The getHomeUri() method was recently upgraded to better handle home page urls without scheme (i.e. https://). However it added a potential crash caused by a null pointer exception because it does not verify that getWSession() does not return null.