### PR TITLE
Support step and list attributes on DateTime picker

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
@@ -630,8 +630,7 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
         public void showDialog(final int type, final double value,
                                double min, double max, double step,
                                DateTimeSuggestion[] suggestions) {
-            // Not implemented for |suggestions| and |step| yet.
-            mDatePrompt.setDateTime(type, value, min, max);
+            mDatePrompt.setDateTime(type, value, min, max, step, suggestions);
 
             try {
                 if (mDelegate != null) {
@@ -652,11 +651,17 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
     }
 
     public static class DateTimePrompt extends BasePromptImpl implements WSession.PromptDelegate.DateTimePrompt {
+        private static final double MS_PER_SECOND = 1000.0;
+        private static final double MS_PER_DAY = 86400000.0;
+        private static final double MS_PER_WEEK = 604800000.0;
+
         private final InputDialogContainer.InputActionDelegate mDelegate;
         @DatetimeType int mType;
         String mDefaultValue;
         String mMinValue;
         String mMaxValue;
+        String mStepValue;
+        String[] mListValues;
 
         SimpleDateFormat mFormatter;
 
@@ -665,6 +670,11 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
         }
 
         public void setDateTime(int type, double value, double min, double max) {
+            setDateTime(type, value, min, max, Double.NaN, null);
+        }
+
+        public void setDateTime(int type, double value, double min, double max,
+                                double step, DateTimeSuggestion[] suggestions) {
             String format;
             if (type == TextInputType.DATE) {
                 mType = Type.DATE;
@@ -699,6 +709,44 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
             mDefaultValue = mFormatter.format(defaultDate);
             mMinValue = mFormatter.format(new Date((long) min));
             mMaxValue = mFormatter.format(new Date((long) max));
+
+            // Chromium gives us the step already multiplied by the type's scale
+            // factor (e.g. 86 400 000 per day for date, 1 000 per second for
+            // time).  Normalise it back to the raw HTML attribute unit so the
+            // widget receives the same value as the Gecko backend.
+            if (!Double.isNaN(step) && step > 0) {
+                if (mType == Type.DATE) {
+                    step = step / MS_PER_DAY;
+                } else if (mType == Type.TIME || mType == Type.DATETIME_LOCAL) {
+                    step = step / MS_PER_SECOND;
+                } else if (mType == Type.WEEK) {
+                    step = step / MS_PER_WEEK;
+                }
+                // MONTH scale factor is 1, no conversion needed
+            }
+            mStepValue = Double.isNaN(step) || step <= 0 ? null : String.valueOf(step);
+
+            // Convert suggestion values to formatted strings. MONTH and WEEK
+            // use a special Chromium encoding (MonthPicker/WeekPicker), the
+            // rest are plain ms-since-epoch.
+            if (suggestions != null && suggestions.length > 0) {
+                List<String> listVals = new ArrayList<>();
+                for (DateTimeSuggestion s : suggestions) {
+                    try {
+                        double sv = s.value();
+                        if (mType == Type.MONTH) {
+                            sv = MonthPicker.createDateFromValue(sv).getTimeInMillis();
+                        } else if (mType == Type.WEEK) {
+                            sv = WeekPicker.createDateFromValue(sv).getTimeInMillis();
+                        }
+                        listVals.add(mFormatter.format(new Date((long) sv)));
+                    } catch (Exception ignored) {
+                    }
+                }
+                mListValues = listVals.isEmpty() ? null : listVals.toArray(new String[0]);
+            } else {
+                mListValues = null;
+            }
         }
 
         @Override
@@ -716,6 +764,14 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
         @Override
         @Nullable
         public String maxValue() { return mMaxValue; }
+
+        @Override
+        @Nullable
+        public String stepValue() { return mStepValue; }
+
+        @Override
+        @Nullable
+        public String[] listValues() { return mListValues; }
 
         @UiThread
         @NonNull

--- a/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
+++ b/app/src/common/gecko/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
@@ -507,6 +507,20 @@ class PromptDelegateImpl implements GeckoSession.PromptDelegate {
                 return mGeckoPrompt.maxValue;
             }
 
+            @Nullable
+            @Override
+            public String stepValue() {
+                return mGeckoPrompt.stepValue;
+            }
+
+            @Nullable
+            @Override
+            public String[] listValues() {
+                // GeckoView does not expose datalist suggestions via DateTimePrompt;
+                // return null so the widget falls back gracefully.
+                return null;
+            }
+
             @NonNull
             @Override
             public WSession.PromptDelegate.PromptResponse confirm(@NonNull String datetime) {

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WSession.java
@@ -1246,6 +1246,16 @@ public interface WSession {
             @Nullable String maxValue();
 
             /**
+             * A String representing the step attribute value, or null if not specified.
+             */
+            @Nullable String stepValue();
+
+            /**
+             * Suggested values from a datalist element (list attribute). May be null.
+             */
+            @Nullable String[] listValues();
+
+            /**
              * Confirms the prompt and passes the date and/or time value back to content.
              *
              * @param datetime A String representing the date and time to be returned to content.

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/DateTimePromptWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/prompts/DateTimePromptWidget.java
@@ -3,9 +3,11 @@ package com.igalia.wolvic.ui.widgets.prompts;
 import android.content.Context;
 import android.text.format.DateFormat;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
-
 import android.widget.DatePicker;
+import android.widget.Spinner;
 import android.widget.TimePicker;
 
 import com.igalia.wolvic.R;
@@ -14,15 +16,18 @@ import com.igalia.wolvic.browser.api.WSession;
 import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
-
 public class DateTimePromptWidget extends PromptWidget {
+
     private AudioEngine mAudio;
     private Button mCancelButton, mClearButton, mOkButton;
     private WSession.PromptDelegate.DateTimePrompt mPrompt;
@@ -32,6 +37,7 @@ public class DateTimePromptWidget extends PromptWidget {
         YES,
         NO
     }
+
     private static Date parseDate(final SimpleDateFormat formatter, final String value, final DefaultToNow defaultToNow) {
         try {
             if (value != null && !value.isEmpty()) {
@@ -88,6 +94,12 @@ public class DateTimePromptWidget extends PromptWidget {
         final Calendar cal = formatter.getCalendar();
         cal.setTime(date);
 
+        // Parse step attribute (days for date types, seconds for time)
+        final double stepValue = parseStep(mPrompt.stepValue());
+
+        final String[] listValues = mPrompt.listValues();  // datalist suggestions
+        final List<Date> suggestions = buildSuggestions(formatter, listValues);
+
         if (mPrompt.type() == WSession.PromptDelegate.DateTimePrompt.Type.DATE
                 || mPrompt.type() == WSession.PromptDelegate.DateTimePrompt.Type.MONTH
                 || mPrompt.type() == WSession.PromptDelegate.DateTimePrompt.Type.WEEK
@@ -96,7 +108,7 @@ public class DateTimePromptWidget extends PromptWidget {
             datePicker.init(
                     cal.get(Calendar.YEAR),
                     cal.get(Calendar.MONTH),
-                    cal.get(Calendar.DAY_OF_MONTH), /* listener */
+                    cal.get(Calendar.DAY_OF_MONTH),
                     null);
             if (minDate != null) {
                 datePicker.setMinDate(minDate.getTime());
@@ -147,6 +159,54 @@ public class DateTimePromptWidget extends PromptWidget {
             timePicker = null;
         }
 
+        // Populate suggestions spinner if we have list values
+        final Spinner suggestionsSpinner = findViewById(R.id.suggestions_spinner);
+        if (!suggestions.isEmpty()) {
+            suggestionsSpinner.setVisibility(View.VISIBLE);
+            final List<String> labels = new ArrayList<>();
+            for (Date s : suggestions) {
+                labels.add(formatter.format(s));
+            }
+            final ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                    aContext, android.R.layout.simple_spinner_item, labels);
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+            suggestionsSpinner.setAdapter(adapter);
+
+            // Pre-select the entry that matches the current default value, if any.
+            final String defaultFormatted = formatter.format(date);
+            int preselect = labels.indexOf(defaultFormatted);
+            if (preselect >= 0) {
+                suggestionsSpinner.setSelection(preselect);
+            }
+
+            // When the user picks a suggestion, update the pickers to reflect it.
+            suggestionsSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+                @Override
+                public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                    final Date picked = suggestions.get(position);
+                    final Calendar sc = formatter.getCalendar();
+                    sc.setTime(picked);
+                    if (datePicker != null) {
+                        datePicker.updateDate(
+                                sc.get(Calendar.YEAR),
+                                sc.get(Calendar.MONTH),
+                                sc.get(Calendar.DAY_OF_MONTH));
+                    }
+                    if (timePicker != null) {
+                        timePicker.setHour(sc.get(Calendar.HOUR_OF_DAY));
+                        timePicker.setMinute(sc.get(Calendar.MINUTE));
+                    }
+                    cal.setTime(picked);
+                }
+
+                @Override
+                public void onNothingSelected(AdapterView<?> parent) {
+                }
+            });
+        } else {
+            suggestionsSpinner.setVisibility(View.GONE);
+        }
+
         mCancelButton.setOnClickListener(v -> {
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -179,7 +239,15 @@ public class DateTimePromptWidget extends PromptWidget {
                     cal.set(Calendar.HOUR_OF_DAY, timePicker.getHour());
                     cal.set(Calendar.MINUTE, timePicker.getMinute());
                 }
-                ((DateTimePromptDelegate) mPromptDelegate).confirm(formatter.format(cal.getTime()));
+
+                // Round to nearest step boundary if step is set
+                final String confirmed;
+                if (!Double.isNaN(stepValue) && stepValue > 0) {
+                    confirmed = formatter.format(snapToStep(cal.getTime(), stepValue, minDate, maxDate, mPrompt.type()));
+                } else {
+                    confirmed = formatter.format(cal.getTime());
+                }
+                ((DateTimePromptDelegate) mPromptDelegate).confirm(confirmed);
             }
             hide(REMOVE_WIDGET);
         });
