### PR TITLE
Fix build issue in SessionStateTest

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionSettings.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionSettings.java
@@ -18,6 +18,9 @@ class SessionSettings {
     private int viewportMode;
     private String userAgentOverride;
 
+    /* package */ SessionSettings() {
+    }
+
     /* package */ SessionSettings(@NonNull Builder builder) {
         this.isPrivateBrowsingEnabled = builder.isPrivateBrowsingEnabled;
         this.isTrackingProtectionEnabled = builder.isTrackingProtectionEnabled;

--- a/app/src/test/java/com/igalia/wolvic/browser/engine/SessionStateTest.java
+++ b/app/src/test/java/com/igalia/wolvic/browser/engine/SessionStateTest.java
@@ -1,4 +1,4 @@
-package com.igalia.wolvic;
+package com.igalia.wolvic.browser.engine;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.igalia.wolvic.browser.engine.SessionSettings;
-import com.igalia.wolvic.browser.engine.SessionState;
 
 import org.junit.Test;
 


### PR DESCRIPTION
This new test added as part of 7858cea89@main was added to test the session state save/restore process. However it was using an object with package only visibility.

Moved the test to the package and added a new package only constructor that will be used by the test.