### PR TITLE
Fix SessionStateTest package and harden session persistence

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -81,6 +81,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
 
     private static final String WINDOWS_SAVE_FILENAME = "windows_state.json";
+    private static final String WINDOWS_SAVE_FILENAME_TMP = "windows_state.json.tmp";
+    private static final String WINDOWS_SAVE_FILENAME_BAK = "windows_state.json.bak";
 
     private static final int TAB_ADDED_NOTIFICATION_ID = 0;
     private static final int TAB_SENT_NOTIFICATION_ID = 1;
@@ -255,8 +257,15 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     private void saveStateOnDiskIO() {
-        File file = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME);
-        try (Writer writer = new FileWriter(file)) {
+        File file    = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME);
+        File tmpFile = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME_TMP);
+        File bakFile = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME_BAK);
+
+        // --- Step 1: Build state and write to a temporary file ---
+        // Writing to a temp file first means that if the app is killed mid-write,
+        // the main session file is never corrupted (atomic write pattern).
+        final int[] tabCount = {0}; // captured for the success log after the try block
+        try (Writer writer = new FileWriter(tmpFile)) {
             WindowsState state = new WindowsState();
             state.privateMode = mPrivateMode;
             state.focusedWindowPlacement = mFocusedWindow.isFullScreen() ?  mFocusedWindow.getWindowPlacementBeforeFullscreen() : mFocusedWindow.getWindowPlacement();
@@ -284,12 +293,31 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             gson.toJson(state, writer);
             writer.flush();
-
-            Log.d(LOGTAG, "Windows state saved");
-
+            tabCount[0] = state.tabs.size();
         } catch (IOException e) {
-            Log.e(LOGTAG, "Error saving windows state: " + e.getLocalizedMessage());
-            file.delete();
+            Log.e(LOGTAG, "Error writing temporary session file; original session is intact: " + e.getLocalizedMessage());
+            tmpFile.delete(); // clean up the incomplete temp file only
+            return;
+        }
+
+        // --- Step 2: Promote current valid file to backup ---
+        // Before replacing the main file, move it to .bak so we always have
+        // the last-known-good state as a fallback.
+        if (file.exists()) {
+            bakFile.delete(); // remove old backup first
+            if (!file.renameTo(bakFile)) {
+                Log.w(LOGTAG, "Could not create session backup; continuing with atomic replace");
+            }
+        }
+
+        // --- Step 3: Atomically replace main file with the newly written temp ---
+        if (!tmpFile.renameTo(file)) {
+            Log.e(LOGTAG, "Atomic rename of session file failed; attempting to restore backup");
+            if (bakFile.exists() && !bakFile.renameTo(file)) {
+                Log.e(LOGTAG, "Could not restore session backup after failed rename");
+            }
+        } else {
+            Log.d(LOGTAG, "Windows state saved (" + tabCount[0] + " tabs)");
         }
     }
 
@@ -304,22 +332,52 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     private WindowsState restoreState() {
-        WindowsState restored = null;
+        File file    = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME);
+        File bakFile = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME_BAK);
 
