### PR TITLE
Add an UA override for spatialfusion.io

### DIFF
--- a/app/src/gecko/assets/userAgentOverride.json
+++ b/app/src/gecko/assets/userAgentOverride.json
@@ -21,6 +21,7 @@
   "b1788b8e6dd78d0d5b91b66f8f9be9f9eae5024a38e426aaa2f0f7859d96b56fd693941f8a3ef071c4f21367f26cd14ff6ef4303c1fbec7e33ff1ca44137431f": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
   "c0f87f0034d49b825116cdb8a9387e9b3715dd78f6affb05cd3141c3e56c780ffde29f68347278a2b8fa5fc20e09a693f61bd4189d42c109ae29105ba89b5bbb": "Mozilla/5.0 (X11; LinuxX86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
   "41ff0a55eb311911674b0c8a68eda6f2078cba4f7a44d6af6290fe149330e6d4e34493b0b0f81fc69d1a2345dac539e1bee8ac7d9704f84a81271e0411da0536": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
-  "2bfa15616eae89fd65c14de431f1b14ca64a21aa7bbf4f7a058fa44bd760b4dc800afee6ad239fe62fd57439187e49795ad80b3519723e513c019c1472011b74": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36"
+  "2bfa15616eae89fd65c14de431f1b14ca64a21aa7bbf4f7a058fa44bd760b4dc800afee6ad239fe62fd57439187e49795ad80b3519723e513c019c1472011b74": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36",
+  "aacfce8ae3678bafb9485588d15233cecc4fd0ce7d592728a277987961536159b382e2667daba893d5c80c714cd1748639be8b95354f5a5cd22ab11d364bf1e1": "Mozilla/5.0 (Linux; Android 10.1.1; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/17.2.0.9.61 SamsungBrowser/4.0 Chrome/93.0.3163.109 Mobile VR Safari/537.36"
 }
 


### PR DESCRIPTION
That allows Wolvic not to be filtered out by UA. The experience does not launch anyway because we don't support some required features like plane detection for example.