### PR TITLE
Show a warning dialog when disabling hand tracking

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -5,7 +5,9 @@
 
 package com.igalia.wolvic.ui.widgets.settings;
 
+import android.animation.ValueAnimator;
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.Point;
 import android.view.LayoutInflater;
 
@@ -22,6 +24,8 @@ import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 
 class ControllerOptionsView extends SettingsView {
 
+    private static final int HAND_TRACKING_WARNING_HIGHLIGHT_DURATION = 1000;
+    private static final int HAND_TRACKING_WARNING_HIGHLIGHT_START_DELAY = 300;
     private OptionsControllerBinding mBinding;
 
     public ControllerOptionsView(Context aContext, WidgetManagerDelegate aWidgetManager) {
@@ -161,10 +165,35 @@ class ControllerOptionsView extends SettingsView {
         }
     }
 
+    private void showHandTrackingWarningIfNeeded(boolean enabled) {
+        if (enabled) {
+            mBinding.handtrackingSwitchWarning.setVisibility(GONE);
+        } else {
+            mBinding.handtrackingSwitchWarning.setVisibility(VISIBLE);
+
+            int highlightColor = getContext().getResources().getColor(R.color.eggplant);
+            int targetColor = highlightColor & 0x00FFFFFF; // clear alpha
+
+            mBinding.handtrackingSwitchWarning.setBackgroundColor(highlightColor);
+
+            ValueAnimator animator = ValueAnimator.ofArgb(highlightColor, targetColor);
+            animator.setDuration(HAND_TRACKING_WARNING_HIGHLIGHT_DURATION);
+            animator.setStartDelay(HAND_TRACKING_WARNING_HIGHLIGHT_START_DELAY);
+            animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+                @Override
+                public void onAnimationUpdate(ValueAnimator valueAnimator) {
+                    mBinding.handtrackingSwitchWarning.setBackgroundColor((int) valueAnimator.getAnimatedValue());
+                }
+            });
+            animator.start();
+        }
+    }
+
     private void setHandTrackingEnabled(boolean value, boolean doApply) {
         mBinding.handtrackingSwitch.setOnCheckedChangeListener(null);
         mBinding.handtrackingSwitch.setValue(value, false);
         mBinding.handtrackingSwitch.setOnCheckedChangeListener(mHandtrackingListener);
+        showHandTrackingWarningIfNeeded(value);
 
         if (doApply) {
             mWidgetManager.setHandTrackingEnabled(value);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -17,11 +17,8 @@ import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsControllerBinding;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
-import com.igalia.wolvic.ui.widgets.UIWidget;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
-import com.igalia.wolvic.ui.widgets.dialogs.PromptDialogWidget;
-import com.igalia.wolvic.ui.widgets.dialogs.UIDialog;
 
 class ControllerOptionsView extends SettingsView {
 
@@ -209,22 +206,8 @@ class ControllerOptionsView extends SettingsView {
         });
     };
 
-    private SwitchSetting.OnCheckedChangeListener mHandtrackingListener = (compoundButton, enabled, apply) -> {
-        if (!enabled) {
-            PromptDialogWidget dialog = new PromptDialogWidget(getContext());
-            dialog.setTitle(R.string.disable_hand_tracking_dialog_title);
-            dialog.setBody(R.string.disable_hand_tracking_dialog_body);
-            dialog.setButtons(new int[]{R.string.ok_button});
-            dialog.setCheckboxVisible(false);
-            dialog.setDescriptionVisible(false);
-            dialog.setButtonsDelegate((index, isChecked) -> {
-                dialog.hide(UIWidget.REMOVE_WIDGET);
-                dialog.releaseWidget();
-            });
-            dialog.show(UIWidget.REQUEST_FOCUS);
-        }
-        setHandTrackingEnabled(enabled, true);
-    };
+    private SwitchSetting.OnCheckedChangeListener mHandtrackingListener = (compoundButton, enabled, apply) ->
+            setHandTrackingEnabled(enabled, true);
 
     @Override
     public Point getDimensions() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/ControllerOptionsView.java
@@ -17,8 +17,11 @@ import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.databinding.OptionsControllerBinding;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
 import com.igalia.wolvic.ui.views.settings.SwitchSetting;
+import com.igalia.wolvic.ui.widgets.UIWidget;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
+import com.igalia.wolvic.ui.widgets.dialogs.PromptDialogWidget;
+import com.igalia.wolvic.ui.widgets.dialogs.UIDialog;
 
 class ControllerOptionsView extends SettingsView {
 
@@ -206,8 +209,22 @@ class ControllerOptionsView extends SettingsView {
         });
     };
 