-        File file = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME);
+        // --- Attempt 1: restore from the primary session file ---
+        WindowsState restored = tryRestoreFromFile(file);
+        if (restored != null) {
+            return restored;
+        }
+
+        // --- Attempt 2: primary failed (corrupt / schema mismatch); try backup ---
+        if (bakFile.exists()) {
+            Log.w(LOGTAG, "Primary session file unreadable; attempting restore from backup");
+            restored = tryRestoreFromFile(bakFile);
+            if (restored != null) {
+                Log.d(LOGTAG, "Windows state restored from backup");
+                return restored;
+            }
+        }
+
+        // --- Both files unreadable: start fresh but deliberately do NOT delete ---
+        // Preserving the files allows for forensic analysis or recovery via future
+        // app versions, rather than permanently destroying the user's session.
+        Log.e(LOGTAG, "All session restore attempts failed; starting with no tabs");
+        return null;
+    }
+
+    /**
+     * Reads and deserializes a {@link WindowsState} from the given file.
+     * Returns {@code null} (with a log message) on any error — never throws.
+     */
+    private WindowsState tryRestoreFromFile(File file) {
+        if (!file.exists()) {
+            return null;
+        }
         try (Reader reader = new FileReader(file)) {
             Gson gson = new GsonBuilder().create();
             Type type = new TypeToken<WindowsState>() {}.getType();
-            restored = gson.fromJson(reader, type);
-
-            Log.d(LOGTAG, "Windows state restored");
-
+            WindowsState state = gson.fromJson(reader, type);
+            if (state != null) {
+                Log.d(LOGTAG, "Windows state restored from " + file.getName());
+            }
+            return state;
         } catch (Exception e) {
-            Log.e(LOGTAG, "Error restoring windows state, tabs will not be restored: " + e.getLocalizedMessage());
-            file.delete();
+            Log.e(LOGTAG, "Error reading session file '" + file.getName() + "': " + e.getLocalizedMessage());
+            return null;
         }
-
-        return restored;
     }
 
     public void setDelegate(Delegate aDelegate) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/Windows.java
@@ -261,9 +261,6 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         File tmpFile = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME_TMP);
         File bakFile = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME_BAK);
 
-        // --- Step 1: Build state and write to a temporary file ---
-        // Writing to a temp file first means that if the app is killed mid-write,
-        // the main session file is never corrupted (atomic write pattern).
         final int[] tabCount = {0}; // captured for the success log after the try block
         try (Writer writer = new FileWriter(tmpFile)) {
             WindowsState state = new WindowsState();
@@ -300,9 +297,6 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             return;
         }
 
-        // --- Step 2: Promote current valid file to backup ---
-        // Before replacing the main file, move it to .bak so we always have
-        // the last-known-good state as a fallback.
         if (file.exists()) {
             bakFile.delete(); // remove old backup first
             if (!file.renameTo(bakFile)) {
@@ -310,7 +304,6 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             }
         }
 
-        // --- Step 3: Atomically replace main file with the newly written temp ---
         if (!tmpFile.renameTo(file)) {
             Log.e(LOGTAG, "Atomic rename of session file failed; attempting to restore backup");
             if (bakFile.exists() && !bakFile.renameTo(file)) {
@@ -335,13 +328,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         File file    = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME);
         File bakFile = new File(mContext.getFilesDir(), WINDOWS_SAVE_FILENAME_BAK);
 
-        // --- Attempt 1: restore from the primary session file ---
         WindowsState restored = tryRestoreFromFile(file);
         if (restored != null) {
             return restored;
         }
 
-        // --- Attempt 2: primary failed (corrupt / schema mismatch); try backup ---
         if (bakFile.exists()) {
             Log.w(LOGTAG, "Primary session file unreadable; attempting restore from backup");
             restored = tryRestoreFromFile(bakFile);
@@ -351,17 +342,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             }
         }
 
-        // --- Both files unreadable: start fresh but deliberately do NOT delete ---
-        // Preserving the files allows for forensic analysis or recovery via future
-        // app versions, rather than permanently destroying the user's session.
         Log.e(LOGTAG, "All session restore attempts failed; starting with no tabs");
         return null;
     }
 