@@ -240,6 +308,64 @@ public class DateTimePromptWidget extends PromptWidget {
         return datePicker.getYear() == boundaryCal.get(Calendar.YEAR)
                 && datePicker.getMonth() == boundaryCal.get(Calendar.MONTH)
                 && datePicker.getDayOfMonth() == boundaryCal.get(Calendar.DAY_OF_MONTH);
+    }
+
+    // Returns NaN if step is null, "any", or invalid.
+    private static double parseStep(@Nullable String stepStr) {
+        if (stepStr == null || stepStr.isEmpty() || "any".equalsIgnoreCase(stepStr)) {
+            return Double.NaN;
+        }
+        try { return Double.parseDouble(stepStr); } catch (NumberFormatException e) { return Double.NaN; }
+    }
+
+    // Parse suggestion strings to Dates, skipping entries that fail.
+    private static List<Date> buildSuggestions(SimpleDateFormat formatter, @Nullable String[] listValues) {
+        final List<Date> result = new ArrayList<>();
+        if (listValues == null) return result;
+        for (String v : listValues) {
+            final Date d = parseDate(formatter, v, DefaultToNow.NO);
+            if (d != null) {
+                result.add(d);
+            }
+        }
+        return result;
+    }
+
+    // Snap to nearest valid step value (base + n*step), then clamp to [minDate, maxDate].
+    // Step unit: days for date, weeks for week, seconds for time/datetime-local.
+    private static final long MS_PER_SECOND = 1000L;
+    private static final long MS_PER_DAY = 24L * 60L * 60L * MS_PER_SECOND;
+    private static final long MS_PER_WEEK = 7L * MS_PER_DAY;
+
+    private static Date snapToStep(Date selected, double stepValue,
+                                   @Nullable Date minDate, @Nullable Date maxDate, int type) {
+        if (type == WSession.PromptDelegate.DateTimePrompt.Type.MONTH) {
+            return selected;
+        }
+
+        final long stepMs;
+        switch (type) {
+            case WSession.PromptDelegate.DateTimePrompt.Type.WEEK:
+                stepMs = Math.round(stepValue * MS_PER_WEEK);
+                break;
+            case WSession.PromptDelegate.DateTimePrompt.Type.TIME:
+            case WSession.PromptDelegate.DateTimePrompt.Type.DATETIME_LOCAL:
+                stepMs = Math.round(stepValue * MS_PER_SECOND);
+                break;
+            default: // DATE
+                stepMs = Math.round(stepValue * MS_PER_DAY);
+                break;
+        }
+        if (stepMs <= 0) return selected;
+
+        final long base = minDate != null ? minDate.getTime() : 0L;
+        final long offset = selected.getTime() - base;
+        Date snapped = new Date(base + Math.round((double) offset / stepMs) * stepMs);
+
+        // Clamp so the snapped value never violates the picker's constraints.
+        if (minDate != null && snapped.before(minDate)) snapped = minDate;
+        if (maxDate != null && snapped.after(maxDate)) snapped = maxDate;
+        return snapped;
     }
 
     public interface DateTimePromptDelegate extends PromptDelegate {

--- a/app/src/main/res/layout/prompt_datetime.xml
+++ b/app/src/main/res/layout/prompt_datetime.xml
@@ -45,19 +45,32 @@
                         android:layout_height="wrap_content"
                         android:background="@drawable/prompt_background"
                         android:layout_margin="20dp"
-                        android:orientation="horizontal">
+                        android:orientation="vertical">
 
-                        <DatePicker
-                            android:id="@+id/date_picker"
-                            android:layout_width="475dp"
-                            android:layout_height="match_parent">
-                        </DatePicker>
+                        <Spinner
+                            android:id="@+id/suggestions_spinner"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="12dp"
+                            android:visibility="gone" />
 
-                        <TimePicker
-                            android:id="@+id/time_picker"
-                            android:layout_width="475dp"
-                            android:layout_height="match_parent">
-                        </TimePicker>
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+
+                            <DatePicker
+                                android:id="@+id/date_picker"
+                                android:layout_width="475dp"
+                                android:layout_height="match_parent">
+                            </DatePicker>
+
+                            <TimePicker
+                                android:id="@+id/time_picker"
+                                android:layout_width="475dp"
+                                android:layout_height="match_parent">
+                            </TimePicker>
+                        </LinearLayout>
                     </LinearLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/test/java/com/igalia/wolvic/DateTimePromptTest.java
+++ b/app/src/test/java/com/igalia/wolvic/DateTimePromptTest.java
@@ -1,0 +1,274 @@
+package com.igalia.wolvic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.igalia.wolvic.browser.api.WSession;
+import com.igalia.wolvic.ui.widgets.prompts.DateTimePromptWidget;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * Tests for DateTime picker step and list attribute helpers.
+ */
+public class DateTimePromptTest {
+
+    // Reflection helpers - the methods under test are private static.
+
+    private double invokeParseStep(String input) throws Exception {
+        Method m = DateTimePromptWidget.class.getDeclaredMethod("parseStep", String.class);
+        m.setAccessible(true);
+        return (double) m.invoke(null, input);
+    }
+
+    private Date invokeSnapToStep(Date selected, double step, Date min, Date max, int type) throws Exception {
+        Method m = DateTimePromptWidget.class.getDeclaredMethod(
+                "snapToStep", Date.class, double.class, Date.class, Date.class, int.class);
+        m.setAccessible(true);
+        return (Date) m.invoke(null, selected, step, min, max, type);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Date> invokeBuildSuggestions(SimpleDateFormat fmt, String[] values) throws Exception {
+        Method m = DateTimePromptWidget.class.getDeclaredMethod(
+                "buildSuggestions", SimpleDateFormat.class, String[].class);
+        m.setAccessible(true);
+        return (List<Date>) m.invoke(null, fmt, values);
+    }
+
+    private SimpleDateFormat utcFmt(String pattern) {
+        SimpleDateFormat sdf = new SimpleDateFormat(pattern, Locale.ROOT);
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf;
+    }
+
+    // parseStep
+
+    @Test
+    public void parseStep_null_isNaN() throws Exception {
+        assertTrue(Double.isNaN(invokeParseStep(null)));
+    }
+
+    @Test
+    public void parseStep_empty_isNaN() throws Exception {
+        assertTrue(Double.isNaN(invokeParseStep("")));
+    }
+
+    @Test
+    public void parseStep_any_isNaN() throws Exception {
+        assertTrue(Double.isNaN(invokeParseStep("any")));
+    }
+
+    @Test
+    public void parseStep_anyMixedCase_isNaN() throws Exception {
+        assertTrue(Double.isNaN(invokeParseStep("ANY")));
+    }
+
+    @Test
+    public void parseStep_garbage_isNaN() throws Exception {
+        assertTrue(Double.isNaN(invokeParseStep("not-a-number")));
+    }
+
+    @Test
+    public void parseStep_integer_returnsValue() throws Exception {
+        assertEquals(2.0, invokeParseStep("2"), 0.0);
+    }
+
+    @Test
+    public void parseStep_decimal_returnsValue() throws Exception {
+        assertEquals(0.5, invokeParseStep("0.5"), 0.0);
+    }
+
+    @Test
+    public void parseStep_largeSeconds_returnsValue() throws Exception {
+        assertEquals(3600.0, invokeParseStep("3600"), 0.0);
+    }
+
+    // snapToStep - DATE type (step unit = days)
+
+    @Test
+    public void snapToStep_date_exactMultiple_unchanged() throws Exception {
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date min      = fmt.parse("2024-01-01");
+        Date selected = fmt.parse("2024-01-05"); // 4 days after min, step=2 -> n=2 exactly
+        Date result   = invokeSnapToStep(selected, 2.0, min, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.DATE);
+        assertEquals("2024-01-05", fmt.format(result));
+    }
+
+    @Test
+    public void snapToStep_date_roundsDown() throws Exception {
+        // Jan 4 is 3 days after min, rounds down to Jan 1 with step=7
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date min      = fmt.parse("2024-01-01");
+        Date selected = fmt.parse("2024-01-04");
+        Date result   = invokeSnapToStep(selected, 7.0, min, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.DATE);
+        assertEquals("2024-01-01", fmt.format(result));
+    }
+
+    @Test
+    public void snapToStep_date_roundsUp() throws Exception {
+        // Jan 6 is 5 days after min, closer to Jan 8 (step=7)
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date min      = fmt.parse("2024-01-01");
+        Date selected = fmt.parse("2024-01-06");
+        Date result   = invokeSnapToStep(selected, 7.0, min, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.DATE);
+        assertEquals("2024-01-08", fmt.format(result));
+    }
+
+    @Test
+    public void snapToStep_date_noMin_usesEpoch() throws Exception {
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date selected = fmt.parse("1970-01-03"); // 2 days from epoch, step=2 -> n=1 exact
+        Date result   = invokeSnapToStep(selected, 2.0, null, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.DATE);
+        assertEquals("1970-01-03", fmt.format(result));
+    }
+
+    // snapToStep - WEEK type (step unit = weeks, so step=1 = 7 days)
+
+    @Test
+    public void snapToStep_week_snapsToWeekBoundary() throws Exception {
+        // step=2 weeks from Jan 1.  Jan 10 is 9 days in -> closer to 14 (2 wks) than 0
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date min      = fmt.parse("2024-01-01");
+        Date selected = fmt.parse("2024-01-10");
+        Date result   = invokeSnapToStep(selected, 2.0, min, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.WEEK);
+        assertEquals("2024-01-15", fmt.format(result));
+    }
+
+    // snapToStep - MONTH type (no-op, type=month is not used in practice)
+
+    @Test
+    public void snapToStep_month_returnsUnchanged() throws Exception {
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date min      = fmt.parse("2024-01-01");
+        Date selected = fmt.parse("2024-03-17");
+        Date result   = invokeSnapToStep(selected, 2.0, min, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.MONTH);
+        assertEquals("2024-03-17", fmt.format(result));
+    }
+
+    // snapToStep - TIME type (step unit = seconds)
+
+    @Test
+    public void snapToStep_time_snapsToNearest15Min() throws Exception {
+        // step=900s (15 min). 00:17 -> snaps to 00:15
+        SimpleDateFormat fmt = utcFmt("HH:mm");
+        Date selected = fmt.parse("00:17");
+        Date result   = invokeSnapToStep(selected, 900.0, null, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.TIME);
+        assertEquals("00:15", fmt.format(result));
+    }
+
+    @Test
+    public void snapToStep_time_exactBoundary_unchanged() throws Exception {
+        SimpleDateFormat fmt = utcFmt("HH:mm");
+        Date selected = fmt.parse("01:30"); // 5400s / 900 = 6, exact
+        Date result   = invokeSnapToStep(selected, 900.0, null, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.TIME);
+        assertEquals("01:30", fmt.format(result));
+    }
+
+    @Test
+    public void snapToStep_time_withMin_snapsRelativeToMin() throws Exception {
+        // min=00:05, step=900s, 00:22 is 1020s after min -> closer to 900 than 1800
+        SimpleDateFormat fmt = utcFmt("HH:mm");
+        Date min      = fmt.parse("00:05");
+        Date selected = fmt.parse("00:22");
+        Date result   = invokeSnapToStep(selected, 900.0, min, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.TIME);
+        assertEquals("00:20", fmt.format(result));
+    }
+
+    // snapToStep - clamping to [min, max]
+
+    @Test
+    public void snapToStep_clampedToMax() throws Exception {
+        // min=2024-01-01, max=2024-01-05, step=7 -> snapping Jan 5 would go to Jan 8, clamp to Jan 5
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date min      = fmt.parse("2024-01-01");
+        Date max      = fmt.parse("2024-01-05");
+        Date selected = fmt.parse("2024-01-05");
+        Date result   = invokeSnapToStep(selected, 7.0, min, max,
+                WSession.PromptDelegate.DateTimePrompt.Type.DATE);
+        assertEquals("2024-01-05", fmt.format(result));
+    }
+
+    @Test
+    public void snapToStep_clampedToMin() throws Exception {
+        // If snapping rounds below min, result should be min
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        Date min      = fmt.parse("2024-01-03");
+        Date selected = fmt.parse("2024-01-03");
+        Date result   = invokeSnapToStep(selected, 7.0, min, null,
+                WSession.PromptDelegate.DateTimePrompt.Type.DATE);
+        // offset=0, snaps to base=min exactly
+        assertEquals("2024-01-03", fmt.format(result));
+    }
+
+    // buildSuggestions
+
+    @Test
+    public void buildSuggestions_null_returnsEmpty() throws Exception {
+        List<Date> result = invokeBuildSuggestions(utcFmt("yyyy-MM-dd"), null);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void buildSuggestions_emptyArray_returnsEmpty() throws Exception {
+        List<Date> result = invokeBuildSuggestions(utcFmt("yyyy-MM-dd"), new String[0]);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void buildSuggestions_validDates_allParsed() throws Exception {
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        List<Date> result = invokeBuildSuggestions(fmt,
+                new String[]{"2024-03-15", "2024-06-01", "2024-12-25"});
+        assertEquals(3, result.size());
+        assertEquals("2024-03-15", fmt.format(result.get(0)));
+        assertEquals("2024-06-01", fmt.format(result.get(1)));
+        assertEquals("2024-12-25", fmt.format(result.get(2)));
+    }
+
+    @Test
+    public void buildSuggestions_invalidEntriesSkipped() throws Exception {
+        SimpleDateFormat fmt = utcFmt("yyyy-MM-dd");
+        List<Date> result = invokeBuildSuggestions(fmt,
+                new String[]{"2024-03-15", "not-a-date", "2024-06-01", "", null});
+        assertEquals(2, result.size());
+        assertEquals("2024-03-15", fmt.format(result.get(0)));
+        assertEquals("2024-06-01", fmt.format(result.get(1)));
+    }
+
+    @Test
+    public void buildSuggestions_timeFormat_parsedCorrectly() throws Exception {
+        SimpleDateFormat fmt = utcFmt("HH:mm");
+        List<Date> result = invokeBuildSuggestions(fmt,
+                new String[]{"09:00", "12:30", "18:45"});
+        assertEquals(3, result.size());
+        assertEquals("09:00", fmt.format(result.get(0)));
+        assertEquals("12:30", fmt.format(result.get(1)));
+        assertEquals("18:45", fmt.format(result.get(2)));
+    }
+
+    @Test
+    public void buildSuggestions_allInvalid_returnsEmpty() throws Exception {
+        List<Date> result = invokeBuildSuggestions(utcFmt("yyyy-MM-dd"),
+                new String[]{"bad", "", null, "also-bad"});
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
Handle the HTML step attribute on date/time inputs by snapping the selected value to the nearest valid step boundary when the user confirms. For Chromium, datalist suggestions are also forwarded and shown in a Spinner above the pickers so the user can pick from them.

On the Gecko side step is read from GeckoView directly but datalist is not exposed by the engine so we just fall back gracefully.

Fixes #1257