### PR TITLE
Fix layer enabling condition

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -699,7 +699,7 @@ public class SettingsStore {
     }
 
     public boolean getLayersEnabled() {
-        if ((DeviceType.isOculusBuild() || DeviceType.isPicoXR())  || DeviceType.isPfdmXR() && !mDisableLayers) {
+        if ((DeviceType.isOculusBuild() || DeviceType.isPicoXR() || DeviceType.isPfdmXR()) && !mDisableLayers) {
             Log.i(LOGTAG, "Layers are enabled");
             return true;
         }


### PR DESCRIPTION
When PfdmXR devices were added the condition was not properly updated resulting in wrong enabling/disabling of layers. Move the parentheses to where it should be, so that layers are enabled for Meta, Pico and PfdmXR devices unless it's explicitly disabled.