### PR TITLE
Set the pressed status for the Settings button in the tray

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/TrayViewModel.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/viewmodel/TrayViewModel.java
@@ -30,7 +30,7 @@ public class TrayViewModel extends AndroidViewModel {
     private MutableLiveData<ObservableInt> leftControllerBatteryLevel;
     private MutableLiveData<ObservableInt> rightControllerIcon;
     private MutableLiveData<ObservableInt> rightControllerBatteryLevel;
-
+    private MutableLiveData<ObservableBoolean> settingsWidgetVisible;
 
     public TrayViewModel(@NonNull Application application) {
         super(application);
@@ -54,6 +54,7 @@ public class TrayViewModel extends AndroidViewModel {
         leftControllerBatteryLevel = new MutableLiveData<>(new ObservableInt(R.drawable.ic_icon_statusbar_indicator));
         rightControllerIcon = new MutableLiveData<>(new ObservableInt(R.drawable.ic_icon_statusbar_controller_generic));
         rightControllerBatteryLevel = new MutableLiveData<>(new ObservableInt(R.drawable.ic_icon_statusbar_indicator));
+        settingsWidgetVisible = new MutableLiveData<>(new ObservableBoolean(false));
     }
 
     Observer<ObservableBoolean> mIsVisibleObserver = new Observer<ObservableBoolean>() {
@@ -81,6 +82,7 @@ public class TrayViewModel extends AndroidViewModel {
         leftControllerBatteryLevel.setValue(leftControllerBatteryLevel.getValue());
         rightControllerIcon.setValue(rightControllerIcon.getValue());
         rightControllerBatteryLevel.setValue(rightControllerBatteryLevel.getValue());
+        settingsWidgetVisible.postValue(settingsWidgetVisible.getValue());
     }
 
     public void setIsMaxWindows(boolean isMaxWindows) {
@@ -202,5 +204,11 @@ public class TrayViewModel extends AndroidViewModel {
 
     public MutableLiveData<ObservableInt> getRightControllerBatteryLevel() {
         return rightControllerBatteryLevel;
+    }
+
+    public MutableLiveData<ObservableBoolean> getSettingsWidgetVisible() { return settingsWidgetVisible; }
+
+    public void setSettingsWidgetVisible(boolean visible) {
+        settingsWidgetVisible.setValue(new ObservableBoolean(visible));
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -651,9 +651,17 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
         toggleSettingsDialog(SettingsView.SettingViewType.MAIN);
     }
 
+    private void createSettingsWidget() {
+        assert mSettingsWidget == null : "SettingsWidget already created";
+        mSettingsWidget = new SettingsWidget(getContext());
+        mSettingsWidget.setVisibilityListener(visible -> {
+            mTrayViewModel.setSettingsWidgetVisible(visible);
+        });
+    }
+
     public void toggleSettingsDialog(@NonNull SettingsView.SettingViewType settingDialog) {
         if (mSettingsWidget == null) {
-            mSettingsWidget = new SettingsWidget(getContext());
+            createSettingsWidget();
         }
         mSettingsWidget.attachToWindow(mAttachedWindow);
 
@@ -667,7 +675,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
     public void showSettingsDialog(@NonNull SettingsView.SettingViewType settingDialog) {
         if (mSettingsWidget == null) {
-            mSettingsWidget = new SettingsWidget(getContext());
+            createSettingsWidget();
         }
         mSettingsWidget.attachToWindow(mAttachedWindow);
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/dialogs/UIDialog.java
@@ -73,6 +73,9 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
                 mDialogs.addLast(this);
             }
         }
+        if (visibilityListener != null) {
+            visibilityListener.onUIDialogVisibilityChanged(true);
+        }
     }
 
     @Override
@@ -87,6 +90,9 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
         UIDialog head = mDialogs.peek();
         if (head != null) {
             head.show();
+        }
+        if (visibilityListener != null) {
+            visibilityListener.onUIDialogVisibilityChanged(false);
         }
     }
 
@@ -113,5 +119,15 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
 
     public static void closeAllDialogs() {
         new LinkedList<>(mDialogs).forEach(dialog -> dialog.onDismiss());
+    }
+
+    public interface VisibilityListener {
+        void onUIDialogVisibilityChanged(boolean isVisible);
+    }
+
+    private VisibilityListener visibilityListener;
+
+    public void setVisibilityListener(VisibilityListener listener) {
+        this.visibilityListener = listener;
     }
 }

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -239,6 +239,7 @@
                 app:tooltipDensity="@dimen/tray_tooltip_density"
                 app:tooltipPosition="bottom"
                 app:tooltipLayout="@layout/tooltip_tray"
+                app:activeMode="@{traymodel.settingsWidgetVisible}"
                 android:src="@drawable/ic_icon_tray_settings_v3"/>
         </LinearLayout>
 


### PR DESCRIPTION
The settings button in the tray was never show as pressed. That's because we didn't have the data in the view model to activate/deactivate it.

We added a visibility changed interface to the UIDialog class which is called whenever show()/hide() are called. We can use that information later to fillin a boolean in the view model that will be used later to show the pressed/unpressed status of the button.

Fixes #1702 