### PR TITLE
Version bump to v1.9 (v1.3)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,8 +101,8 @@ def isWebKitAvailable = {
 }
 
 // Version names for Gecko and Chromium releases.
-def GECKO_RELEASE_VERSION_NAME = '1.8.1'
-def CHROMIUM_RELEASE_VERSION_NAME = '1.2.1'
+def GECKO_RELEASE_VERSION_NAME = '1.9'
+def CHROMIUM_RELEASE_VERSION_NAME = '1.3'
 
 android {
     namespace 'com.igalia.wolvic'


### PR DESCRIPTION
We forgot to bump the Wolvic version in main when we branched for 1.8.x (and 1.2.x for chromium). Better late than never.