### PR TITLE
Add null checks to StringUtils::removeSpaces calls

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChinesePinyinKeyboard.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChinesePinyinKeyboard.java
@@ -145,10 +145,8 @@ public class ChinesePinyinKeyboard extends BaseKeyboard {
 
             // When using backslashes ({@code \}) in the replacement string
             // will cause crash at `replaceFirst()`, so we need to replace it first.
-            if (result.words.get(0).code.length() > 0 &&
-                result.words.get(0).code.charAt(result.words.get(0).code.length() - 1)
-                        == kBackslashCode) {
-                newCode = result.words.get(0).code.replace("\\", "\\\\");
+            if (newCode != null && !newCode.isEmpty() && newCode.charAt(newCode.length() - 1) == kBackslashCode) {
+                newCode = newCode.replace("\\", "\\\\");
                 aComposingText = aComposingText.replace("\\", "\\\\");
             }
             String codeWithoutSpaces = newCode != null ? StringUtils.removeSpaces(newCode) : "";

--- a/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChinesePinyinKeyboard.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChinesePinyinKeyboard.java
@@ -151,7 +151,7 @@ public class ChinesePinyinKeyboard extends BaseKeyboard {
                 newCode = result.words.get(0).code.replace("\\", "\\\\");
                 aComposingText = aComposingText.replace("\\", "\\\\");
             }
-            String codeWithoutSpaces = StringUtils.removeSpaces(newCode);
+            String codeWithoutSpaces = newCode != null ? StringUtils.removeSpaces(newCode) : "";
             result.composing = aComposingText.replaceFirst(Pattern.quote(codeWithoutSpaces), newCode);
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChineseZhuyinKeyboard.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/keyboards/ChineseZhuyinKeyboard.java
@@ -104,7 +104,8 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
         result.action = CandidatesResult.Action.SHOW_CANDIDATES;
         result.composing = aComposingText;
         if (result.words.size() > 0) {
-            String codeWithoutSpaces = StringUtils.removeSpaces(result.words.get(0).code);
+            String code = result.words.get(0).code;
+            String codeWithoutSpaces = code != null ? StringUtils.removeSpaces(code) : "";
             result.composing = aComposingText.replaceFirst(Pattern.quote(codeWithoutSpaces), result.words.get(0).code);
         }
 

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1464,7 +1464,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             return;
         }
         if (mCurrentKeyboard.usesComposingText()) {
-            String code = StringUtils.removeSpaces(aItem.code);
+            String code = aItem.code != null ? StringUtils.removeSpaces(aItem.code) : "";
             mComposingText = mCurrentKeyboard.getComposingText(mComposingText, code).trim();
 
             postInputCommand(() -> {


### PR DESCRIPTION
They assume non-null parametters but it was not always guaranteed.

Fixes #1942