### PR TITLE
Securize refresh rate selection

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -495,7 +495,11 @@ struct DeviceDelegateOpenXR::State {
 
     uint32_t displayRefreshRateCount = 0;
     CHECK_XRCMD(OpenXRExtensions::sXrEnumerateDisplayRefreshRatesFB(session, 0, &displayRefreshRateCount, nullptr));
-    CHECK(displayRefreshRateCount > 0);
+    if (displayRefreshRateCount == 0) {
+        VRB_ERROR("OpenXR runtime reports 0 display refresh rates but XR_FB_display_refresh_rate is supported");
+        return;
+    }
+
     refreshRates.resize(displayRefreshRateCount);
     CHECK_XRCMD(OpenXRExtensions::sXrEnumerateDisplayRefreshRatesFB(session, displayRefreshRateCount, &displayRefreshRateCount, refreshRates.data()));
 
@@ -733,7 +737,7 @@ struct DeviceDelegateOpenXR::State {
   }
 
   void UpdateDisplayRefreshRate() {
-    if (!OpenXRExtensions::IsExtensionSupported(XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME))
+    if (!OpenXRExtensions::IsExtensionSupported(XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME) || refreshRates.empty())
       return;
 
     float suggestedRefreshRate = 0.0;


### PR DESCRIPTION
If the XR_FB_display_refresh_rate extension was available we assumed that the API will always return a non empty list of supported refresh rates. However in some particular configurations the extension might appear as available but no refresh rates will be ever returned. That could cause crashes due to assertions.

As this is an extension and not a critical piece of the main execution path we should just report the error and bail out.

This was happening to me when trying to run the AOSP flavour in a Quest device. With this fix Wolvic can be run in Quest devices even with the AOSP flavour.