-    /**
-     * Reads and deserializes a {@link WindowsState} from the given file.
-     * Returns {@code null} (with a log message) on any error — never throws.
-     */
     private WindowsState tryRestoreFromFile(File file) {
         if (!file.exists()) {
             return null;

--- a/app/src/test/java/com/igalia/wolvic/browser/engine/SessionStateTest.java
+++ b/app/src/test/java/com/igalia/wolvic/browser/engine/SessionStateTest.java
@@ -10,18 +10,8 @@ import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
-/**
- * Regression tests for the session persistence bug (issue #1878).
- *
- * Root cause: {@code mSettings} was written twice to the JSON output by
- * {@code SessionStateAdapterFactory}, creating duplicate keys. GSON's behaviour
- * with duplicate keys is undefined and version-dependent, which caused
- * deserialization failures after app updates, triggering {@code file.delete()}
- * in {@code Windows.restoreState()} and permanently wiping all user tabs.
- */
-public class SessionStateTest {
 
-    // ── Regression: mSettings must appear exactly once ──────────────────────
+public class SessionStateTest {
 
     @Test
     public void testSerializationWithoutDuplicates() {
@@ -41,7 +31,6 @@ public class SessionStateTest {
         assertEquals("mSettings key must appear exactly once (duplicate = corruption)", firstIndex, lastIndex);
     }
 
-    // ── Round-trip: serialise → deserialise must preserve all fields ─────────
 
     @Test
     public void testRoundTrip_preservesUriAndTitle() {
@@ -71,8 +60,6 @@ public class SessionStateTest {
 
         String json = gson.toJson(state);
 
-        // When mSettings is null the adapter skips the block entirely,
-        // so neither mSettings nor mSessionState should appear in the output.
         assertTrue("mSettings should not be written when null", !json.contains("\"mSettings\""));
 
         SessionState restored = gson.fromJson(json, SessionState.class);
@@ -80,14 +67,11 @@ public class SessionStateTest {
         assertEquals("https://example.com", restored.mUri);
     }
 
-    // ── Error resilience: corrupt JSON must not crash (silent null return) ───
 
     @Test
     public void testDeserialize_corruptJson_returnsNull() {
         Gson gson = new GsonBuilder().create();
 
-        // Simulates the kind of truncated/corrupt file that arises from a
-        // partial write (app killed mid-save before the atomic fix).
         String corrupt = "{ \"mUri\": \"https://wolvic.com\", \"mSettings\": { BAD JSON";
 
         SessionState restored = null;
@@ -96,29 +80,18 @@ public class SessionStateTest {
         } catch (Exception ignored) {
             // GSON may throw or return null; either way the caller must handle it.
         }
-        // The important invariant: we must not crash, and the result is unusable.
-        // (restored may be null, or a partial object — both are acceptable.)
-        // What is NOT acceptable is an unhandled exception propagating to the UI.
     }
 
     @Test
     public void testDeserialize_emptyJson_returnsNull() {
         Gson gson = new GsonBuilder().create();
-        // Empty file → fromJson returns null; restoreState() must handle this
         SessionState restored = gson.fromJson("{}", SessionState.class);
-        // An empty object deserializes to a SessionState with all defaults
-        assertNotNull(restored); // GSON creates a default-constructed object
         assertEquals("Default mUri should be empty string", "", restored.mUri);
     }
-
-    // ── Backward compatibility: old-format JSON (fields added in later versions)
 
     @Test
     public void testDeserialize_missingNewFields_usesDefaults() {
         Gson gson = new GsonBuilder().create();
-
-        // Simulate a session file written by an older Wolvic version that did
-        // not have mLastUse, mRegion, or mParentId fields.
         String oldFormat = "{\"mUri\":\"https://example.com\",\"mTitle\":\"Old Tab\"}";
 
         SessionState restored = gson.fromJson(oldFormat, SessionState.class);
@@ -126,7 +99,6 @@ public class SessionStateTest {
         assertNotNull(restored);
         assertEquals("https://example.com", restored.mUri);
         assertEquals("Old Tab", restored.mTitle);
-        // New fields must default to safe values (0 / null), not cause exceptions
         assertEquals(0L, restored.mLastUse);
         assertNull(restored.mRegion);
         assertNull(restored.mParentId);
@@ -136,10 +108,8 @@ public class SessionStateTest {
     public void testDeserialize_extraUnknownFields_ignoredSafely() {
         Gson gson = new GsonBuilder().create();
 
-        // A session file from a NEWER Wolvic version with fields our code doesn't know yet.
         String newFormat = "{\"mUri\":\"https://a.com\",\"mTitle\":\"A\",\"mFutureField\":\"value\"}";
 
-        // GSON's default behaviour is to ignore unknown fields — this must not throw.
         SessionState restored = gson.fromJson(newFormat, SessionState.class);
 
         assertNotNull(restored);

--- a/app/src/test/java/com/igalia/wolvic/browser/engine/SessionStateTest.java
+++ b/app/src/test/java/com/igalia/wolvic/browser/engine/SessionStateTest.java
@@ -2,6 +2,7 @@ package com.igalia.wolvic.browser.engine;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.Gson;
@@ -9,34 +10,139 @@ import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
+/**
+ * Regression tests for the session persistence bug (issue #1878).
+ *
+ * Root cause: {@code mSettings} was written twice to the JSON output by
+ * {@code SessionStateAdapterFactory}, creating duplicate keys. GSON's behaviour
+ * with duplicate keys is undefined and version-dependent, which caused
+ * deserialization failures after app updates, triggering {@code file.delete()}
+ * in {@code Windows.restoreState()} and permanently wiping all user tabs.
+ */
 public class SessionStateTest {
+
+    // ── Regression: mSettings must appear exactly once ──────────────────────
 
     @Test
     public void testSerializationWithoutDuplicates() {
         Gson gson = new GsonBuilder().create();
-        
+
         SessionState state = new SessionState();
         state.mUri = "https://wolvic.com";
         state.mTitle = "Wolvic";
-        
-        // Add settings to trigger the fixed branch
         state.mSettings = new SessionSettings();
-        
-        // Serialize
+
         String json = gson.toJson(state);
-        
-        // Ensure "mSettings" only appears once in the JSON output
+
         int firstIndex = json.indexOf("\"mSettings\"");
-        int lastIndex = json.lastIndexOf("\"mSettings\"");
-        
-        assertTrue("mSettings should be present", firstIndex != -1);
-        assertEquals("mSettings should only appear once", firstIndex, lastIndex);
-        
-        // Deserialize
-        SessionState restored = gson.fromJson(json, SessionState.class);
+        int lastIndex  = json.lastIndexOf("\"mSettings\"");
+
+        assertTrue("mSettings key must be present in JSON", firstIndex != -1);
+        assertEquals("mSettings key must appear exactly once (duplicate = corruption)", firstIndex, lastIndex);
+    }
+
+    // ── Round-trip: serialise → deserialise must preserve all fields ─────────
+
+    @Test
+    public void testRoundTrip_preservesUriAndTitle() {
+        Gson gson = new GsonBuilder().create();
+
+        SessionState state = new SessionState();
+        state.mUri   = "https://wolvic.com";
+        state.mTitle = "Wolvic Browser";
+        state.mSettings = new SessionSettings();
+
+        SessionState restored = gson.fromJson(gson.toJson(state), SessionState.class);
+
         assertNotNull(restored);
         assertEquals("https://wolvic.com", restored.mUri);
-        assertEquals("Wolvic", restored.mTitle);
+        assertEquals("Wolvic Browser", restored.mTitle);
         assertNotNull(restored.mSettings);
+    }
+
+    @Test
+    public void testRoundTrip_withNullSettings_noSettingsKeyInJson() {
+        Gson gson = new GsonBuilder().create();
+
+        SessionState state = new SessionState();
+        state.mUri      = "https://example.com";
+        state.mTitle    = "Example";
+        state.mSettings = null; // null settings → the conditional branch is NOT entered
+
+        String json = gson.toJson(state);
+
+        // When mSettings is null the adapter skips the block entirely,
+        // so neither mSettings nor mSessionState should appear in the output.
+        assertTrue("mSettings should not be written when null", !json.contains("\"mSettings\""));
+
+        SessionState restored = gson.fromJson(json, SessionState.class);
+        assertNotNull(restored);
+        assertEquals("https://example.com", restored.mUri);
+    }
+
+    // ── Error resilience: corrupt JSON must not crash (silent null return) ───
+
+    @Test
+    public void testDeserialize_corruptJson_returnsNull() {
+        Gson gson = new GsonBuilder().create();
+
+        // Simulates the kind of truncated/corrupt file that arises from a
+        // partial write (app killed mid-save before the atomic fix).
+        String corrupt = "{ \"mUri\": \"https://wolvic.com\", \"mSettings\": { BAD JSON";
+
+        SessionState restored = null;
+        try {
+            restored = gson.fromJson(corrupt, SessionState.class);
+        } catch (Exception ignored) {
+            // GSON may throw or return null; either way the caller must handle it.
+        }
+        // The important invariant: we must not crash, and the result is unusable.
+        // (restored may be null, or a partial object — both are acceptable.)
+        // What is NOT acceptable is an unhandled exception propagating to the UI.
+    }
+
+    @Test
+    public void testDeserialize_emptyJson_returnsNull() {
+        Gson gson = new GsonBuilder().create();
+        // Empty file → fromJson returns null; restoreState() must handle this
+        SessionState restored = gson.fromJson("{}", SessionState.class);
+        // An empty object deserializes to a SessionState with all defaults
+        assertNotNull(restored); // GSON creates a default-constructed object
+        assertEquals("Default mUri should be empty string", "", restored.mUri);
+    }
+
+    // ── Backward compatibility: old-format JSON (fields added in later versions)
+
+    @Test
+    public void testDeserialize_missingNewFields_usesDefaults() {
+        Gson gson = new GsonBuilder().create();
+
+        // Simulate a session file written by an older Wolvic version that did
+        // not have mLastUse, mRegion, or mParentId fields.
+        String oldFormat = "{\"mUri\":\"https://example.com\",\"mTitle\":\"Old Tab\"}";
+
+        SessionState restored = gson.fromJson(oldFormat, SessionState.class);
+
+        assertNotNull(restored);
+        assertEquals("https://example.com", restored.mUri);
+        assertEquals("Old Tab", restored.mTitle);
+        // New fields must default to safe values (0 / null), not cause exceptions
+        assertEquals(0L, restored.mLastUse);
+        assertNull(restored.mRegion);
+        assertNull(restored.mParentId);
+    }
+
+    @Test
+    public void testDeserialize_extraUnknownFields_ignoredSafely() {
+        Gson gson = new GsonBuilder().create();
+
+        // A session file from a NEWER Wolvic version with fields our code doesn't know yet.
+        String newFormat = "{\"mUri\":\"https://a.com\",\"mTitle\":\"A\",\"mFutureField\":\"value\"}";
+
+        // GSON's default behaviour is to ignore unknown fields — this must not throw.
+        SessionState restored = gson.fromJson(newFormat, SessionState.class);
+
+        assertNotNull(restored);
+        assertEquals("https://a.com", restored.mUri);
     }
 }


### PR DESCRIPTION
After #1962 got merged to fix the tab loss issue (#1878), CI started failing  turned out SessionStateTest.java ended up in the wrong package. Since SessionSettings is package private, the compiler wasn't happy about it being accessed from com.igalia.wolvic instead of com.igalia.wolvic.browser.engine where it actually lives.
This PR fixes that by moving the test file to the right place. While doing that, the tests got a proper expansion too there are now 7 of them covering the original duplicate key regression, the null settings branch, round-trip data preservation, backward and forward JSON compatibility, and what happens when the file is corrupt.
Also took the chance to make the session writes in Windows.java a bit safer. It now writes to a .tmp file first and keeps a .bak around as fallback, so even if something goes wrong mid-write or a future parse fails, the user's tabs won't just silently vanish.

Fixes CI failure introduced by #1962