### PR TITLE
Enable user-driven spatial manipulation of debug widget via OpenXR

### DIFF
--- a/app/src/main/cpp/Controller.cpp
+++ b/app/src/main/cpp/Controller.cpp
@@ -82,6 +82,15 @@ Controller::operator=(const Controller& aController) {
   handActionButtonToggle = aController.handActionButtonToggle;
   handActionButtonTransform = aController.handActionButtonTransform;
   selectFactor = aController.selectFactor;
+
+  isWidgetSelected = aController.isWidgetSelected;
+  widgetMoveLocation = aController.widgetMoveLocation;
+  widgetMoveLocationValid = aController.widgetMoveLocationValid;
+  widgetRotateLocation = aController.widgetRotateLocation;
+  widgetRotateLocationValid = aController.widgetRotateLocationValid;
+  widgetMovePoseTime = aController.widgetMovePoseTime;
+  widgetRotatePoseTime = aController.widgetRotatePoseTime;
+  widgetScaleValue = aController.widgetScaleValue;
   return *this;
 }
 
@@ -135,6 +144,15 @@ Controller::Reset() {
   handActionButtonToggle = nullptr;
   handActionButtonTransform = nullptr;
   selectFactor = 0.0;
+
+  isWidgetSelected = false;
+  widgetMoveLocation = {XR_TYPE_SPACE_LOCATION};
+  widgetMoveLocationValid = false;
+  widgetRotateLocation = {XR_TYPE_SPACE_LOCATION};
+  widgetRotateLocationValid = false;
+  widgetMovePoseTime = 0;
+  widgetRotatePoseTime = 0;
+  widgetScaleValue = 0.0f;
 }
 
 vrb::Vector Controller::StartPoint() const {

--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -82,6 +82,18 @@ struct Controller {
 
   int32_t batteryLevel;
 
+  // Widget Manipulation States
+  bool isWidgetSelected;
+  XrSpaceLocation widgetMoveLocation;
+  bool widgetMoveLocationValid;
+  XrSpaceLocation widgetRotateLocation;
+  bool widgetRotateLocationValid;
+  // vrb::Matrix widgetMovePose; // Derived on demand
+  // vrb::Matrix widgetRotatePose; // Derived on demand
+  XrTime widgetMovePoseTime;
+  XrTime widgetRotatePoseTime;
+  float widgetScaleValue;
+
   vrb::Vector StartPoint() const;
   vrb::Vector Direction() const;
 

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -86,6 +86,16 @@ public:
   virtual void SetHandActionEnabled(const int32_t aControllerIndex, bool aEnabled = false) = 0;
   virtual void SetMode(const int32_t aControllerIndex, ControllerMode aMode = ControllerMode::None) = 0;
   virtual void SetSelectFactor(const int32_t aControllerIndex, float aFactor = 1.0f) = 0;
+
+  // Widget Manipulation States
+  virtual void SetWidgetSelectedState(int32_t aControllerIndex, bool isSelected) = 0;
+  virtual bool IsWidgetSelected(int32_t aControllerIndex) const = 0;
+  virtual void SetWidgetRawPoses(int32_t aControllerIndex, const XrSpaceLocation& movePose, bool movePoseValid, const XrSpaceLocation& rotatePose, bool rotatePoseValid) = 0;
+  virtual bool GetWidgetMovePose(int32_t aControllerIndex, vrb::Matrix& outPose, XrTime& outTime) const = 0;
+  virtual bool GetWidgetRotatePose(int32_t aControllerIndex, vrb::Matrix& outPose, XrTime& outTime) const = 0;
+  virtual void SetWidgetScaleValue(int32_t aControllerIndex, float scaleValue) = 0;
+  virtual float GetWidgetScaleValue(int32_t aControllerIndex) const = 0;
+
 protected:
   ControllerDelegate() {}
 private:

--- a/app/src/openxr/cpp/OpenXRInputSource.h
+++ b/app/src/openxr/cpp/OpenXRInputSource.h
@@ -110,6 +110,23 @@ private:
     bool mIsHandInteractionSupported { false };
 
     void HandleEyeTrackingScroll(XrTime predictedDisplayTime, bool triggerClicked, const vrb::Matrix& pointerTransform, const vrb::Matrix& eyeTrackingTransform, ControllerDelegate &controllerDelegate);
+
+    // Actions and spaces for widget manipulation (right hand only)
+    XrAction mMoveWidgetAction { XR_NULL_HANDLE };
+    XrSpace mMoveWidgetSpace { XR_NULL_HANDLE };
+    XrAction mSelectWidgetAction { XR_NULL_HANDLE };
+    XrAction mRotateWidgetAction { XR_NULL_HANDLE };
+    XrSpace mRotateWidgetSpace { XR_NULL_HANDLE };
+    XrAction mScaleWidgetAction { XR_NULL_HANDLE };
+
+    // States for widget manipulation
+    bool mIsWidgetSelected { false };
+    XrSpaceLocation mWidgetMovePoseLocation { XR_TYPE_SPACE_LOCATION }; // For position
+    XrSpaceLocation mWidgetRotatePoseLocation { XR_TYPE_SPACE_LOCATION }; // For rotation
+    bool mWidgetMovePoseValid { false };
+    bool mWidgetRotatePoseValid { false };
+    float mWidgetScaleValue { 0.0f };
+
 public:
     static OpenXRInputSourcePtr Create(XrInstance, XrSession, OpenXRActionSet&, const XrSystemProperties&, OpenXRHandFlags, int index);
     ~OpenXRInputSource();
@@ -124,6 +141,26 @@ public:
     void SetHandMeshBufferSizes(const uint32_t indexCount, const uint32_t vertexCount);
     HandMeshBufferPtr GetNextHandMeshBuffer();
     float GetSelectThreshold() const { return mClickThreshold; }
+
+    // Public getters for new widget manipulation actions and spaces (read by OpenXRInput and BrowserWorld)
+    XrAction GetMoveWidgetAction() const { return mMoveWidgetAction; }
+    XrSpace GetMoveWidgetSpace() const { return mMoveWidgetSpace; }
+    XrAction GetSelectWidgetAction() const { return mSelectWidgetAction; }
+    XrAction GetRotateWidgetAction() const { return mRotateWidgetAction; }
+    XrSpace GetRotateWidgetSpace() const { return mRotateWidgetSpace; }
+    XrAction GetScaleWidgetAction() const { return mScaleWidgetAction; }
+
+    // Getters for basic properties
+    OpenXRHandFlags GetHand() const { return mHandeness; }
+    int GetIndex() const { return mIndex; }
+
+    // Getters for widget manipulation states
+    bool IsWidgetSelected() const { return mIsWidgetSelected; }
+    const XrSpaceLocation& GetWidgetMovePoseLocation() const { return mWidgetMovePoseLocation; }
+    bool IsWidgetMovePoseValid() const { return mWidgetMovePoseValid; }
+    const XrSpaceLocation& GetWidgetRotatePoseLocation() const { return mWidgetRotatePoseLocation; }
+    bool IsWidgetRotatePoseValid() const { return mWidgetRotatePoseValid; }
+    float GetWidgetScaleValue() const { return mWidgetScaleValue; }
 };
 
 } // namespace crow


