### PR TITLE
Correctly update tab title and subtitle

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/TabsBarItem.java
@@ -104,7 +104,7 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
             String title = mSession.getCurrentTitle();
             String uri = mSession.getCurrentUri();
             mTitle.setText(getTitleForDisplay(uri, title));
-            mSubtitle.setText(UrlUtils.stripProtocol(uri));
+            mSubtitle.setText(UrlUtils.isAboutPage(uri) ? "" : UrlUtils.stripProtocol(uri));
 
             SessionStore.get().getBrowserIcons().loadIntoView(
                     mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
@@ -148,7 +148,13 @@ public class TabsBarItem extends RelativeLayout implements WSession.ContentDeleg
             return;
         }
 
-        mSubtitle.setText(UrlUtils.isAboutPage(url) ? "" : UrlUtils.stripProtocol(url));
+        Windows.ContentType contentType = UrlUtils.getContentType(url);
+        if (contentType != Windows.ContentType.WEB_CONTENT) {
+            mTitle.setText(contentType.titleResId);
+            mSubtitle.setText("");
+        } else {
+            mSubtitle.setText(UrlUtils.stripProtocol(url));
+        }
         SessionStore.get().getBrowserIcons().loadIntoView(
                 mFavicon, mSession.getCurrentUri(), IconRequest.Size.DEFAULT);
     }


### PR DESCRIPTION
Update the subtitle correctly when the tab view is initally attached to the session.

Since the location callback might arrive after the title, for local URLs we update both title and subtitle.