### PR TITLE
Chromium uses "chrome://newtab/" as New Tab URL

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
+++ b/app/src/common/shared/com/igalia/wolvic/utils/UrlUtils.java
@@ -13,6 +13,7 @@ import android.webkit.URLUtil;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.api.WSession;
@@ -189,7 +190,10 @@ public class UrlUtils {
         return url != null && url.equalsIgnoreCase(ABOUT_BOOKMARKS);
     }
 
-    public static final String ABOUT_NEWTAB = "about://newtab";
+    private static final String CHROMIUM_NEWTAB = "chrome://newtab/";
+    private static final String GECKO_NEWTAB = "about://newtab";
+    public static final String ABOUT_NEWTAB =
+            BuildConfig.FLAVOR_backend.equalsIgnoreCase("chromium") ? CHROMIUM_NEWTAB : GECKO_NEWTAB;
 
     public static boolean isNewTabUrl(@Nullable String url) {
         return url != null && url.equalsIgnoreCase(ABOUT_NEWTAB);


### PR DESCRIPTION
When using Chromium, the New Tab UI will be shown when the browser navigates to "chrome://newtab/" which is Chromium's default empty start page.

The reason for this change is that Chrome returns an error when we use the "about://newtab" URL and loads "chrome://newtab/" instead.

Fixes https://github.com/Igalia/wolvic/issues/1868