### PR TITLE
Move layer support detection to the backend

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -112,6 +112,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
@@ -270,6 +271,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private boolean mIsEyeTrackingSupported;
     private String mImmersiveParentElementXPath;
     private String mImmersiveTargetElementXPath;
+    private OptionalInt mMaxCompositionLayers = OptionalInt.empty();
+    private LinkedList<CompositionLayersCallback> mCompositionLayersPendingCallbacks;
 
     private ViewTreeObserver.OnGlobalFocusChangeListener globalFocusListener = new ViewTreeObserver.OnGlobalFocusChangeListener() {
         @Override
@@ -343,6 +346,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mWebXRListeners = new LinkedList<>();
         mBackHandlers = new LinkedList<>();
         mBrightnessQueue = new LinkedList<>();
+        mCompositionLayersPendingCallbacks = new LinkedList<>();
         mCurrentBrightness = Pair.create(null, 1.0f);
         mWidgets = new ConcurrentHashMap<>();
 
@@ -1473,12 +1477,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Keep
     @SuppressWarnings("unused")
-    public boolean areLayersEnabled() {
-        return SettingsStore.getInstance(this).getLayersEnabled();
-    }
-
-    @Keep
-    @SuppressWarnings("unused")
     public String getActiveEnvironment() {
         return getServicesProvider().getEnvironmentsManager().getOrDownloadEnvironment();
     }
@@ -2291,6 +2289,35 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         float increment = 0.05f;
         float clamped = Math.max(0.0f, Math.min(mSettings.getWindowDistance() + (aDelta > 0 ? increment : -increment), 1.0f));
         mSettings.setWindowDistance(clamped);
+    }
+
+    private boolean supportsCompositionLayers() {
+        assert(mMaxCompositionLayers.isPresent());
+        return mMaxCompositionLayers.getAsInt() > 1;
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
+    private void onMaxCompositionLayersAvailable(int aNumLayers) {
+        assert(!mMaxCompositionLayers.isPresent());
+        mMaxCompositionLayers = OptionalInt.of(aNumLayers);
+        Log.i(LOGTAG, "Max composition layers: " + aNumLayers + " so " + (supportsCompositionLayers() ? "enabling" : "disabling") + " layers support");
+        runOnUiThread(() -> {
+            boolean supportsLayers = supportsCompositionLayers();
+            for (CompositionLayersCallback callback : mCompositionLayersPendingCallbacks) {
+                callback.onCompositionLayersSupport(supportsLayers);
+            }
+            mCompositionLayersPendingCallbacks.clear();
+        });
+    }
+
+    @Override
+    public void areCompositionLayersSupported(@NonNull CompositionLayersCallback callback) {
+        if (!mMaxCompositionLayers.isPresent()) {
+            mCompositionLayersPendingCallbacks.add(callback);
+            return;
+        }
+        callback.onCompositionLayersSupport(supportsCompositionLayers());
     }
 
     private native void addWidgetNative(int aHandle, WidgetPlacement aPlacement);

--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -698,15 +698,6 @@ public class SettingsStore {
         editor.apply();
     }
 
-    public boolean getLayersEnabled() {
-        if ((DeviceType.isOculusBuild() || DeviceType.isPicoXR())  || DeviceType.isPfdmXR() && !mDisableLayers) {
-            Log.i(LOGTAG, "Layers are enabled");
-            return true;
-        }
-        Log.i(LOGTAG, "Layers are not supported");
-        return false;
-    }
-
     public int getTransparentBorderWidth() {
         return 1;
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -538,20 +538,21 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     }
 
     public void proxifyLayerIfNeeded(ArrayList<WindowWidget> aWindows) {
-        if (!SettingsStore.getInstance(getContext()).getLayersEnabled()) {
-            return;
-        }
-        boolean proxify = false;
-        for (WindowWidget window: aWindows) {
-            if (window.getPlacement().borderColor != 0) {
-                proxify = true;
-                break;
+        mWidgetManager.areCompositionLayersSupported((boolean enabled) -> {
+            if (!enabled)
+                return;
+            boolean proxify = false;
+            for (WindowWidget window: aWindows) {
+                if (window.getPlacement().borderColor != 0) {
+                    proxify = true;
+                    break;
+                }
             }
-        }
-        if (mWidgetPlacement.proxifyLayer != proxify) {
-            mWidgetPlacement.proxifyLayer = proxify;
-            mWidgetManager.updateWidget(this);
-        }
+            if (mWidgetPlacement.proxifyLayer != proxify) {
+                mWidgetPlacement.proxifyLayer = proxify;
+                mWidgetManager.updateWidget(this);
+            }
+        });
     }
 
     private void hideOverlays() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WidgetManagerDelegate.java
@@ -39,6 +39,10 @@ public interface WidgetManagerDelegate {
         void onEyeTrackingPermissionRequest(boolean aPermissionGranted);
     }
 
+    interface CompositionLayersCallback {
+        void onCompositionLayersSupport(boolean aSupported);
+    }
+
     float DEFAULT_DIM_BRIGHTNESS = 0.25f;
     float DEFAULT_NO_DIM_BRIGHTNESS = 1.0f;
 
@@ -152,5 +156,5 @@ public interface WidgetManagerDelegate {
     boolean isEyeTrackingSupported();
     boolean isHandTrackingSupported();
     boolean areControllersAvailable();
-
+    void areCompositionLayersSupported(@NonNull CompositionLayersCallback callback);
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/WindowWidget.java
@@ -375,10 +375,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         super.onResume();
         if (isVisible() || mIsInVRVideoMode) {
             mSession.setActive(true);
-            if (!SettingsStore.getInstance(getContext()).getLayersEnabled() && !mSession.hasDisplay()) {
-                // Ensure the Display is correctly recreated.
-                // See: https://github.com/MozillaReality/FirefoxReality/issues/2880
-                callSurfaceChanged();
+            if (!mSession.hasDisplay()) {
+                mWidgetManager.areCompositionLayersSupported((boolean enabled) -> {
+                    if (enabled) {
+                        // Ensure the Display is correctly recreated.
+                        // See: https://github.com/MozillaReality/FirefoxReality/issues/2880
+                        callSurfaceChanged();
+                    }
+                });
             }
         }
     }
@@ -430,12 +434,16 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     private void recreateWidgetSurfaceIfNeeded(float prevDensity) {
-        if (prevDensity != mWidgetPlacement.density || !SettingsStore.getInstance(getContext()).getLayersEnabled())
+        if (prevDensity != mWidgetPlacement.density)
             return;
 
-        // If the densities are the same updateWidget won't generate a new surface as the resulting
-        // texture sizes are equal. We need to force a new surface creation when using layers.
-        mWidgetManager.recreateWidgetSurface(this);
+        mWidgetManager.areCompositionLayersSupported((boolean enabled) -> {
+            if (enabled) {
+                // If the densities are the same updateWidget won't generate a new surface as the resulting
+                // texture sizes are equal. We need to force a new surface creation when using layers.
+                mWidgetManager.recreateWidgetSurface(this);
+            }
+        });
     }
 
     private void setView(View view, boolean switchSurface,  @ViewBrightness int viewBrightness) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/menus/HamburgerMenuWidget.java
@@ -26,6 +26,7 @@ import com.igalia.wolvic.ui.adapters.HamburgerMenuAdapter;
 import com.igalia.wolvic.ui.widgets.UIWidget;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
+import com.igalia.wolvic.ui.widgets.WindowWidget;
 import com.igalia.wolvic.utils.AnimationHelper;
 import com.igalia.wolvic.utils.ViewUtils;
 
@@ -40,8 +41,6 @@ import mozilla.components.concept.engine.webextension.Action;
 public class HamburgerMenuWidget extends UIWidget implements
         WidgetManagerDelegate.FocusChangeListener,
         ComponentsAdapter.StoreUpdatesListener {
-
-    private boolean mProxify = SettingsStore.getInstance(getContext()).getLayersEnabled();
 
     public interface MenuDelegate {
         void onSendTab();
@@ -109,10 +108,8 @@ public class HamburgerMenuWidget extends UIWidget implements
         updateUI();
     }
 
-    @Override
-    public void show(int aShowFlags) {
-        mWidgetPlacement.proxifyLayer = mProxify;
-        super.show(aShowFlags);
+    private void internalShow(boolean proxifyLayer) {
+        mWidgetPlacement.proxifyLayer = proxifyLayer;
 
         if (mWidgetManager != null) {
             mWidgetManager.addFocusChangeListener(this);
@@ -121,6 +118,18 @@ public class HamburgerMenuWidget extends UIWidget implements
         ComponentsAdapter.get().addStoreUpdatesListener(this);
 
         AnimationHelper.scaleIn(findViewById(R.id.menuContainer), 100, 0, null);
+    }
+
+    @Override
+    public void show(int aShowFlags) {
+        super.show(aShowFlags);
+        if (mWidgetManager == null) {
+            internalShow(false);
+        } else {
+            mWidgetManager.areCompositionLayersSupported(supported -> {
+                internalShow(supported);
+            });
+        }
     }
 
     @Override

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -946,6 +946,7 @@ BrowserWorld::RegisterDeviceDelegate(DeviceDelegatePtr aDelegate) {
     m.device->SetControllerDelegate(delegate);
     m.device->SetReorientClient(this);
     m.gestures = m.device->GetGestureDelegate();
+    VRBrowser::OnMaxCompositionLayersAvailable(m.device->MaxCompositionLayers());
   } else if (previousDevice) {
     m.leftCamera = m.rightCamera = nullptr;
     m.controllers->Reset();

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -140,6 +140,7 @@ public:
   virtual bool PopulateTrackedKeyboardInfo(TrackedKeyboardInfo& keyboardInfo) { return false; };
   virtual void SetHandTrackingEnabled(bool value) {};
   virtual float GetSelectThreshold(int32_t controllerIndex) { return 1.f; };
+  virtual unsigned MaxCompositionLayers() const { return 1; }
 
 protected:
   DeviceDelegate() {}

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -54,8 +54,6 @@ const char* const kGetActiveEnvironment = "getActiveEnvironment";
 const char* const kGetActiveEnvironmentSignature = "()Ljava/lang/String;";
 const char* const kGetPointerColor = "getPointerColor";
 const char* const kGetPointerColorSignature = "()I";
-const char* const kAreLayersEnabled = "areLayersEnabled";
-const char* const kAreLayersEnabledSignature = "()Z";
 const char* const kSetDeviceType = "setDeviceType";
 const char* const kSetDeviceTypeSignature = "(I)V";
 const char* const kHaltActivity = "haltActivity";
@@ -80,6 +78,8 @@ const char* const kOnControllersAvailable = "onControllersAvailable";
 const char* const kOnControllersAvailableSignature = "()V";
 const char* const kChangeWindowDistance = "changeWindowDistance";
 const char* const kChangeWindowDistanceSignature = "(F)V";
+const char* const kOnMaxCompositionLayersAvailableName = "onMaxCompositionLayersAvailable";
+const char* const kOnMaxCompositionLayersAvailableSignature = "(I)V";
 
 JNIEnv* sEnv = nullptr;
 jclass sBrowserClass = nullptr;
@@ -106,7 +106,6 @@ jmethodID sCheckTogglePassthrough = nullptr;
 jmethodID sResetWindowsPosition = nullptr;
 jmethodID sGetActiveEnvironment = nullptr;
 jmethodID sGetPointerColor = nullptr;
-jmethodID sAreLayersEnabled = nullptr;
 jmethodID sSetDeviceType = nullptr;
 jmethodID sHaltActivity = nullptr;
 jmethodID sHandlePoorPerformance = nullptr;
@@ -119,6 +118,7 @@ jmethodID sSetEyeTrackingSupported = nullptr;
 jmethodID sSetHandTrackingSupported = nullptr;
 jmethodID sOnControllersAvailable = nullptr;
 jmethodID sChangeWindowDistance = nullptr;
+jmethodID sOnMaxCompositionLayersAvailable = nullptr;
 
 } // namespace
 
@@ -161,7 +161,6 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sResetWindowsPosition = FindJNIMethodID(sEnv, sBrowserClass, kResetWindowsPosition, kResetWindowsPositionSignature);
   sGetActiveEnvironment = FindJNIMethodID(sEnv, sBrowserClass, kGetActiveEnvironment, kGetActiveEnvironmentSignature);
   sGetPointerColor = FindJNIMethodID(sEnv, sBrowserClass, kGetPointerColor, kGetPointerColorSignature);
-  sAreLayersEnabled = FindJNIMethodID(sEnv, sBrowserClass, kAreLayersEnabled, kAreLayersEnabledSignature);
   sSetDeviceType = FindJNIMethodID(sEnv, sBrowserClass, kSetDeviceType, kSetDeviceTypeSignature);
   sHaltActivity = FindJNIMethodID(sEnv, sBrowserClass, kHaltActivity, kHaltActivitySignature);
   sHandlePoorPerformance = FindJNIMethodID(sEnv, sBrowserClass, kHandlePoorPerformance, kHandlePoorPerformanceSignature);
@@ -174,6 +173,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sSetHandTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetHandTrackingSupported, kSetHandTrackingSupportedSignature);
   sOnControllersAvailable = FindJNIMethodID(sEnv, sBrowserClass, kOnControllersAvailable, kOnControllersAvailableSignature);
   sChangeWindowDistance = FindJNIMethodID(sEnv, sBrowserClass, kChangeWindowDistance, kChangeWindowDistanceSignature);
+  sOnMaxCompositionLayersAvailable = FindJNIMethodID(sEnv, sBrowserClass, kOnMaxCompositionLayersAvailableName, kOnMaxCompositionLayersAvailableSignature);
 }
 
 JNIEnv * VRBrowser::Env()
@@ -216,7 +216,6 @@ VRBrowser::ShutdownJava() {
   sResetWindowsPosition = nullptr;
   sGetActiveEnvironment = nullptr;
   sGetPointerColor = nullptr;
-  sAreLayersEnabled = nullptr;
   sSetDeviceType = nullptr;
   sHaltActivity = nullptr;
   sOnAppLink = nullptr;
@@ -224,6 +223,7 @@ VRBrowser::ShutdownJava() {
   sEnv = nullptr;
   sAppendAppNotesToCrashReport = nullptr;
   sChangeWindowDistance = nullptr;
+  sOnMaxCompositionLayersAvailable = nullptr;
 }
 
 void
@@ -418,15 +418,6 @@ VRBrowser::GetPointerColor() {
   return (int32_t )jHexColor;
 }
 
-bool
-VRBrowser::AreLayersEnabled() {
-  if (!ValidateMethodID(sEnv, sActivity, sAreLayersEnabled, __FUNCTION__)) { return false; }
-  jboolean enabled = sEnv->CallBooleanMethod(sActivity, sAreLayersEnabled);
-  CheckJNIException(sEnv, __FUNCTION__);
-
-  return enabled;
-}
-
 void
 VRBrowser::SetDeviceType(const jint aType) {
   if (!ValidateMethodID(sEnv, sActivity, sSetDeviceType, __FUNCTION__)) { return; }
@@ -514,6 +505,13 @@ void
 VRBrowser::ChangeWindowDistance(jfloat aDelta) {
     if (!ValidateMethodID(sEnv, sActivity, sChangeWindowDistance, __FUNCTION__)) { return; }
     sEnv->CallVoidMethod(sActivity, sChangeWindowDistance, aDelta);
+    CheckJNIException(sEnv, __FUNCTION__);
+}
+
+void
+VRBrowser::OnMaxCompositionLayersAvailable(jint aNumLayers) {
+    if (!ValidateMethodID(sEnv, sActivity, sOnMaxCompositionLayersAvailable, __FUNCTION__)) { return; }
+    sEnv->CallVoidMethod(sActivity, sOnMaxCompositionLayersAvailable, aNumLayers);
     CheckJNIException(sEnv, __FUNCTION__);
 }
 

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -54,6 +54,7 @@ void SetEyeTrackingSupported(bool aIsSupported);
 void SetHandTrackingSupported(bool aIsSupported);
 void OnControllersAvailable();
 void ChangeWindowDistance(jfloat aDelta);
+void OnMaxCompositionLayersAvailable(jint aNumLayers);
 } // namespace VRBrowser;
 
 } // namespace crow

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -140,7 +140,6 @@ struct DeviceDelegateOpenXR::State {
     for (int i = 0; i < 2; ++i) {
       cameras[i] = vrb::CameraEye::Create(localContext->GetRenderThreadCreationContext());
     }
-    layersEnabled = VRBrowser::AreLayersEnabled();
 
 #ifndef HVR
     PFN_xrInitializeLoaderKHR initializeLoaderKHR;
@@ -310,6 +309,7 @@ struct DeviceDelegateOpenXR::State {
     CHECK_XRCMD(xrGetSystemProperties(instance, system, &systemProperties))
     VRB_LOG("OpenXR system name: %s", systemProperties.systemName);
 
+    layersEnabled = systemProperties.graphicsProperties.maxLayerCount > 1 && OpenXRExtensions::IsExtensionSupported(XR_KHR_ANDROID_SURFACE_SWAPCHAIN_EXTENSION_NAME);
     if (systemProperties.graphicsProperties.maxLayerCount == 0)
         VRB_ERROR("OpenXR runtime reports 0 layers. There must be at least 1");
 
@@ -1782,6 +1782,14 @@ DeviceDelegateOpenXR::UpdatePassthrough() {
     OpenXRExtensions::sXrPassthroughLayerResumeFB(m.passthroughLayer->GetPassthroughLayerHandle());
   else
     OpenXRExtensions::sXrPassthroughLayerPauseFB(m.passthroughLayer->GetPassthroughLayerHandle());
+}
+
+unsigned
+DeviceDelegateOpenXR::MaxCompositionLayers() const {
+  CHECK(m.instance != XR_NULL_HANDLE && m.system != XR_NULL_SYSTEM_ID);
+  // Even if the runtime supports multiple layers, do not report them if the Android surface
+  // swapchain extension is not available, because we won't be able to create the swapchains
+  return m.layersEnabled ? m.systemProperties.graphicsProperties.maxLayerCount : 1;
 }
 
 } // namespace crow

--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.h
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.h
@@ -81,6 +81,7 @@ public:
   bool ShouldExitRenderLoop() const;
   void SetImmersiveBlendMode(device::BlendMode) override;
   float GetSelectThreshold(int32_t controllerIndex) override;
+  unsigned MaxCompositionLayers() const override;
 
 protected:
   struct State;


### PR DESCRIPTION
The check for support for composition layers must be done in the backend (OpenXR) which is the one with enough data to decide.

We were doing it the other way around, checking which devices did support them and forcing it in the Java side because we knew that would work on the native side.

It's much safer and less error prone to do it on the backend. This forces us to make some Java calls asynchronous because we don't know whether the backend has done its checks or not.