### PR TITLE
Show the ETP widget when clicking on the Advanced button

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SitePermissionsOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SitePermissionsOptionsView.java
@@ -85,6 +85,7 @@ class SitePermissionsOptionsView extends SettingsView {
                 mBinding.contentText.setText(R.string.settings_privacy_policy_tracking_description);
                 mBinding.emptyText.setText(R.string.settings_privacy_policy_tracking_empty_description);
                 mBinding.emptySecondText.setVisibility(GONE);
+                break;
             case SitePermission.SITE_PERMISSION_AUTOFILL:
                 mBinding.headerLayout.setTitle(R.string.settings_privacy_policy_login_exceptions_title);
                 mBinding.contentText.setText(R.string.settings_privacy_policy_login_exceptions_description);


### PR DESCRIPTION
The current code was always showing the Password Exceptions dialog instead. The problem was that we had a switch to select the proper dialog and the ETP option didn't have a break at the end so it was falling back to the next option which was the password exceptions option.

Fixes #1901