### PR TITLE
Add Custom Search Engines

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -24,6 +24,7 @@ import com.igalia.wolvic.VRBrowserApplication;
 import com.igalia.wolvic.browser.api.WContentBlocking;
 import com.igalia.wolvic.browser.api.WSessionSettings;
 import com.igalia.wolvic.browser.engine.EngineProvider;
+import com.igalia.wolvic.search.CustomSearchEngine;
 import com.igalia.wolvic.speech.SpeechServices;
 import com.igalia.wolvic.telemetry.TelemetryService;
 import com.igalia.wolvic.ui.viewmodel.SettingsViewModel;
@@ -1092,6 +1093,50 @@ public class SettingsStore {
             editor.remove(mContext.getString(R.string.settings_key_search_engine_id));
         }
         editor.apply();
+    }
+
+    public List<CustomSearchEngine> getCustomSearchEngines() {
+        String json = mPrefs.getString(mContext.getString(R.string.settings_key_custom_search_engines), "[]");
+        try {
+            Gson gson = new Gson();
+            Type listType = new TypeToken<List<CustomSearchEngine>>(){}.getType();
+            List<CustomSearchEngine> engines = gson.fromJson(json, listType);
+            return engines != null ? engines : new ArrayList<>();
+        } catch (Exception e) {
+            Log.e(LOGTAG, "Error reading custom search engines", e);
+            return new ArrayList<>();
+        }
+    }
+
+    public void setCustomSearchEngines(List<CustomSearchEngine> engines) {
+        Gson gson = new Gson();
+        String json = gson.toJson(engines);
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putString(mContext.getString(R.string.settings_key_custom_search_engines), json);
+        editor.apply();
+    }
+
+    public void addCustomSearchEngine(CustomSearchEngine engine) {
+        List<CustomSearchEngine> engines = getCustomSearchEngines();
+        engines.add(engine);
+        setCustomSearchEngines(engines);
+    }
+
+    public void removeCustomSearchEngine(String engineId) {
+        List<CustomSearchEngine> engines = getCustomSearchEngines();
+        engines.removeIf(e -> e.getId().equals(engineId));
+        setCustomSearchEngines(engines);
+    }
+
+    public void updateCustomSearchEngine(CustomSearchEngine engine) {
+        List<CustomSearchEngine> engines = getCustomSearchEngines();
+        for (int i = 0; i < engines.size(); i++) {
+            if (engines.get(i).getId().equals(engine.getId())) {
+                engines.set(i, engine);
+                break;
+            }
+        }
+        setCustomSearchEngines(engines);
     }
 
     public void setWebGLOutOfProcess(boolean isEnabled) {

--- a/app/src/common/shared/com/igalia/wolvic/search/CustomSearchEngine.java
+++ b/app/src/common/shared/com/igalia/wolvic/search/CustomSearchEngine.java
@@ -1,0 +1,105 @@
+package com.igalia.wolvic.search;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Objects;
+
+public class CustomSearchEngine {
+
+    public static final String ID_PREFIX = "custom_";
+
+    private final String id;
+    private final String name;
+    private final String searchUrl;
+    @Nullable
+    private final String suggestUrl;
+
+    public CustomSearchEngine(@NonNull String id, @NonNull String name, @NonNull String searchUrl, @Nullable String suggestUrl) {
+        this.id = id;
+        this.name = name;
+        this.searchUrl = searchUrl;
+        this.suggestUrl = suggestUrl;
+    }
+
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    @NonNull
+    public String getSearchUrl() {
+        return searchUrl;
+    }
+
+    @Nullable
+    public String getSuggestUrl() {
+        return suggestUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomSearchEngine other = (CustomSearchEngine) o;
+        return Objects.equals(id, other.id) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(searchUrl, other.searchUrl) &&
+                Objects.equals(suggestUrl, other.suggestUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, searchUrl, suggestUrl);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "CustomSearchEngine{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", searchUrl='" + searchUrl + '\'' +
+                ", suggestUrl='" + suggestUrl + '\'' +
+                '}';
+    }
+
+    public static class Builder {
+        private String id;
+        private String name;
+        private String searchUrl;
+        private String suggestUrl;
+
+        public Builder setId(@NonNull String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setName(@NonNull String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setSearchUrl(@NonNull String searchUrl) {
+            this.searchUrl = searchUrl;
+            return this;
+        }
+
+        public Builder setSuggestUrl(@Nullable String suggestUrl) {
+            this.suggestUrl = suggestUrl;
+            return this;
+        }
+
+        public CustomSearchEngine build() {
+            if (id == null || name == null || searchUrl == null) {
+                throw new IllegalStateException("id, name, and searchUrl are required");
+            }
+            return new CustomSearchEngine(id, name, searchUrl, suggestUrl);
+        }
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/search/SearchEngineValidation.java
+++ b/app/src/common/shared/com/igalia/wolvic/search/SearchEngineValidation.java
@@ -1,0 +1,166 @@
+package com.igalia.wolvic.search;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Patterns;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.igalia.wolvic.R;
+
+import java.net.IDN;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class SearchEngineValidation {
+
+    public static final String DUMMY_PLACEHOLDER_FOR_VALIDATION = "test";
+    public static final int CUSTOM_SEARCH_ENGINE_NAME_MAX_LEN = 50;
+
+    public static class ValidationResult {
+        private final boolean isValid;
+        @Nullable
+        private final String errorMessage;
+
+        private ValidationResult(boolean isValid, @Nullable String errorMessage) {
+            this.isValid = isValid;
+            this.errorMessage = errorMessage;
+        }
+
+        public static ValidationResult success() {
+            return new ValidationResult(true, null);
+        }
+
+        public static ValidationResult error(@NonNull String message) {
+            return new ValidationResult(false, message);
+        }
+
+        public boolean isValid() {
+            return isValid;
+        }
+
+        @Nullable
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+
+    @NonNull
+    public static ValidationResult validateSearchUrl(@NonNull Context context, @Nullable String searchUrl) {
+        return validateUrl(context, searchUrl, true);
+    }
+
+    @NonNull
+    public static ValidationResult validateName(@NonNull Context context, @Nullable String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return ValidationResult.error(context.getString(R.string.search_engine_error_name_required));
+        }
+
+        String trimmedName = name.trim();
+        if (trimmedName.length() > CUSTOM_SEARCH_ENGINE_NAME_MAX_LEN) {
+            return ValidationResult.error(context.getString(R.string.search_engine_error_name_too_long));
+        }
+
+        return ValidationResult.success();
+    }
+
+    @NonNull
+    public static ValidationResult validateSuggestUrl(@NonNull Context context, @Nullable String suggestUrl) {
+        return validateUrl(context, suggestUrl, false);
+    }
+
+    @NonNull
+    private static ValidationResult validateUrl(@NonNull Context context, @Nullable String url, boolean isRequired) {
+        if (url == null || url.trim().isEmpty()) {
+            return isRequired
+                    ? ValidationResult.error(context.getString(R.string.search_engine_error_url_required))
+                    : ValidationResult.success();
+        }
+
+        String trimmedUrl = url.trim();
+
+        if (!trimmedUrl.contains("%s") && !trimmedUrl.contains("{searchTerms}")) {
+            return ValidationResult.error(context.getString(R.string.search_engine_error_url_placeholder, "%s"));
+        }
+
+        String urlForValidation = trimmedUrl
+                .replace("%s", DUMMY_PLACEHOLDER_FOR_VALIDATION)
+                .replace("{searchTerms}", DUMMY_PLACEHOLDER_FOR_VALIDATION);
+
+        Uri uri = Uri.parse(urlForValidation);
+
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            return ValidationResult.error(context.getString(R.string.search_engine_error_url_scheme));
+        }
+        scheme = scheme.toLowerCase(Locale.ROOT);
+        if (!scheme.equals("http") && !scheme.equals("https")) {
+            return ValidationResult.error(context.getString(R.string.search_engine_error_url_scheme_unsupported));
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            return ValidationResult.error(context.getString(R.string.search_engine_error_url_host));
+        }
+
+        if (isPrivateOrLocalHost(host)) {
+            return ValidationResult.error(context.getString(R.string.search_engine_error_url_private));
+        }
+
+        return ValidationResult.success();
+    }
+
+    @NonNull
+    public static List<ValidationResult> validateAll(@NonNull Context context, @Nullable String name, @Nullable String searchUrl, @Nullable String suggestUrl) {
+        List<ValidationResult> results = new ArrayList<>();
+        
+        ValidationResult nameResult = validateName(context, name);
+        if (!nameResult.isValid()) {
+            results.add(nameResult);
+        }
+
+        ValidationResult searchUrlResult = validateSearchUrl(context, searchUrl);
+        if (!searchUrlResult.isValid()) {
+            results.add(searchUrlResult);
+        }
+
+        ValidationResult suggestUrlResult = validateSuggestUrl(context, suggestUrl);
+        if (!suggestUrlResult.isValid()) {
+            results.add(suggestUrlResult);
+        }
+
+        return results;
+    }
+
+    private static boolean isPrivateOrLocalHost(@NonNull String host) {
+        String lowerHost = IDN.toASCII(host).toLowerCase();
+        if (lowerHost.equals("localhost") || lowerHost.equals("localhost.localdomain")) {
+            return true;
+        }
+
+        if (Patterns.IP_ADDRESS.matcher(host).matches()) {
+            return isPrivateIp(host);
+        }
+
+        try {
+            String asciiHost = IDN.toASCII(host).toLowerCase();
+            if (asciiHost.endsWith(".local") || asciiHost.endsWith(".localhost")) {
+                return true;
+            }
+        } catch (Exception ignored) {
+        }
+
+        return false;
+    }
+
+    private static boolean isPrivateIp(@NonNull String ip) {
+        try {
+            java.net.InetAddress address = java.net.InetAddress.getByName(ip);
+            return address.isSiteLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress();
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/search/SearchEngineWrapper.kt
+++ b/app/src/common/shared/com/igalia/wolvic/search/SearchEngineWrapper.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
-import android.net.Uri
+import android.graphics.Bitmap
 import android.os.Build
 import android.util.Log
 import androidx.preference.PreferenceManager
@@ -30,6 +30,8 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
 
+private const val OPENSEARCH_SEARCH_TERMS_PLACEHOLDER = "{searchTerms}"
+
 class SearchEngineWrapper private constructor(aContext: Context) :
     OnSharedPreferenceChangeListener {
     private val mContextRef: WeakReference<Context?>
@@ -45,6 +47,7 @@ class SearchEngineWrapper private constructor(aContext: Context) :
             SearchMiddleware(aContext,
                 ioDispatcher = mIoDispatcher)
         ))
+    private val mEmptyIcon: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
     fun registerForUpdates() {
         if (hasContext()) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -81,16 +84,16 @@ class SearchEngineWrapper private constructor(aContext: Context) :
         return currentSearchEngine!!.buildSearchUrl(aQuery!!)
     }
 
-    fun getSuggestions(aQuery: String?): CompletableFuture<List<String>?> {
+    fun getSuggestions(aQuery: String?): CompletableFuture<List<String>> {
+        val engine = currentSearchEngine
+        if (engine?.type == SearchEngine.Type.CUSTOM) {
+            if (engine.suggestUrl != null && mAutocompleteEnabled && mSuggestionsClient != null) {
+                return getSuggestionsAsync(mSuggestionsClient!!, aQuery ?: "")
+            }
+            return CompletableFuture.completedFuture(emptyList())
+        }
         return getSuggestionsAsync(mSuggestionsClient!!, aQuery ?: "")
     }
-
-    val resourceURL: String
-        get() {
-            if (currentSearchEngine == null) setupPreferredSearchEngine()
-            val uri = Uri.parse(currentSearchEngine!!.buildSearchUrl(""))
-            return uri.scheme + "://" + uri.host
-        }
 
     // Receiver for locale updates
     private val mLocaleChangedReceiver: BroadcastReceiver = object : BroadcastReceiver() {
@@ -111,8 +114,52 @@ class SearchEngineWrapper private constructor(aContext: Context) :
     val availableSearchEngines: Collection<SearchEngine>
         get() {
             updateSearchEngine()
-            return mSearchEnginesMap!!.values
+            val allEngines = mutableListOf<SearchEngine>()
+            mSearchEnginesMap?.values?.let { allEngines.addAll(it) }
+            val customEngines = getCustomSearchEngines()
+            for (custom in customEngines) {
+                allEngines.add(
+                    SearchEngine(
+                        id = custom.id,
+                        name = custom.name,
+                        icon = mEmptyIcon,
+                        type = SearchEngine.Type.CUSTOM,
+                        resultUrls = listOf(custom.searchUrl.replace("%s", OPENSEARCH_SEARCH_TERMS_PLACEHOLDER)),
+                        suggestUrl = custom.suggestUrl?.replace("%s", OPENSEARCH_SEARCH_TERMS_PLACEHOLDER)
+                    )
+                )
+            }
+            return allEngines
         }
+
+    private fun getCustomSearchEngines(): List<CustomSearchEngine> {
+        return if (hasContext()) {
+            SettingsStore.getInstance(context!!).customSearchEngines
+        } else {
+            emptyList()
+        }
+    }
+
+    fun addCustomSearchEngine(engine: CustomSearchEngine) {
+        if (hasContext()) {
+            SettingsStore.getInstance(context!!).addCustomSearchEngine(engine)
+        }
+    }
+
+    fun removeCustomSearchEngine(engineId: String) {
+        if (hasContext()) {
+            SettingsStore.getInstance(context!!).removeCustomSearchEngine(engineId)
+            if (currentSearchEngine?.id == engineId) {
+                setupPreferredSearchEngine()
+            }
+        }
+    }
+
+    fun updateCustomSearchEngine(engine: CustomSearchEngine) {
+        if (hasContext()) {
+            SettingsStore.getInstance(context!!).updateCustomSearchEngine(engine)
+        }
+    }
 
     fun setDefaultSearchEngine() {
         if (hasContext()) setupSearchEngine(context!!, null)
@@ -174,25 +221,48 @@ class SearchEngineWrapper private constructor(aContext: Context) :
             mSearchEnginesMap!![searchEngine.id] = searchEngine
         }
 
-        val newSearchEngine = if (mSearchEnginesMap!!.containsKey(userPref)) {
-            mSearchEnginesMap!![userPref]
-        } else {
-            mSearchEnginesMap!![mBrowserStore.state.search.regionDefaultSearchEngineId]
+        var newSearchEngine: SearchEngine? = null
+
+        if (mSearchEnginesMap!!.containsKey(userPref)) {
+            newSearchEngine = mSearchEnginesMap!![userPref]
+        } else if (userPref != null && userPref.startsWith(CustomSearchEngine.ID_PREFIX)) {
+            val customEngine = SettingsStore.getInstance(thisContext).customSearchEngines.find { it.id == userPref }
+            if (customEngine != null) {
+                newSearchEngine = SearchEngine(
+                    id = customEngine.id,
+                    name = customEngine.name,
+                    icon = mEmptyIcon,
+                    type = SearchEngine.Type.CUSTOM,
+                    resultUrls = listOf(customEngine.searchUrl.replace("%s", OPENSEARCH_SEARCH_TERMS_PLACEHOLDER)),
+                    suggestUrl = customEngine.suggestUrl?.replace("%s", OPENSEARCH_SEARCH_TERMS_PLACEHOLDER)
+                )
+            }
+        }
+        
+        if (newSearchEngine == null) {
+            newSearchEngine = mSearchEnginesMap!![mBrowserStore.state.search.regionDefaultSearchEngineId]
         }
 
         if (newSearchEngine == null || currentSearchEngine == newSearchEngine) return
 
-        mSuggestionsClient = SearchSuggestionClient(
-            newSearchEngine
-        ) label@
-        { searchUrl: String? ->
-            if (mAutocompleteEnabled && vRBrowserActivity != null) {
-                if (!vRBrowserActivity!!.windows.isInPrivateMode) {
-                    return@label fetchSearchSuggestions(thisContext, searchUrl!!)
+        val shouldCreateClient = newSearchEngine.type != SearchEngine.Type.CUSTOM ||
+                newSearchEngine.suggestUrl != null
+        val suggestionClient = if (shouldCreateClient) {
+            SearchSuggestionClient(
+                newSearchEngine
+            ) label@
+            { searchUrl: String? ->
+                if (mAutocompleteEnabled && vRBrowserActivity != null) {
+                    if (!vRBrowserActivity!!.windows.isInPrivateMode) {
+                        return@label fetchSearchSuggestions(thisContext, searchUrl!!)
+                    }
                 }
+                null
             }
+        } else {
             null
         }
+        mSuggestionsClient = suggestionClient
         currentSearchEngine = newSearchEngine
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/search/suggestions/SearchSuggestionsClient.kt
+++ b/app/src/common/shared/com/igalia/wolvic/search/suggestions/SearchSuggestionsClient.kt
@@ -9,9 +9,9 @@ import mozilla.components.concept.fetch.Request
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletableFuture
 
-fun getSuggestionsAsync(client: SearchSuggestionClient, query: String): CompletableFuture<List<String>?> =
+fun getSuggestionsAsync(client: SearchSuggestionClient, query: String): CompletableFuture<List<String>> =
         GlobalScope.future {
-            client.getSuggestions(query)
+            (client.getSuggestions(query) ?: emptyList()).orEmpty().filterNotNull()
         }
 
 fun fetchSearchSuggestions(context: Context, searchUrl: String): String? {

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/CustomSearchEnginesAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/CustomSearchEnginesAdapter.java
@@ -1,0 +1,147 @@
+package com.igalia.wolvic.ui.adapters;
+
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.databinding.DataBindingUtil;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.databinding.CustomSearchEngineItemBinding;
+import com.igalia.wolvic.search.CustomSearchEngine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomSearchEnginesAdapter extends RecyclerView.Adapter<CustomSearchEnginesAdapter.ViewHolder> {
+
+    public interface Delegate {
+        void onEngineSelected(View view, CustomSearchEngine engine);
+        void onEngineDeleted(View view, CustomSearchEngine engine);
+    }
+
+    private List<CustomSearchEngine> mEngines = new ArrayList<>();
+    private Delegate mDelegate;
+
+    public void setEngines(List<CustomSearchEngine> engines) {
+        DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(new DiffUtil.Callback() {
+            @Override
+            public int getOldListSize() {
+                return mEngines.size();
+            }
+
+            @Override
+            public int getNewListSize() {
+                return engines.size();
+            }
+
+            @Override
+            public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+                return mEngines.get(oldItemPosition).getId().equals(engines.get(newItemPosition).getId());
+            }
+
+            @Override
+            public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+                return mEngines.get(oldItemPosition).equals(engines.get(newItemPosition));
+            }
+        });
+
+        mEngines.clear();
+        mEngines.addAll(engines);
+        diffResult.dispatchUpdatesTo(this);
+    }
+
+    public void setDelegate(Delegate delegate) {
+        mDelegate = delegate;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        CustomSearchEngineItemBinding binding = DataBindingUtil.inflate(
+                LayoutInflater.from(parent.getContext()),
+                R.layout.custom_search_engine_item,
+                parent,
+                false);
+        return new ViewHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        CustomSearchEngine engine = mEngines.get(position);
+        holder.binding.setEngine(engine);
+        holder.binding.setDelegate(mDelegate);
+        holder.binding.setIsHovered(false);
+        holder.binding.executePendingBindings();
+
+        // Layout hover listener - shows/hides delete button
+        holder.binding.layout.setOnHoverListener((view, motionEvent) -> {
+            int ev = motionEvent.getActionMasked();
+            switch (ev) {
+                case MotionEvent.ACTION_HOVER_ENTER:
+                    holder.binding.setIsHovered(true);
+                    view.getBackground().setState(new int[]{android.R.attr.state_hovered});
+                    view.postInvalidate();
+                    return false;
+
+                case MotionEvent.ACTION_CANCEL:
+                case MotionEvent.ACTION_HOVER_EXIT:
+                    view.getBackground().setState(new int[]{android.R.attr.state_active});
+                    holder.binding.setIsHovered(false);
+                    view.postInvalidate();
+                    return false;
+            }
+            return false;
+        });
+
+        // Trash icon hover and click
+        holder.binding.trash.setOnHoverListener((view, motionEvent) -> {
+            int ev = motionEvent.getActionMasked();
+            switch (ev) {
+                case MotionEvent.ACTION_HOVER_ENTER:
+                    holder.binding.setIsHovered(true);
+                    return false;
+                case MotionEvent.ACTION_HOVER_EXIT:
+                    holder.binding.setIsHovered(false);
+                    return false;
+            }
+            return false;
+        });
+
+        holder.binding.trash.setOnTouchListener((view, motionEvent) -> {
+            holder.binding.setIsHovered(true);
+            int ev = motionEvent.getActionMasked();
+            switch (ev) {
+                case MotionEvent.ACTION_UP:
+                    if (mDelegate != null) {
+                        mDelegate.onEngineDeleted(view, engine);
+                    }
+                    return true;
+                case MotionEvent.ACTION_DOWN:
+                    return true;
+                case MotionEvent.ACTION_CANCEL:
+                    holder.binding.setIsHovered(false);
+                    return false;
+            }
+            return false;
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return mEngines.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        CustomSearchEngineItemBinding binding;
+
+        ViewHolder(CustomSearchEngineItemBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/views/settings/SingleEditSetting.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/views/settings/SingleEditSetting.java
@@ -121,6 +121,11 @@ public class SingleEditSetting extends RelativeLayout {
         // If the edit field was visible when the click happened, this is a "save" action.
         boolean isCurrentlyEditing = mEdit1.getVisibility() == View.VISIBLE;
 
+        // Update text1 with the current edit text before hiding the edit field
+        if (isCurrentlyEditing) {
+            mText1.setText(mEdit1.getText().toString());
+        }
+
         mText1.setVisibility(mEdit1.getVisibility());
         mEdit1.setVisibility(mEdit1.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
         @StringRes int buttonText = mEdit1.getVisibility() == View.VISIBLE ?
@@ -186,5 +191,4 @@ public class SingleEditSetting extends RelativeLayout {
     public void setPasswordToggleVisibility(int visibility) {
         mPasswordToggle.setVisibility(visibility);
     }
-
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/CustomSearchEnginesOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/CustomSearchEnginesOptionsView.java
@@ -1,0 +1,101 @@
+package com.igalia.wolvic.ui.widgets.settings;
+
+import android.content.Context;
+import android.graphics.Point;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.databinding.DataBindingUtil;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.browser.SettingsStore;
+import com.igalia.wolvic.databinding.OptionsCustomSearchEnginesBinding;
+import com.igalia.wolvic.search.CustomSearchEngine;
+import com.igalia.wolvic.search.SearchEngineWrapper;
+import com.igalia.wolvic.ui.adapters.CustomSearchEnginesAdapter;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+import com.igalia.wolvic.ui.widgets.WidgetPlacement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomSearchEnginesOptionsView extends SettingsView implements CustomSearchEnginesAdapter.Delegate {
+
+    private OptionsCustomSearchEnginesBinding mBinding;
+    private CustomSearchEnginesAdapter mAdapter;
+
+    public CustomSearchEnginesOptionsView(Context aContext, WidgetManagerDelegate aWidgetManager) {
+        super(aContext, aWidgetManager);
+        initialize(aContext);
+    }
+
+    private void initialize(Context aContext) {
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.options_custom_search_engines, this, true);
+
+        // Header
+        mBinding.headerLayout.setBackClickListener(view -> {
+            mDelegate.showView(SettingViewType.SEARCH_ENGINE);
+        });
+
+        // Footer button - add new engine
+        mBinding.footerLayout.setFooterButtonClickListener(view -> {
+            mDelegate.showView(SettingViewType.SEARCH_ENGINE_EDIT);
+        });
+
+        // Setup RecyclerView
+        mAdapter = new CustomSearchEnginesAdapter();
+        mAdapter.setDelegate(this);
+        mBinding.enginesList.setAdapter(mAdapter);
+
+        loadEngines();
+    }
+
+    private void loadEngines() {
+        List<CustomSearchEngine> engines = new ArrayList<>(
+                SettingsStore.getInstance(getContext()).getCustomSearchEngines());
+        
+        mAdapter.setEngines(engines);
+
+        mBinding.setIsEmpty(engines.isEmpty());
+    }
+
+    @Override
+    public void onEngineSelected(View view, CustomSearchEngine engine) {
+        mDelegate.showView(SettingViewType.SEARCH_ENGINE_EDIT, engine);
+    }
+
+    @Override
+    public void onEngineDeleted(View view, CustomSearchEngine engine) {
+        showConfirmDeleteSearchEngineDialog(engine.getName(), () -> {
+            SearchEngineWrapper.get(getContext()).removeCustomSearchEngine(engine.getId());
+            Toast.makeText(getContext(), R.string.search_engine_deleted, Toast.LENGTH_SHORT).show();
+            loadEngines();
+        });
+    }
+
+    @Override
+    public Point getDimensions() {
+        return new Point(WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
+                WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
+    }
+
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.CUSTOM_SEARCH_ENGINES;
+    }
+
+    @Override
+    public void onShown() {
+        super.onShown();
+        loadEngines();
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/EditSearchEngineOptionsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/EditSearchEngineOptionsView.java
@@ -1,0 +1,218 @@
+package com.igalia.wolvic.ui.widgets.settings;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Point;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+
+import com.igalia.wolvic.R;
+import com.igalia.wolvic.databinding.OptionsEditSearchEngineBinding;
+import com.igalia.wolvic.search.CustomSearchEngine;
+import com.igalia.wolvic.search.SearchEngineValidation;
+import com.igalia.wolvic.search.SearchEngineValidation.ValidationResult;
+import com.igalia.wolvic.search.SearchEngineWrapper;
+import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
+import com.igalia.wolvic.ui.widgets.WidgetPlacement;
+
+import java.util.List;
+
+@SuppressLint("ViewConstructor")
+class EditSearchEngineOptionsView extends SettingsView {
+
+    private OptionsEditSearchEngineBinding mBinding;
+    private CustomSearchEngine mEngine;
+    private boolean mIsEditMode;
+
+    private boolean mNameValid = false;
+    private boolean mSearchUrlValid = false;
+    private boolean mSuggestUrlValid = true;
+
+    public EditSearchEngineOptionsView(@NonNull Context aContext, @NonNull WidgetManagerDelegate aWidgetManager, @Nullable CustomSearchEngine engine) {
+        super(aContext, aWidgetManager);
+        mEngine = engine;
+        mIsEditMode = engine != null;
+        initialize(aContext);
+    }
+
+    private void initialize(Context aContext) {
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.options_edit_search_engine, this, true);
+
+        mScrollbar = mBinding.scrollbar;
+
+        mBinding.headerLayout.setBackClickListener(view -> {
+            onDismiss();
+        });
+
+        mBinding.footerLayout.setFooterButtonClickListener(mIsEditMode ? v -> onDismiss() : v -> saveEngine());
+        mBinding.footerLayout.setFooterButtonText(mIsEditMode ? R.string.close_button : R.string.add_search_engine_save);
+        mBinding.footerLayout.setFooterButtonEnabled(false);
+
+        mBinding.nameEdit.setHint1(getContext().getString(R.string.add_search_engine_name_hint));
+        mBinding.searchUrlEdit.setHint1(getContext().getString(R.string.add_search_engine_search_url_hint));
+        mBinding.suggestUrlEdit.setHint1(getContext().getString(R.string.add_search_engine_suggest_url_hint));
+
+        mBinding.nameEdit.setOnSaveClickedListener(v -> validateAndSaveName());
+        mBinding.searchUrlEdit.setOnSaveClickedListener(v -> validateAndSaveSearchUrl());
+        mBinding.suggestUrlEdit.setOnSaveClickedListener(v -> validateAndSaveSuggestUrl());
+
+        if (mIsEditMode) {
+            mBinding.nameEdit.setFirstText(mEngine.getName());
+            mBinding.searchUrlEdit.setFirstText(mEngine.getSearchUrl());
+            if (mEngine.getSuggestUrl() != null) {
+                mBinding.suggestUrlEdit.setFirstText(mEngine.getSuggestUrl());
+            }
+            mNameValid = true;
+            mSearchUrlValid = true;
+            mSuggestUrlValid = true;
+            updateFooterButtonState();
+        }
+    }
+
+    @Override
+    public void onShown() {
+        super.onShown();
+        mBinding.headerLayout.setTitle(mIsEditMode ? R.string.edit_search_engine_title : R.string.add_search_engine_title);
+    }
+
+    private void validateAndSaveName() {
+        String name = mBinding.nameEdit.getFirstText().trim();
+        SearchEngineValidation.ValidationResult result = SearchEngineValidation.validateName(getContext(), name);
+
+        mNameValid = result.isValid();
+        updateFooterButtonState();
+        if (!mNameValid) {
+            showError(result.getErrorMessage());
+            return;
+        }
+
+        hideError();
+        if (mIsEditMode) {
+            saveCurrentEngine(name, null, null);
+        }
+    }
+
+    private void validateAndSaveSearchUrl() {
+        String searchUrl = mBinding.searchUrlEdit.getFirstText().trim();
+        SearchEngineValidation.ValidationResult result = SearchEngineValidation.validateSearchUrl(getContext(), searchUrl);
+
+        mSearchUrlValid = result.isValid();
+        updateFooterButtonState();
+
+        if (!mSearchUrlValid) {
+            showError(result.getErrorMessage());
+            return;
+        }
+
+        hideError();
+        if (mIsEditMode) {
+            saveCurrentEngine(null, searchUrl, null);
+        }
+    }
+
+    private void validateAndSaveSuggestUrl() {
+        String suggestUrl = mBinding.suggestUrlEdit.getFirstText().trim();
+        SearchEngineValidation.ValidationResult result = SearchEngineValidation.validateSuggestUrl(getContext(),
+                suggestUrl.isEmpty() ? null : suggestUrl);
+
+        mSuggestUrlValid = result.isValid();
+        updateFooterButtonState();
+
+        if (!mSuggestUrlValid) {
+            showError(result.getErrorMessage());
+            return;
+        }
+
+        hideError();
+        if (mIsEditMode) {
+            saveCurrentEngine(null, null, suggestUrl);
+        }
+    }
+
+    private void showError(String message) {
+        mBinding.errorText.setVisibility(View.VISIBLE);
+        mBinding.errorText.setText(message);
+    }
+
+    private void hideError() {
+        mBinding.errorText.setVisibility(View.GONE);
+    }
+
+    private void updateFooterButtonState() {
+        mBinding.footerLayout.setFooterButtonEnabled(mNameValid && mSearchUrlValid && mSuggestUrlValid);
+    }
+
+    private void saveEngine() {
+        String name = mBinding.nameEdit.getFirstText().trim();
+        String searchUrl = mBinding.searchUrlEdit.getFirstText().trim();
+        String suggestUrl = mBinding.suggestUrlEdit.getFirstText().trim();
+
+        List<ValidationResult> results =
+                SearchEngineValidation.validateAll(getContext(), name, searchUrl, suggestUrl.isEmpty() ? null : suggestUrl);
+
+        if (!results.isEmpty()) {
+            showError(results.get(0).getErrorMessage());
+            return;
+        }
+
+        String id = CustomSearchEngine.ID_PREFIX + System.currentTimeMillis();
+        CustomSearchEngine engine = new CustomSearchEngine.Builder()
+                .setId(id)
+                .setName(name)
+                .setSearchUrl(searchUrl)
+                .setSuggestUrl(suggestUrl.isEmpty() ? null : suggestUrl)
+                .build();
+        SearchEngineWrapper.get(getContext()).addCustomSearchEngine(engine);
+
+        Toast.makeText(getContext(), R.string.add_search_engine_save, Toast.LENGTH_SHORT).show();
+        onDismiss();
+    }
+
+    private void saveCurrentEngine(@Nullable String name, @Nullable String searchUrl, @Nullable String suggestUrl) {
+        if (mEngine == null) {
+            return;
+        }
+
+        String finalName = name != null ? name : mEngine.getName();
+        String finalSearchUrl = searchUrl != null ? searchUrl : mEngine.getSearchUrl();
+        String finalSuggestUrl;
+        if (suggestUrl != null) {
+            finalSuggestUrl = suggestUrl.isEmpty() ? null : suggestUrl;
+        } else {
+            finalSuggestUrl = mEngine.getSuggestUrl();
+        }
+
+        CustomSearchEngine engine = new CustomSearchEngine.Builder()
+                .setId(mEngine.getId())
+                .setName(finalName)
+                .setSearchUrl(finalSearchUrl)
+                .setSuggestUrl(finalSuggestUrl)
+                .build();
+        SearchEngineWrapper.get(getContext()).updateCustomSearchEngine(engine);
+        mEngine = engine;
+    }
+
+    @Override
+    public Point getDimensions() {
+        return new Point(WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
+                WidgetPlacement.dpDimension(getContext(), R.dimen.display_options_height));
+    }
+
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.SEARCH_ENGINE_EDIT;
+    }
+}

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SearchEngineView.java
@@ -3,13 +3,14 @@ package com.igalia.wolvic.ui.widgets.settings;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Point;
-import androidx.preference.PreferenceManager;
 import android.view.LayoutInflater;
 
+import androidx.preference.PreferenceManager;
 import androidx.databinding.DataBindingUtil;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.databinding.OptionsSearchEngineBinding;
+import com.igalia.wolvic.search.CustomSearchEngine;
 import com.igalia.wolvic.search.SearchEngineWrapper;
 import com.igalia.wolvic.ui.views.settings.RadioGroupSetting;
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
@@ -54,10 +55,26 @@ public class SearchEngineView extends SettingsView implements SharedPreferences.
             mDelegate.showView(SettingViewType.PRIVACY);
         });
 
+        // Add custom search engine button
+        mBinding.addEngineButton.setOnClickListener(view -> {
+            mDelegate.showView(SettingViewType.CUSTOM_SEARCH_ENGINES);
+        });
+
         // Footer
         mBinding.footerLayout.setFooterButtonClickListener(mResetListener);
 
-        mSearchEngines = new ArrayList<>(SearchEngineWrapper.get(getContext()).getAvailableSearchEngines());
+        List<SearchEngine> allEngines = new ArrayList<>(SearchEngineWrapper.get(getContext()).getAvailableSearchEngines());
+
+        // Put custom search engines at the top of the list
+        mSearchEngines = new ArrayList<>();
+        for (SearchEngine engine : allEngines) {
+            if (engine.getId() != null && engine.getId().startsWith(CustomSearchEngine.ID_PREFIX)) {
+                mSearchEngines.add(0, engine);
+            } else {
+                mSearchEngines.add(engine);
+            }
+        }
+
         mBinding.searchEngineRadio.setOptions(mSearchEngines.stream().map(SearchEngine::getName).toArray(String[]::new));
 
         mBinding.searchEngineRadio.setOnCheckedChangeListener(mSearchEngineListener);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsFooter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsFooter.java
@@ -82,4 +82,8 @@ public class SettingsFooter extends FrameLayout {
     public void setFooterButtonVisibility(int visibility) {
         mBinding.resetButton.setFooterButtonVisibility(visibility);
     }
+
+    public void setFooterButtonEnabled(boolean enabled) {
+        mBinding.resetButton.setEnabled(enabled);
+    }
 }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsView.java
@@ -38,6 +38,8 @@ public abstract class SettingsView extends FrameLayout {
         LOGIN_EXCEPTIONS,
         LOGIN_EDIT,
         SEARCH_ENGINE,
+        SEARCH_ENGINE_EDIT,
+        CUSTOM_SEARCH_ENGINES,
         TERMS_OF_SERVICE,
         PRIVACY_POLICY
     }
@@ -51,6 +53,7 @@ public abstract class SettingsView extends FrameLayout {
         void exitWholeSettings();
         void showRestartDialog(RestartDialogWidget.CancelCallback cancelCallback);
         void showClearUserDataDialog();
+        void showConfirmDeleteSearchEngineDialog(String engineName, Runnable onConfirm);
         void showAlert(String aTitle, String aMessage);
         void showView(SettingsView.SettingViewType type);
         void showView(SettingsView.SettingViewType type, @Nullable Object extras);
@@ -86,6 +89,12 @@ public abstract class SettingsView extends FrameLayout {
     protected void showClearUserDataDialog() {
         if (mDelegate != null) {
             mDelegate.showClearUserDataDialog();
+        }
+    }
+
+    protected void showConfirmDeleteSearchEngineDialog(String engineName, Runnable onConfirm) {
+        if (mDelegate != null) {
+            mDelegate.showConfirmDeleteSearchEngineDialog(engineName, onConfirm);
         }
     }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/settings/SettingsWidget.java
@@ -36,6 +36,7 @@ import com.igalia.wolvic.browser.SettingsStore;
 import com.igalia.wolvic.browser.engine.Session;
 import com.igalia.wolvic.databinding.SettingsBinding;
 import com.igalia.wolvic.db.SitePermission;
+import com.igalia.wolvic.search.CustomSearchEngine;
 import com.igalia.wolvic.telemetry.TelemetryService;
 import com.igalia.wolvic.ui.viewmodel.SettingsViewModel;
 import com.igalia.wolvic.ui.widgets.UIWidget;
@@ -43,6 +44,7 @@ import com.igalia.wolvic.ui.widgets.WidgetPlacement;
 import com.igalia.wolvic.ui.widgets.WindowWidget;
 import com.igalia.wolvic.ui.widgets.Windows;
 import com.igalia.wolvic.ui.widgets.dialogs.ClearUserDataDialogWidget;
+import com.igalia.wolvic.ui.widgets.dialogs.PromptDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.RestartDialogWidget;
 import com.igalia.wolvic.ui.widgets.dialogs.UIDialog;
 import com.igalia.wolvic.utils.DeviceType;
@@ -69,6 +71,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     private int mViewMarginV;
     private RestartDialogWidget mRestartDialog;
     private ClearUserDataDialogWidget mClearUserDataDialog;
+    private PromptDialogWidget mDeleteSearchEngineDialog;
     private Accounts mAccounts;
     private Executor mUIThreadExecutor;
     private SettingsView.SettingViewType mOpenDialog;
@@ -505,6 +508,12 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             case SEARCH_ENGINE:
                 showView(new SearchEngineView(getContext(), mWidgetManager));
                 break;
+            case SEARCH_ENGINE_EDIT:
+                showView(new EditSearchEngineOptionsView(getContext(), mWidgetManager, (CustomSearchEngine) extras));
+                break;
+            case CUSTOM_SEARCH_ENGINES:
+                showView(new CustomSearchEnginesOptionsView(getContext(), mWidgetManager));
+                break;
             case TERMS_OF_SERVICE:
                 showView(new LegalDocumentView(getContext(), mWidgetManager, LegalDocumentView.LegalDocument.TERMS_OF_SERVICE));
                 break;
@@ -577,6 +586,12 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
                 } else if (isSavedLoginsSubview(mCurrentView)) {
                     showView(SettingsView.SettingViewType.SAVED_LOGINS);
 
+                } else if (mCurrentView instanceof EditSearchEngineOptionsView) {
+                    showView(SettingsView.SettingViewType.CUSTOM_SEARCH_ENGINES);
+
+                } else if (mCurrentView instanceof CustomSearchEnginesOptionsView) {
+                    showView(SettingsView.SettingViewType.SEARCH_ENGINE);
+
                 } else {
                     showView(SettingsView.SettingViewType.MAIN);
                 }
@@ -610,6 +625,29 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
         }
 
         mClearUserDataDialog.show(REQUEST_FOCUS);
+    }
+
+    @Override
+    public void showConfirmDeleteSearchEngineDialog(String engineName, Runnable onConfirm) {
+        if (mDeleteSearchEngineDialog == null) {
+            mDeleteSearchEngineDialog = new PromptDialogWidget(getContext());
+            mDeleteSearchEngineDialog.setIcon(R.drawable.ic_icon_trash);
+            mDeleteSearchEngineDialog.setButtons(new int[] {
+                    R.string.cancel_button,
+                    R.string.delete_button
+            });
+            mDeleteSearchEngineDialog.setCheckboxVisible(false);
+            mDeleteSearchEngineDialog.setDescriptionVisible(false);
+        }
+        mDeleteSearchEngineDialog.setTitle(getContext().getString(R.string.delete_search_engine_dialog_title));
+        mDeleteSearchEngineDialog.setBody(getContext().getString(R.string.delete_search_engine_dialog_text, engineName));
+        mDeleteSearchEngineDialog.setButtonsDelegate((index, isChecked) -> {
+            if (index == PromptDialogWidget.POSITIVE) {
+                onConfirm.run();
+            }
+            mDeleteSearchEngineDialog.hide(UIWidget.REMOVE_WIDGET);
+        });
+        mDeleteSearchEngineDialog.show(REQUEST_FOCUS);
     }
 
     @Override

--- a/app/src/main/res/layout/custom_search_engine_item.xml
+++ b/app/src/main/res/layout/custom_search_engine_item.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="engine"
+            type="com.igalia.wolvic.search.CustomSearchEngine" />
+        <variable
+            name="delegate"
+            type="com.igalia.wolvic.ui.adapters.CustomSearchEnginesAdapter.Delegate" />
+        <variable
+            name="isHovered"
+            type="boolean" />
+    </data>
+
+    <RelativeLayout
+        android:id="@+id/layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/saved_login_item_background_color"
+        android:padding="10dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:onClick="@{(view) -> delegate.onEngineSelected(view, engine)}"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:soundEffectsEnabled="false"
+        android:addStatesFromChildren="true">
+
+        <LinearLayout
+            android:id="@+id/title_url"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:layout_toStartOf="@id/buttons_container"
+            android:gravity="center_vertical"
+            android:addStatesFromChildren="true">
+
+            <TextView
+                android:id="@+id/engineName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:ellipsize="end"
+                android:paddingEnd="20dp"
+                android:scrollHorizontally="true"
+                android:singleLine="true"
+                android:text="@{engine.name}"
+                android:textColor="@color/library_panel_title_text_color"
+                android:textSize="@dimen/settings_text_size"
+                android:textStyle="bold"
+                tools:text="Google" />
+
+            <TextView
+                android:id="@+id/engineUrl"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:ellipsize="end"
+                android:paddingEnd="20dp"
+                android:scrollHorizontally="true"
+                android:singleLine="true"
+                android:text="@{engine.searchUrl}"
+                android:textColor="@color/library_panel_description_color"
+                android:textSize="@dimen/settings_text_size"
+                tools:text="https://google.com/search?q={searchTerms}" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/buttons_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_gravity="end"
+            android:orientation="horizontal"
+            app:visibleInvisible="@{isHovered}"
+            android:addStatesFromChildren="true">
+
+            <ImageView
+                android:id="@+id/trash"
+                android:contentDescription="Delete custom search engine"
+                android:layout_width="@dimen/library_item_row_height"
+                android:layout_height="@dimen/library_item_row_height"
+                android:layout_gravity="center_vertical|end"
+                android:padding="@dimen/library_icon_padding_max"
+                android:soundEffectsEnabled="false"
+                android:src="@drawable/ic_icon_trash"
+                app:srcCompat="@drawable/ic_icon_trash"
+                app:tint="@color/library_panel_icon_color" />
+        </LinearLayout>
+    </RelativeLayout>
+</layout>

--- a/app/src/main/res/layout/options_custom_search_engines.xml
+++ b/app/src/main/res/layout/options_custom_search_engines.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="isEmpty"
+            type="boolean" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="@dimen/settings_dialog_width"
+        android:layout_height="@dimen/settings_dialog_height"
+        android:background="@drawable/dialog_background"
+        android:paddingStart="30dp"
+        android:paddingEnd="30dp">
+
+        <com.igalia.wolvic.ui.widgets.settings.SettingsHeader
+            android:id="@+id/header_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:helpVisibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@string/custom_search_engines_title" />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginBottom="10dp"
+            app:layout_constraintBottom_toTopOf="@id/footer_layout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_layout">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:layout_marginStart="110dp"
+                android:layout_marginEnd="110dp"
+                visibleGone="@{isEmpty}">
+                <TextView
+                    style="@style/settingsText"
+                    android:id="@+id/empty_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:textAlignment="center"
+                    android:paddingBottom="15dp"
+                    android:textColor="@color/rhino"
+                    android:layout_gravity="center"
+                    android:text="@string/custom_search_engines_empty"
+                    tools:text="@string/custom_search_engines_empty" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                visibleGone="@{!isEmpty}">
+                <TextView
+                    style="@style/settingsText"
+                    android:id="@+id/content_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:paddingBottom="5dp"
+                    android:text="@string/custom_search_engines_list_header"
+                    tools:text="@string/custom_search_engines_list_header" />
+
+                <com.igalia.wolvic.ui.views.CustomRecyclerView
+                    android:id="@+id/enginesList"
+                    style="@style/customRecyclerViewStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@color/asphalt"
+                    android:contentDescription="Search Engines List"
+                    android:paddingEnd="15dp"
+                    app:layoutManager="LinearLayoutManager" />
+            </LinearLayout>
+        </FrameLayout>
+
+        <com.igalia.wolvic.ui.widgets.settings.SettingsFooter
+            android:id="@+id/footer_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:buttonText="@string/add_search_engine_title"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/options_edit_search_engine.xml
+++ b/app/src/main/res/layout/options_edit_search_engine.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/dialog_background"
+        android:paddingStart="30dp"
+        android:paddingEnd="30dp">
+
+        <com.igalia.wolvic.ui.widgets.settings.SettingsHeader
+            android:id="@+id/header_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:helpVisibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@string/settings_display" />
+
+        <com.igalia.wolvic.ui.views.CustomScrollView
+            android:id="@+id/scrollbar"
+            style="@style/customScrollViewStyle"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginBottom="10dp"
+            android:paddingEnd="30dp"
+            app:layout_constraintBottom_toTopOf="@id/footer_layout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_layout">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <com.igalia.wolvic.ui.views.settings.SingleEditSetting
+                    android:id="@+id/name_edit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:width="300dp"
+                    android:inputType="text|textNoSuggestions"
+                    app:description="@string/add_search_engine_name_title"
+                    app:hintTextColor="@color/iron_blur"
+                    app:highlightedTextColor="@color/fog" />
+
+                <com.igalia.wolvic.ui.views.settings.SingleEditSetting
+                    android:id="@+id/search_url_edit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:width="300dp"
+                    android:inputType="textUri"
+                    app:description="@string/add_search_engine_search_url_title"
+                    app:hintTextColor="@color/iron_blur"
+                    app:highlightedTextColor="@color/fog" />
+
+                <com.igalia.wolvic.ui.views.settings.SingleEditSetting
+                    android:id="@+id/suggest_url_edit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:width="300dp"
+                    android:inputType="textUri"
+                    app:description="@string/add_search_engine_suggest_url_title"
+                    app:hintTextColor="@color/iron_blur"
+                    app:highlightedTextColor="@color/fog" />
+
+                <TextView
+                    android:id="@+id/error_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:ellipsize="end"
+                    android:scrollHorizontally="true"
+                    android:singleLine="true"
+                    android:layout_marginEnd="10dp"
+                    android:textColor="@color/dessert"
+                    android:textSize="@dimen/text_smaller_size"
+                    android:visibility="gone"/>
+
+            </LinearLayout>
+        </com.igalia.wolvic.ui.views.CustomScrollView>
+
+        <com.igalia.wolvic.ui.widgets.settings.SettingsFooter
+            android:id="@+id/footer_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:buttonText="@string/privacy_options_saved_login_delete"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/options_search_engine.xml
+++ b/app/src/main/res/layout/options_search_engine.xml
@@ -34,11 +34,30 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/header_layout">
 
-            <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
-                android:id="@+id/searchEngineRadio"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layout="@layout/setting_radio_group_v" />
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/addEngineButton"
+                    style="@style/settingsButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="15dp"
+                    android:gravity="start|center_vertical"
+                    android:paddingStart="15dp"
+                    android:paddingEnd="15dp"
+                    android:textAlignment="center"
+                    android:text="@string/custom_search_engines_manage" />
+
+                <com.igalia.wolvic.ui.views.settings.RadioGroupVSetting
+                    android:id="@+id/searchEngineRadio"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:layout="@layout/setting_radio_group_v" />
+
+            </LinearLayout>
         </com.igalia.wolvic.ui.views.CustomScrollView>
 
         <com.igalia.wolvic.ui.widgets.settings.SettingsFooter
@@ -49,8 +68,7 @@
             app:description="@string/settings_privacy_choose_search_engine_reset"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/scrollbar" />
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -90,6 +90,7 @@
     <string name="settings_key_terms_service_accepted" translatable="false">settings_key_terms_service_accepted</string>
     <string name="settings_key_privacy_policy_accepted" translatable="false">settings_key_privacy_policy_accepted</string>
     <string name="settings_key_search_engine_id" translatable="false">settings_key_search_engine_id</string>
+    <string name="settings_key_custom_search_engines" translatable="false">settings_key_custom_search_engines</string>
     <string name="settings_key_eye_tracking_supported" translatable="false">settings_key_eye_tracking_supported</string>
     <string name="settings_key_tabs_location" translatable="false">settings_key_tabs_location</string>
     <string name="environment_override_help_url" translatable="false">https://github.com/igalia/wolvic/wiki/Environments</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,6 +132,70 @@
     <!-- This string labels the Reset button that restores the default search engine settings values. -->
     <string name="settings_privacy_choose_search_engine_reset">Reset Search Engine Settings</string>
 
+    <!-- This string is used as the title of the add custom search engine dialog. -->
+    <string name="add_search_engine_title">Add Search Engine</string>
+
+    <!-- This string is used as the title for the name input field in the add search engine dialog. -->
+    <string name="add_search_engine_name_title">Name</string>
+
+    <!-- This string is used as the hint for the name input field in the add search engine dialog. -->
+    <string name="add_search_engine_name_hint">Enter search engine name</string>
+
+    <!-- This string is used as the title for the search URL input field in the add search engine dialog. -->
+    <string name="add_search_engine_search_url_title">Search URL</string>
+
+    <!-- This string is used as the hint for the search URL input field in the add search engine dialog. -->
+    <string name="add_search_engine_search_url_hint">https://example.com/search?q={searchTerms}</string>
+
+    <!-- This string is used as the title for the suggest URL input field in the add search engine dialog. -->
+    <string name="add_search_engine_suggest_url_title">Suggestion URL (optional)</string>
+
+    <!-- This string is used as the hint for the suggest URL input field in the add search engine dialog. -->
+    <string name="add_search_engine_suggest_url_hint">https://example.com/suggest?q={searchTerms}</string>
+
+    <!-- This string is used for the save button in the add search engine dialog. -->
+    <string name="add_search_engine_save">Save</string>
+
+    <!-- This string is used for the cancel button in the add search engine dialog. -->
+    <string name="add_search_engine_cancel">Cancel</string>
+
+    <!-- This string is used as the title of the edit custom search engine dialog. -->
+    <string name="edit_search_engine_title">Edit Search Engine</string>
+
+    <!-- This string is used for the save button in the edit search engine dialog. -->
+    <string name="edit_search_engine_save">Update</string>
+
+    <!-- This string is shown when a custom search engine is deleted -->
+    <string name="search_engine_deleted">Search engine deleted</string>
+
+    <!-- This string is used as the title of the delete search engine confirmation dialog -->
+    <string name="delete_search_engine_dialog_title">Delete Search Engine</string>
+
+    <!-- This string is used as the text of the delete search engine confirmation dialog -->
+    <string name="delete_search_engine_dialog_text">Are you sure you want to delete the %1$s search engine?</string>
+
+    <!-- This string is used as the title of the custom search engines management view -->
+    <string name="custom_search_engines_title">Custom Search Engines</string>
+
+    <!-- This string is shown when there are no custom search engines -->
+    <string name="custom_search_engines_empty">No custom search engines. Use the Add Search Engine button to add one.</string>
+
+    <!-- This string is used for the button to manage custom search engines -->
+    <string name="custom_search_engines_manage">Custom Search Engines</string>
+
+    <!-- This string is the header for the list of custom search engines -->
+    <string name="custom_search_engines_list_header">Custom Search Engines</string>
+
+    <!-- Validation error messages for custom search engines -->
+    <string name="search_engine_error_url_required">URL is required</string>
+    <string name="search_engine_error_url_placeholder">URL must contain %s or {searchTerms} placeholder</string>
+    <string name="search_engine_error_url_scheme">URL must have a scheme (http:// or https://)</string>
+    <string name="search_engine_error_url_scheme_unsupported">Only http and https URLs are allowed</string>
+    <string name="search_engine_error_url_host">URL must have a valid host</string>
+    <string name="search_engine_error_url_private">Private/localhost URLs are not allowed for security reasons</string>
+    <string name="search_engine_error_name_required">Name is required</string>
+    <string name="search_engine_error_name_too_long">Name must be 50 characters or less</string>
+
     <!-- This string is used as the title of the pop-ups dialog used to remove sites from the currently
          allowed pop-up sites. -->
     <string name="settings_privacy_policy_popups_title_v1">Exceptions for Pop-Ups</string>
@@ -1019,9 +1083,15 @@
          This appears in such contexts as dialog boxes, `<select>` menus, etc. -->
     <string name="cancel_button">Cancel</string>
 
+    <!-- This string labels a button that is used to close a dialog or view. -->
+    <string name="close_button">Close</string>
+
     <!-- This string labels a button that is used to approve an action.
          This appears in such contexts as dialog boxes, `<select>` menus, etc. -->
     <string name="ok_button">OK</string>
+
+    <!-- This string labels a button that is used to delete an item. -->
+    <string name="delete_button">Delete</string>
 
     <!-- This string labels a button that is used to upload a file.
          This appears in such contexts as dialog boxes, `<select>` menus, etc. -->

--- a/app/src/test/java/com/igalia/wolvic/search/CustomSearchEngineTest.java
+++ b/app/src/test/java/com/igalia/wolvic/search/CustomSearchEngineTest.java
@@ -1,0 +1,105 @@
+package com.igalia.wolvic.search;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CustomSearchEngineTest {
+
+    @Test
+    public void testBuilderCreatesValidEngine() {
+        CustomSearchEngine engine = new CustomSearchEngine.Builder()
+                .setId("custom_1")
+                .setName("Test Engine")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .setSuggestUrl("https://example.com/suggest?q=%s")
+                .build();
+
+        assertEquals("custom_1", engine.getId());
+        assertEquals("Test Engine", engine.getName());
+        assertEquals("https://example.com/search?q=%s", engine.getSearchUrl());
+        assertEquals("https://example.com/suggest?q=%s", engine.getSuggestUrl());
+    }
+
+    @Test
+    public void testBuilderWithOptionalSuggestUrl() {
+        CustomSearchEngine engine = new CustomSearchEngine.Builder()
+                .setId("custom_2")
+                .setName("No Suggestions")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+
+        assertNull(engine.getSuggestUrl());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testBuilderThrowsWhenMissingId() {
+        new CustomSearchEngine.Builder()
+                .setName("Test")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testBuilderThrowsWhenMissingName() {
+        new CustomSearchEngine.Builder()
+                .setId("custom_1")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testBuilderThrowsWhenMissingSearchUrl() {
+        new CustomSearchEngine.Builder()
+                .setId("custom_1")
+                .setName("Test")
+                .build();
+    }
+
+    @Test
+    public void testEquality() {
+        CustomSearchEngine engine1 = new CustomSearchEngine.Builder()
+                .setId("custom_1")
+                .setName("Test")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+
+        CustomSearchEngine engine2 = new CustomSearchEngine.Builder()
+                .setId("custom_1")
+                .setName("Test")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+
+        assertEquals(engine1, engine2);
+    }
+
+    @Test
+    public void testInequality() {
+        CustomSearchEngine engine1 = new CustomSearchEngine.Builder()
+                .setId("custom_1")
+                .setName("Test 1")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+
+        CustomSearchEngine engine2 = new CustomSearchEngine.Builder()
+                .setId("custom_2")
+                .setName("Test 2")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+
+        assertNotEquals(engine1, engine2);
+    }
+
+    @Test
+    public void testToString() {
+        CustomSearchEngine engine = new CustomSearchEngine.Builder()
+                .setId("custom_1")
+                .setName("Test")
+                .setSearchUrl("https://example.com/search?q=%s")
+                .build();
+
+        String str = engine.toString();
+        assertTrue(str.contains("custom_1"));
+        assertTrue(str.contains("Test"));
+    }
+}

--- a/app/src/test/java/com/igalia/wolvic/search/SearchEngineValidationTest.java
+++ b/app/src/test/java/com/igalia/wolvic/search/SearchEngineValidationTest.java
@@ -1,0 +1,133 @@
+package com.igalia.wolvic.search;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.igalia.wolvic.R;
+
+@RunWith(RobolectricTestRunner.class)
+public class SearchEngineValidationTest {
+
+    @Test
+    public void testValidSearchUrl() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSearchUrl(ApplicationProvider.getApplicationContext(), "https://example.com/search?q=%s");
+        assertTrue(result.isValid());
+        assertNull(result.getErrorMessage());
+    }
+
+    @Test
+    public void testHttpSearchUrl() {
+        SearchEngineValidation.ValidationResult result =
+                SearchEngineValidation.validateSearchUrl(ApplicationProvider.getApplicationContext(), "http://example.com/search?q=%s");
+        assertTrue(result.isValid());
+        assertNull(result.getErrorMessage());
+    }
+
+    @Test
+    public void testMissingSearchUrl() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSearchUrl(ApplicationProvider.getApplicationContext(), null);
+        assertFalse(result.isValid());
+        assertEquals(result.getErrorMessage(), ApplicationProvider.getApplicationContext().getString(R.string.search_engine_error_url_required));
+    }
+
+    @Test
+    public void testEmptySearchUrl() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSearchUrl(ApplicationProvider.getApplicationContext(), "");
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    public void testMissingPlaceholder() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSearchUrl(ApplicationProvider.getApplicationContext(), "https://example.com/search");
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage().contains("%s"));
+    }
+
+    @Test
+    public void testInvalidScheme() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSearchUrl(ApplicationProvider.getApplicationContext(), "ftp://example.com/search?q=%s");
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    public void testLocalhostRejected() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSearchUrl(ApplicationProvider.getApplicationContext(), "https://localhost/search?q=%s");
+        assertFalse(result.isValid());
+        assertEquals(result.getErrorMessage(), ApplicationProvider.getApplicationContext().getString(R.string.search_engine_error_url_private));
+    }
+
+    @Test
+    public void testValidName() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateName(ApplicationProvider.getApplicationContext(), "My Search Engine");
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testEmptyNameRejected() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateName(ApplicationProvider.getApplicationContext(), "");
+        assertFalse(result.isValid());
+        assertEquals(result.getErrorMessage(), ApplicationProvider.getApplicationContext().getString(R.string.search_engine_error_name_required));
+    }
+
+    @Test
+    public void testNameTooLongRejected() {
+        String longName = "A".repeat(100);
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateName(ApplicationProvider.getApplicationContext(), longName);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage().contains("50"));
+    }
+
+    @Test
+    public void testValidSuggestUrl() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSuggestUrl(ApplicationProvider.getApplicationContext(), "https://example.com/suggest?q=%s");
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testEmptySuggestUrlIsValid() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSuggestUrl(ApplicationProvider.getApplicationContext(), "");
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testNullSuggestUrlIsValid() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSuggestUrl(ApplicationProvider.getApplicationContext(), null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testSuggestUrlWithoutPlaceholderRejected() {
+        SearchEngineValidation.ValidationResult result = 
+                SearchEngineValidation.validateSuggestUrl(ApplicationProvider.getApplicationContext(), "https://example.com/suggest");
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage().contains("%s"));
+    }
+
+    @Test
+    public void testValidateAllReturnsAllErrors() {
+        List<SearchEngineValidation.ValidationResult> results = 
+                SearchEngineValidation.validateAll(ApplicationProvider.getApplicationContext(), "", "", null);
+        
+        assertTrue(results.size() >= 2);
+    }
+}


### PR DESCRIPTION
This PR introduces the long awaited feature of custom search engines. Using existing classes, it adds a new dialog that lists the existing custom search engines and allows the user to add/edit/delete them. The add/edit custom search engine is also based on similar dialogs in Wolvic like the Saved Logins dialog.

Users can not only specify a search URL for searches but also a URL for suggestions that are shown as the user types in the url bar.

Once a new custom search engine is added, it'll appear at the top of the list of available search engines.

It features validation for both the name and the search URLs provided by the user as they will likely have placeholders for the search terms ({searchTerms} is recommended by OpenSearch spec but %s can be used too).

Last but not least we include also a couple of new tests mainly for the new validation code.

Fixes #1696