### PR TITLE
[Chromium] Fix the total matches count in find in page

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionFinderImpl.kt
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/SessionFinderImpl.kt
@@ -40,6 +40,9 @@ class SessionFinderImpl(private val webContents: WebContents) : WSession.Session
     }
 
     override fun onFindResultAvailable(details: FindNotificationDetails) {
+        if (!details.finalUpdate)
+            return
+
         val finderResult = WSession.SessionFinder.FinderResult().apply {
             found = details.numberOfMatches > 0
             current = details.activeMatchOrdinal


### PR DESCRIPTION
The code assumes that the Web Engine reports the number of matches only once (as Gecko does). However Chromium reports partial results on the go. As the code was only considering the first notification from the engine we were not properly picking the right values for current and total number of matches (just the first partial results).

Fixes #1481