### PR TITLE
Check pose's valid bit instead of tracked bit

### DIFF
--- a/app/src/openxr/cpp/OpenXRInput.cpp
+++ b/app/src/openxr/cpp/OpenXRInput.cpp
@@ -295,8 +295,8 @@ bool OpenXRInput::PopulateTrackedKeyboardInfo(DeviceDelegate::TrackedKeyboardInf
   // Only report keyboard as active (be shown to the user) if it is connected and actively tracked.
   keyboardInfo.isActive =
     (keyboardTrackingFB->description.flags & XR_KEYBOARD_TRACKING_CONNECTED_BIT_FB) != 0 &&
-    (keyboardTrackingFB->location.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT) != 0 &&
-    (keyboardTrackingFB->location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT) != 0;
+    (keyboardTrackingFB->location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0 &&
+    (keyboardTrackingFB->location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0;
 
   // Copy the model buffer over only if it has changed
   if (keyboardTrackingFB->modelBufferChanged) {


### PR DESCRIPTION
It's safer, more reliable and error-resistant to check the valid bit than the tracked bit. First of all, from the functionality POV we do really want to check that the pose is valid, it does not really matter whether it's tracked or emulated by the runtime. Also many runtimes are buggy and do not properly fill in the tracked bit. Last but not least it allows us to remove fallbacks for those buggy runtimes.