### PR TITLE
Added new manifest permission strings for hand tracking for HorizonOS

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
+    <uses-permission android:name="horizonos.permission.HAND_TRACKING" />
 
     <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
 

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -26,6 +26,7 @@
 
     <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
+    <uses-permission android:name="horizonos.permission.HAND_TRACKING" />
 
     <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
 


### PR DESCRIPTION
Meta's HorizonOS defines new permission names for hand tracking.

We are not removing the old (deprecated) ones for back compatibility.