-    private SwitchSetting.OnCheckedChangeListener mHandtrackingListener = (compoundButton, enabled, apply) ->
-            setHandTrackingEnabled(enabled, true);
+    private SwitchSetting.OnCheckedChangeListener mHandtrackingListener = (compoundButton, enabled, apply) -> {
+        if (!enabled) {
+            PromptDialogWidget dialog = new PromptDialogWidget(getContext());
+            dialog.setTitle(R.string.disable_hand_tracking_dialog_title);
+            dialog.setBody(R.string.disable_hand_tracking_dialog_body);
+            dialog.setButtons(new int[]{R.string.ok_button});
+            dialog.setCheckboxVisible(false);
+            dialog.setDescriptionVisible(false);
+            dialog.setButtonsDelegate((index, isChecked) -> {
+                dialog.hide(UIWidget.REMOVE_WIDGET);
+                dialog.releaseWidget();
+            });
+            dialog.show(UIWidget.REQUEST_FOCUS);
+        }
+        setHandTrackingEnabled(enabled, true);
+    };
 
     @Override
     public Point getDimensions() {

--- a/app/src/main/res/layout/options_controller.xml
+++ b/app/src/main/res/layout/options_controller.xml
@@ -72,6 +72,36 @@
                     android:layout_height="wrap_content"
                     app:description="@string/controller_options_handtracking" />
 
+                <RelativeLayout
+                    android:id="@+id/handtracking_switch_warning"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:visibility="gone"
+                    android:paddingBottom="8dp">
+
+                    <ImageView
+                        android:id="@+id/info_icon"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_alignParentStart="true"
+                        android:layout_alignParentTop="true"
+                        android:layout_marginStart="24dp"
+                        android:src="@drawable/ic_addons_info" />
+
+                    <TextView
+                        android:id="@+id/setting_description"
+                        style="@style/settingsText"
+                        android:layout_alignParentTop="true"
+                        android:layout_centerVertical="true"
+                        android:layout_marginStart="12dp"
+                        android:layout_marginEnd="24dp"
+                        android:layout_toEndOf="@id/info_icon"
+                        android:text="@string/disable_hand_tracking_dialog_body"
+                        android:textAlignment="textStart" />
+
+                </RelativeLayout>
+
                 <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
                     android:id="@+id/window_selection_radio"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2615,4 +2615,7 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <string name="controller_options_hover_to_select">Hover</string>
     <string name="announcements_title">Announcements</string>
 
+    <!-- Shown in the controller options view when disabling the hand tracking switch -->
+    <string name="disable_hand_tracking_dialog_body">Hand tracking is disabled temporarily. It will be automatically re-enabled on next launch. This option is not persistent on purpose to avoid issues when controllers are unavailable.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2614,5 +2614,8 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <string name="controller_options_click_to_select">Click</string>
     <string name="controller_options_hover_to_select">Hover</string>
     <string name="announcements_title">Announcements</string>
+    <!-- These two strings are displayed when the user disables hand tracking in the controllers view widget. -->
+    <string name="disable_hand_tracking_dialog_title">On disabling Hand Tracking</string>
+    <string name="disable_hand_tracking_dialog_body">Hand tracking is disabled temporarily. It will be automatically re-enabled on next launch. This option is not persistent on purpose to avoid issues when controllers are unavailable.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2614,8 +2614,5 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <string name="controller_options_click_to_select">Click</string>
     <string name="controller_options_hover_to_select">Hover</string>
     <string name="announcements_title">Announcements</string>
-    <!-- These two strings are displayed when the user disables hand tracking in the controllers view widget. -->
-    <string name="disable_hand_tracking_dialog_title">On disabling Hand Tracking</string>
-    <string name="disable_hand_tracking_dialog_body">Hand tracking is disabled temporarily. It will be automatically re-enabled on next launch. This option is not persistent on purpose to avoid issues when controllers are unavailable.</string>
 
 </resources>


### PR DESCRIPTION
The hand tracking setting is ephemeral, hand tracking is automatically restored on the next app launch to prevent issues with unavailable controllers. Users have been confused because indeed it looks like that their preferences are not saved, but that's done on purpouse. We must inform them about the volatility of the setting.

From now on a dialog is shown when hand tracking is disabled.