### PR TITLE
[Chromium] Do not stop find-in-page if there were no previous searches

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionFinderImpl.kt
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionFinderImpl.kt
@@ -27,7 +27,7 @@ class SessionFinderImpl(private val webContents: WebContents) : WSession.Session
     }
 
     override fun clear() {
-        mFinder.stopFinding(true);
+        previousSearchString?.let { mFinder.stopFinding(true) }
         previousSearchString = null
     }
 


### PR DESCRIPTION
Calling stop in the find helper might cause crashes in case not previous search had happened before. It's sane to do that anyway as there is no point in stopping an action that hasn't started yet.

Fixes #1921