### PR TITLE
Check if layers are enabled when deciding to update the window surface

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -424,7 +424,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     private void recreateWidgetSurfaceIfNeeded(float prevDensity) {
-        if (prevDensity != mWidgetPlacement.density || !isLayer())
+        if (prevDensity != mWidgetPlacement.density || !SettingsStore.getInstance(getContext()).getLayersEnabled())
             return;
 
         // If the densities are the same updateWidget won't generate a new surface as the resulting


### PR DESCRIPTION
When deciding to update the widget surface, the isLayer() method is unreliable because it can return false even if layers are enabled, for example if mSurface becomes null. With this change, we will use the settings for this check.

This fixes the bug that the Library is not shown with Chromium.