### PR TITLE
Update CHROMIUM.md

### DIFF
--- a/CHROMIUM.md
+++ b/CHROMIUM.md
@@ -119,6 +119,11 @@ proprietary_codecs=true
 _Build Command:_
 
 ```
+autoninja -C out/Default content_aar ui_aar
+```
+
+If the `autoninja` command fails, you can try to build directly with `ninja`:
+```
 ninja -C out/Default content_aar ui_aar
 ```
 


### PR DESCRIPTION
Fix build instructions:
- It is required to run again gclient sync after switching to the wolvic branch. Otherwise, the `gn gen` command fails.
- `autoninja` doesn't work anymore to build the project. Directly calling `ninja` allows to build without issues.

The second issue is probably due to an incompatibility between an up-to-date `depot_tools` and the `wolvic` branch of Chromium.