### PR TITLE
Build system improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ on:
         description: 'Gradle version'
         required: false
         type: string
-        default: "8.9"
+        default: "8.13"
 
 jobs:
   build:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ if (getGradle().getStartParameter().getTaskRequests().toString() =~ /[Hh]vr/
 
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()
-    exec {
+    project.exec {
         commandLine 'git', 'rev-parse', '--short', 'HEAD'
         standardOutput = stdout
     }
@@ -156,8 +156,6 @@ android {
         vectorDrawables.useSupportLibrary = true
     }
 
-    project.archivesBaseName = "Wolvic"
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -199,6 +197,19 @@ android {
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
+        }
+    }
+
+    // Select the Glean from GeckoView.
+    // `service-sync-logins` requires Glean, which pulls in glean-native,
+    // but that's also provided by geckoview-omni, so now we need to select which one to use.
+    project.configurations.configureEach {
+        resolutionStrategy.capabilitiesResolution.withCapability("org.mozilla.telemetry:glean-native") {
+            def toBeSelected = candidates.find { it.id instanceof ModuleComponentIdentifier && it.id.module.contains('geckoview') }
+            if (toBeSelected != null) {
+                select(toBeSelected)
+            }
+            because 'use GeckoView Glean instead of standalone Glean'
         }
     }
 
@@ -695,7 +706,7 @@ dependencies {
     configurations.all {
          resolutionStrategy.capabilitiesResolution.withCapability('org.mozilla.geckoview:geckoview') {
             def abi = getName().toLowerCase().contains('x64') ? 'x86_64' : 'arm64'
-            def candidate = branch == "release" ? "geckoview-${abi}" : "geckoview-${branch}-${abi}"
+            def candidate = branch == "release" ? "geckoview-omni-${abi}" : "geckoview-${branch}-omni-${abi}"
             select(candidates.find { it.id.module.contains(candidate) })
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     dependencies {
         classpath libs.agp
-        classpath libs.r8
         classpath libs.kotlin.plugin
         classpath libs.huawei.agconnect.agcp
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,37 @@ buildscript {
     }
 }
 
+plugins {
+    alias libs.plugins.dependency.analysis
+}
+
 allprojects {
     repositories {
         google()
         maven { url 'https://maven.mozilla.org/maven2' }
         maven { url 'https://developer.huawei.com/repo/' }
         maven { url 'https://storage.googleapis.com/r8-releases/raw' }
+    }
+}
+
+dependencyAnalysis {
+    structure {
+        // Ignore Android KTX dependencies. See https://developer.android.com/kotlin/ktx#modules
+        ignoreKtx(true)
+    }
+    issues {
+        all {
+            onAny {
+                // Fail the run if any issues are found (default = 'warn')
+                severity('fail')
+                // Ignore warnings about kotlin-stdlib since we don't directly control its usage
+                exclude('org.jetbrains.kotlin:kotlin-stdlib')
+            }
+            onUsedTransitiveDependencies {
+                // We explicitly want to pull in these dependencies transitively from AC
+                exclude('org.mozilla.appservices.nightly:fxaclient', 'org.mozilla.geckoview:geckoview-omni')
+            }
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ okhttp = "4.12.0"
 opentelemetryAndroid = "0.9.1-alpha"
 opentelemetryApi = "1.46.0"
 openxrLoader = "1.0.34"
-r8 = "8.7.18"
 robolectric = "4.11.1"
 zip4j = "2.11.5"
 
@@ -138,8 +137,6 @@ opentelemetry-android-instrumentation-crash = { module = "io.opentelemetry.andro
 opentelemetry-android-instrumentation-sessions = { module = "io.opentelemetry.android:instrumentation-sessions", version.ref = "opentelemetryAndroid" }
 # OpenXR
 openxrloader = { module = "org.khronos.openxr:openxr_loader_for_android", version.ref = "openxrLoader" }
-# R8
-r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 # Robolectric
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 # Room

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.2"
+agp = "8.11.1"
 androidComponents = "128.0"
 androidxAnnotation = "1.6.0"
 androidxAppcompat = "1.6.1"
@@ -18,6 +18,7 @@ atslRunner = "1.5.2"
 atslJunit = "1.1.5"
 colorpickerpreference = "2.0.6"
 desugarJdkLibs = "2.1.4"
+dependency-analysis = "3.0.1"
 diskLruCache = "2.0.2"
 espresso= "3.5.1"
 gamesActivity = "4.0.0"
@@ -96,12 +97,12 @@ espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref =
 # Games Activity
 games-activity = { module = "androidx.games:games-activity", version.ref = "gamesActivity" }
 # GeckoView
-geckoview-beta-arm64 = { module = "org.mozilla.geckoview:geckoview-beta-arm64-v8", version.ref = "geckoviewBeta" }
-geckoview-beta-x64 = { module = "org.mozilla.geckoview:geckoview-beta-x86_64", version.ref = "geckoviewBeta" }
-geckoview-nightly-arm64 = { module = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a", version.ref = "geckoviewNightly" }
-geckoview-nightly-x64 = { module = "org.mozilla.geckoview:geckoview-nightly-x86_64", version.ref = "geckoviewNightly" }
-geckoview-release-arm64 = { module = "org.mozilla.geckoview:geckoview-arm64-v8a", version.ref = "geckoviewRelease" }
-geckoview-release-x64 = { module = "org.mozilla.geckoview:geckoview-x86_64", version.ref = "geckoviewRelease" }
+geckoview-beta-arm64 = { module = "org.mozilla.geckoview:geckoview-omni-beta-arm64-v8", version.ref = "geckoviewBeta" }
+geckoview-beta-x64 = { module = "org.mozilla.geckoview:geckoview-omni-beta-x86_64", version.ref = "geckoviewBeta" }
+geckoview-nightly-arm64 = { module = "org.mozilla.geckoview:geckoview-nightly-omni-arm64-v8a", version.ref = "geckoviewNightly" }
+geckoview-nightly-x64 = { module = "org.mozilla.geckoview:geckoview-nightly-omni-x86_64", version.ref = "geckoviewNightly" }
+geckoview-release-arm64 = { module = "org.mozilla.geckoview:geckoview-omni-arm64-v8a", version.ref = "geckoviewRelease" }
+geckoview-release-x64 = { module = "org.mozilla.geckoview:geckoview-omni-x86_64", version.ref = "geckoviewRelease" }
 # GSON
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 # Huawei
@@ -161,4 +162,5 @@ work-testing = { module = "androidx.work:work-testing", version.ref = "androidxW
 zip4j = { module = "net.lingala.zip4j:zip4j", version.ref = "zip4j" }
 
 [plugins]
+dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 jetbrains-python-envs = { id = "com.jetbrains.python.envs", version.ref = "jetbrainsPython" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 21 16:13:31 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
There are a few changes that we can make to the build system to improve it and fix some issues:

1. modify the build system to look for the GV (GeckoView) omni version. The current build does look for the lite version instead and for a full-fledged browser we must use the omni version.
2. the change to the omni version of GV pulls some dependencies from Gecko, like glean, that are also provided by mozilla android components. That means that we need to add dependency resolution code to gradle.
3. the dependency resolution code depends on a more recent version of gradle and its plugin, so we need to bump that version too.
4. last but not least, we were manually specifying an R8 version in our deps. However R8 is bundled inside android gradle plugin so there is no need to specify another dependency. What's more those multiple versions could be the source of issues during the minification process.