### PR TITLE
Require Java 17 toolchain to build Wolvic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,6 +164,12 @@ android {
         coreLibraryDesugaringEnabled true
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
+
     packagingOptions {
         jniLibs {
             useLegacyPackaging = true


### PR DESCRIPTION
Generating Java 1.8 compatible code has been deprecated in Java 21. To be prepared for the future we can set the minimum requirement of Java 17 which has been available in long term support versions of the most common Linux distributions for a while. The other option would be to increase the source and target compatibility as 1.8 is rather old, but the safest (and recommended) approach is to set a toolchain compatible with 1.8 code generation.

This fixes this warning in the build:
'''
Task :app:compileOculusvrArm64GeckoGenericDebugJavaWithJavac Java compiler version 21 has deprecated support for compiling with source/target version 8.
Try one of the following options:
1. [Recommended] Use Java toolchain with a lower language version
2. Set a higher source/target version
3. Use a lower version of the JDK running the build (if you're not using Java toolchain)
'''