### PR TITLE
feat: Initial spatial control and aggressive feature stripping

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -427,13 +427,13 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         });
 
         // Create Browser navigation widget
-        mNavigationBar = new NavigationBarWidget(this);
+        // mNavigationBar = new NavigationBarWidget(this); // STRIPPED
 
         // Create keyboard widget
-        mKeyboard = new KeyboardWidget(this);
+        mKeyboard = new KeyboardWidget(this); // KEEPING for potential URL input
 
         // Create the WebXR interstitial
-        mWebXRInterstitial = new WebXRInterstitialWidget(this);
+        mWebXRInterstitial = new WebXRInterstitialWidget(this); // KEEPING for WebXR core functionality
 
         // Windows
         mWindows = new Windows(this);
@@ -483,22 +483,27 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         });
 
         // Create the tray
-        mTray = new TrayWidget(this);
-        mTray.addListeners(mWindows);
-        mTray.setAddWindowVisible(mWindows.canOpenNewWindow());
+        // mTray = new TrayWidget(this); // STRIPPED
+        // if (mTray != null) { // STRIPPED
+        //     mTray.addListeners(mWindows); // STRIPPED
+        //     mTray.setAddWindowVisible(mWindows.canOpenNewWindow()); // STRIPPED
+        // } // STRIPPED
 
         // Create Tabs bar widget
-        if (mSettings.getTabsLocation() == SettingsStore.TABS_LOCATION_HORIZONTAL) {
-            mTabsBar = new HorizontalTabsBar(this, mWindows);
-        } else if (mSettings.getTabsLocation() == SettingsStore.TABS_LOCATION_VERTICAL) {
-            mTabsBar = new VerticalTabsBar(this, mWindows);
-        } else {
-            mTabsBar = null;
-        }
+        // if (mSettings.getTabsLocation() == SettingsStore.TABS_LOCATION_HORIZONTAL) { // STRIPPED
+        //     mTabsBar = new HorizontalTabsBar(this, mWindows); // STRIPPED
+        // } else if (mSettings.getTabsLocation() == SettingsStore.TABS_LOCATION_VERTICAL) { // STRIPPED
+        //     mTabsBar = new VerticalTabsBar(this, mWindows); // STRIPPED
+        // } else { // STRIPPED
+        mTabsBar = null; // STRIPPED - Ensure mTabsBar is null
+        // } // STRIPPED
 
         attachToWindow(mWindows.getFocusedWindow(), null);
 
-        addWidgets(Arrays.asList(mRootWidget, mNavigationBar, mKeyboard, mTray, mTabsBar, mWebXRInterstitial));
+        // addWidgets(Arrays.asList(mRootWidget, mNavigationBar, mKeyboard, mTray, mTabsBar, mWebXRInterstitial));
+        // STRIPPED: Only add essential widgets
+        addWidgets(Arrays.asList(mRootWidget, mKeyboard, mWebXRInterstitial));
+
 
         // Create the platform plugin after widgets are created to be extra safe.
         mPlatformPlugin = createPlatformPlugin(this);
