### PR TITLE
Initialize page title for error pages created with data URIs

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/InternalPages.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/InternalPages.java
@@ -137,7 +137,8 @@ public class InternalPages {
                 .replace("%messageLong%", context.getString(errorType.getMessageRes(), uri))
                 .replace("<ul>", "<ul role=\"presentation\">")
                 .replace("%css%", css)
-                .replace("%advancedSSLStyle%", showSSLAdvanced ? "block" : "none");
+                .replace("%advancedSSLStyle%", showSSLAdvanced ? "block" : "none")
+                .replace("%pageTitle%", uri != null ? uri : "");
 
         if (uri != null) {
             html = html.replace("%url%", uri);


### PR DESCRIPTION
We were not replacing the %pageTitle% placeholder because it was not visible anyway. However with the new vertical/horizontal tabs that is a problem.

Fixes #1858