### PR TITLE
Fix libraries with LOAD segments not aligned to 16kb boundaries

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -182,6 +182,8 @@ include_directories(
 
 # Add dependency on KTX-Software
 add_subdirectory(${CMAKE_SOURCE_DIR}/src/main/cpp/KTX-Software)
+target_link_options(ktx PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(ktx_read PRIVATE "-Wl,-z,max-page-size=16384")
 target_link_libraries(native-lib PRIVATE ktx_read)
 target_include_directories(native-lib PRIVATE ${CMAKE_SOURCE_DIR}/src/main/cpp/KTX-Software/include)
 
@@ -204,3 +206,4 @@ target_link_libraries( # Specifies the target library.
                        EGL
                        GLESv3
                       )
+target_link_options(native-lib PRIVATE "-Wl,-z,max-page-size=16384")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ kotlinCoroutines = "1.7.3"
 okhttp = "4.12.0"
 opentelemetryAndroid = "0.9.1-alpha"
 opentelemetryApi = "1.46.0"
-openxrLoader = "1.0.34"
+openxrLoader = "1.1.48"
 robolectric = "4.11.1"
 zip4j = "2.11.5"
 

--- a/third_party_hash
+++ b/third_party_hash
@@ -1,1 +1,1 @@
-e57d8f132db3857c4aad3fa4fde1bc32f0b2a968
+2ba5b2ee2d96927f6bfc9de8644fdf9fb5be19b5


### PR DESCRIPTION
In particular the build was complaining about:
- lib/arm64-v8a/libktx.so
- lib/arm64-v8a/libktx_read.so
- lib/arm64-v8a/libnative-lib.so
- lib/arm64-v8a/libopenxr_loader.so
- lib/arm64-v8a/libovrplatformloader.so

The first three ones were fixing by adding the required build options to the CMake files.

The OpenXR loader library required version was upgraded to the first release that includes a fix for that.

Last but not least, the Meta Platform SDK in third_party repository was upgraded to v85 which contains a properly aligned library.

Fixes #1917