@@ -516,20 +521,20 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     private void attachToWindow(@NonNull WindowWidget aWindow, @Nullable WindowWidget aPrevWindow) {
         mPermissionDelegate.setParentWidgetHandle(aWindow.getHandle());
-        mNavigationBar.attachToWindow(aWindow);
-        mKeyboard.attachToWindow(aWindow);
-        mTray.attachToWindow(aWindow);
+        // if (mNavigationBar != null) mNavigationBar.attachToWindow(aWindow); // STRIPPED
+        if (mKeyboard != null) mKeyboard.attachToWindow(aWindow); // KEEPING Keyboard
+        // if (mTray != null) mTray.attachToWindow(aWindow); // STRIPPED
 
-        if (mTabsBar != null) {
+        if (mTabsBar != null) { // This will be false now as mTabsBar is set to null
             mTabsBar.attachToWindow(aWindow);
         }
         mWindows.adjustWindowOffsets();
 
         if (aPrevWindow != null) {
-            updateWidget(mNavigationBar);
-            updateWidget(mKeyboard);
-            updateWidget(mTray);
-            if (mTabsBar != null) {
+            // if (mNavigationBar != null) updateWidget(mNavigationBar); // STRIPPED
+            if (mKeyboard != null) updateWidget(mKeyboard); // KEEPING Keyboard
+            // if (mTray != null) updateWidget(mTray); // STRIPPED
+            if (mTabsBar != null) { // This will be false
                 updateWidget(mTabsBar);
             }
         }
@@ -617,11 +622,13 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         super.onStart();
         mFragmentController.dispatchStart();
         getLifecycleRegistry().setCurrentState(Lifecycle.State.STARTED);
-        if (mTray == null) {
-            Log.e(LOGTAG, "Failed to start Tray clock");
-        } else {
+        // if (mTray == null) { // STRIPPED
+        //     Log.e(LOGTAG, "Failed to start Tray clock"); // STRIPPED
+        // } else { // STRIPPED
+        if (mTray != null) { // STRIPPED - Guard with null check
             mTray.start(this);
         }
+        // } // STRIPPED
     }
 
     @Override
@@ -630,7 +637,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         super.onStop();
         mFragmentController.dispatchStop();
         TelemetryService.sessionStop();
-        if (mTray != null) {
+        if (mTray != null) { // STRIPPED - Guard with null check
             mTray.stop(this);
         }
     }
@@ -1601,7 +1608,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         }
         int plugged = intent == null ? -1 : intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
         boolean isCharging = plugged == BatteryManager.BATTERY_PLUGGED_AC || plugged == BatteryManager.BATTERY_PLUGGED_USB || plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS;
-        mTray.setBatteryLevels(mLastBatteryLevel, isCharging, leftLevel, rightLevel);
+        // mTray.setBatteryLevels(mLastBatteryLevel, isCharging, leftLevel, rightLevel); // STRIPPED
+        if (mTray != null) { // STRIPPED - Guard with null check
+            mTray.setBatteryLevels(mLastBatteryLevel, isCharging, leftLevel, rightLevel);
+        }
     }
 
     @Keep
@@ -2005,7 +2015,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public void keyboardDismissed() {
-        mNavigationBar.showVoiceSearch();
+        // mNavigationBar.showVoiceSearch(); // STRIPPED
+        if (mNavigationBar != null) { // STRIPPED - Guard with null check
+            mNavigationBar.showVoiceSearch();
+        }
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserApplication.java
@@ -57,28 +57,28 @@ public class VRBrowserApplication extends Application implements AppServicesProv
         TelemetryService.init(activityContext);
         mConnectivityManager = new ConnectivityReceiver(activityContext);
         mConnectivityManager.init();
-        mPlaces = new Places(activityContext);
-        mServices = new Services(activityContext, mPlaces);
-        mLoginStorage = new LoginStorage(activityContext);
-        mAccounts = new Accounts(activityContext);
+        // mPlaces = new Places(activityContext); // STRIPPED
+        // mServices = new Services(activityContext, mPlaces); // STRIPPED (depends on mPlaces)
+        // mLoginStorage = new LoginStorage(activityContext); // STRIPPED
+        // mAccounts = new Accounts(activityContext); // STRIPPED
         mSessionStore = SessionStore.get();
         mSessionStore.initialize(activityContext);
         mSessionStore.setLocales(LocaleUtils.getPreferredLanguageTags(activityContext));
-        mDownloadsManager = new DownloadsManager(activityContext);
-        mDownloadsManager.init();
-        mBitmapCache = new BitmapCache(activityContext, mAppExecutors.diskIO(), mAppExecutors.mainThread());
-        mEnvironmentsManager = new EnvironmentsManager(activityContext);
+        // mDownloadsManager = new DownloadsManager(activityContext); // STRIPPED
+        // if (mDownloadsManager != null) mDownloadsManager.init(); // STRIPPED
+        mBitmapCache = new BitmapCache(activityContext, mAppExecutors.diskIO(), mAppExecutors.mainThread()); // Keep for image display
+        mEnvironmentsManager = new EnvironmentsManager(activityContext); // Keep for VR environment
         mEnvironmentsManager.init();
-        mDictionariesManager = new DictionariesManager(activityContext);
+        mDictionariesManager = new DictionariesManager(activityContext); // Keep for keyboard (for now)
         mDictionariesManager.init();
-        mAddons = new Addons(activityContext, mSessionStore);
+        // mAddons = new Addons(activityContext, mSessionStore); // STRIPPED
     }
 
     protected void onActivityDestroy() {
-        mConnectivityManager.end();
-        mDownloadsManager.end();
-        mEnvironmentsManager.end();
-        mDictionariesManager.end();
+        if (mConnectivityManager != null) mConnectivityManager.end();
+        if (mDownloadsManager != null) mDownloadsManager.end(); // STRIPPED (but keep guard)
+        if (mEnvironmentsManager != null) mEnvironmentsManager.end();
+        if (mDictionariesManager != null) mDictionariesManager.end();
     }
 
     @Override

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -416,10 +416,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     public void loadHome() {
         if (mSession.isPrivateMode()) {
-            mSession.loadPrivateBrowsingPage();
+            mSession.loadPrivateBrowsingPage(); // Keep private mode behavior for now
 
         } else {
-            mSession.loadUri(mSession.getHomeUri());
+            // mSession.loadUri(mSession.getHomeUri()); // STRIPPED
+            mSession.loadUri("about:blank"); // STRIPPED - Load about:blank by default
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,16 +3,16 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-feature android:glEsVersion="0x00030000"/>
 
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-    <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="${applicationId}.CRASH_RECEIVER_PERMISSION"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/> <!-- Keep for WebXR/Media -->
+    <uses-permission android:name="android.permission.CAMERA"/> <!-- Keep for WebXR/Media -->
+    <!-- <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/> STRIPPED -->
+    <!-- <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/> STRIPPED -->
+    <!-- <uses-permission android:name="${applicationId}.CRASH_RECEIVER_PERMISSION"/> STRIPPED with CrashReporterService -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/> <!-- Keep for potential Chromium cache/data -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/> <!-- Keep for potential Chromium cache/data, monitor usage -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/> <!-- Keep for network -->
+    <uses-permission android:name="android.permission.INTERNET" /> <!-- Essential -->
+    <!-- <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/> STRIPPED -->
 
     <!-- Requested by GeckoView but not needed in VR -->
     <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove"/>
@@ -60,13 +60,13 @@
                 <data android:mimeType="text/plain"/>
             </intent-filter>
         </activity>
-        <service
+        <!-- <service
             android:name="com.igalia.wolvic.crashreporting.CrashReporterService"
             android:exported="false"
             android:process=":crash"
             android:permission="android.permission.BIND_JOB_SERVICE">
-        </service>
-        <provider
+        </service> STRIPPED -->
+        <!-- <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
@@ -74,6 +74,6 @@
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/downloads_provider"/>
-        </provider>
+        </provider> STRIPPED -->
     </application>
 </manifest>

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -85,6 +85,12 @@ public:
 #if HVR
   bool WasButtonAppPressed();
 #endif
+
+  // For debug spatial control
+  void SetDebugWidgetHandle(int32_t handle);
+  void SetDebugWidgetTransform(const vrb::Matrix& transform);
+  void ClearDebugWidgetTransform();
+
 protected:
   struct State;
   static BrowserWorldPtr Create();


### PR DESCRIPTION
Project Goal: Transform Wolvic into a spatial multi-viewer for video content, optimized for minimal resource consumption and device heat.

Current Task: Establish core spatial control over a single existing browser tab/window and aggressively strip browser features.

Changes Implemented:

1.  Spatial Control Foundation (C++):
    *   Added `debugWidgetHandle` and `debugWidgetTransform` to
        `BrowserWorld` to allow overriding a specific widget's transform.
    *   Hardcoded `debugWidgetHandle` to `0` for initial testing.
    *   Modified `BrowserWorld::LayoutWidget` to apply this debug
        transform, bypassing normal layout calculations for the targeted widget.
    *   Implemented a programmatic X-axis oscillation animation for the
        debug widget's transform, primarily in `BrowserWorld::TickImmersive`.

2.  Aggressive Feature Stripping - Phase 1 (UI & High-Level Java Logic):
    *   In `VRBrowserActivity.java`:
        *   Disabled instantiation and usage of major UI components:
          `NavigationBarWidget`, `TrayWidget`, and `TabsBar`.
        *   Updated `addWidgets` to only include essential widgets:
          `RootWidget`, `KeyboardWidget` (retained for potential future basic
          URL input), and `WebXRInterstitialWidget` (for core WebXR).
        *   Added null checks for remaining Java-level code paths that might
          reference the stripped UI components.
    *   Ensured new windows/sessions default to a blank page (see item 4).

3.  Aggressive Feature Stripping - Phase 2 (Backend Services & AndroidManifest):
    *   In `app/src/main/AndroidManifest.xml`:
        *   Commented out `CrashReporterService` and `FileProvider`.
        *   Removed permissions: `ACCESS_COARSE_LOCATION`,
          `ACCESS_FINE_LOCATION`, `REQUEST_INSTALL_PACKAGES`, and the
          app-specific crash receiver permission.
    *   In `VRBrowserApplication.java`:
        *   Commented out the initialization of backend services/managers:
          `Places` (bookmarks/history), `Services` (dependent on Places),
          `LoginStorage`, `Accounts`, `DownloadsManager`, and `Addons`.

4.  Refined Initial Window Setup:
    *   Analyzed `Windows.java`, `Session.java`, and `SessionStore.java` to
      understand initial window and URL loading mechanisms.
    *   Modified `Session.getHomeUri()` in `Session.java` to ensure that
      newly created non-private sessions default to loading `"about:blank"`,
      providing a clean and minimal initial page. This works in conjunction
      with `WindowWidget.loadHome()` which also points to this.

The application is expected to launch with a significantly reduced UI, displaying a single animated window with `about:blank`. The next steps involve building, testing these changes on a device, and addressing any runtime issues or crashes that may arise from the stripping process.