### PR TITLE
Use the orientation of the focused controller to move windows

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1162,7 +1162,7 @@ BrowserWorld::ProcessOVRPlatformEvents() {
 vrb::Matrix
 BrowserWorld::GetActiveControllerOrientation() const {
   for (Controller& controller: m.controllers->GetControllers()) {
-    if (controller.enabled)
+    if (controller.focused)
       return controller.transform->GetTransform();
   }
   return vrb::Matrix::Identity();


### PR DESCRIPTION
This was the original intention but instead of checking the focused property of the controllers we're using enabled. If both hands or controllers were used the the first one (the right one) was always selected because it was the first enabled one in the list (but not the only one).

Fixes #1885