### PR DESCRIPTION
This commit implements the functionality to move, rotate, and scale the debug widget using the right Meta Quest Touch controller.

Key changes include:

1.  **OpenXR Action Setup:**
    *   Defined new OpenXR actions in `OpenXRInputSource` for widget
        manipulation: `move_widget_action` (pose), `select_widget_action`
        (boolean), `rotate_widget_action` (pose), and `scale_widget_action` (float).
    *   Created associated `XrSpace`s for the pose actions.
    *   Added suggested bindings for these actions to the Oculus Touch
        controller profile (right hand): grip pose for move/rotate,
        trigger click for select, and thumbstick Y for scale.

2.  **Input Polling and State Propagation:**
    *   Widget action states are read in `OpenXRInputSource::Update()`.
    *   These states are propagated through `ControllerDelegate` (with new
        interface methods) and stored in the `Controller` state object.
    *   `OpenXRInput::Update()` now calls the new `ControllerDelegate` setters
        to update these states.

3.  **Transformation Logic in `BrowserWorld`:**
    *   Added state variables to `BrowserWorld::State` to manage the grab
        state, initial controller/widget transforms, current scale, and the
        target `debugWidgetTransform`.
    *   Modified `BrowserWorld::State::UpdateControllers()` to:
        *   Identify the right controller.
        *   Retrieve widget manipulation states from `ControllerDelegate`.
        *   Handle grab/release logic.
        *   If grabbed, update `debugWidgetTransform` based on controller
            grip pose (for direct position/rotation follow) and thumbstick
            Y-axis (for scaling).
    *   Refined `debugWidgetHandle` initialization in `BrowserWorld::AddWidget`
        (currently assumes handle 0 for the debug widget) to set
        `debugWidgetTransform` from the widget's actual initial transform.
    *   Updated scaling logic to use `context->GetDeltaTime()`.

4.  **Programmatic Animation Removal:**
    *   Removed the placeholder for the previous programmatic X-axis
        oscillation of the debug widget from `BrowserWorld::TickImmersive`.

This work allows direct user interaction with the debug widget in VR, replacing the previous hardcoded animation.