### PR TITLE
Fix VR keyboard dismissing after first keystroke with controller input

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -15,6 +15,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.InputDevice;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -1341,11 +1342,18 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             if (isAttachToWindowWidget()) {
                 if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
                     return false;
-                } else {
+                }
+                // Only forward to Web engine and dismiss the VR keyboard for physical keyboard
+                // events (SOURCE_KEYBOARD). Controller/gamepad events (SOURCE_GAMEPAD) must
+                // not dismiss the keyboard: dismiss() does not notify the engine, so it would
+                // never re-show it. The typed character was already committed via MotionEvent from
+                // the VRB input layer; the redundant KeyEvent from Meta Horizon OS must be ignored here.
+                if ((event.getSource() & InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD) {
                     connection.sendKeyEvent(event);
                     dismiss();
+                    return true;
                 }
-                return true;
+                return false;
             }
             // Android Components do not support InputConnection.sendKeyEvent()
             if (event.getAction() == KeyEvent.ACTION_DOWN) {


### PR DESCRIPTION
The isAttachToWindowWidget() branch in KeyboardWidget.dispatchKeyEvent() is designed for physical Bluetooth keyboards: when the user types on a real keyboard while the VR keyboard is visible, the key event is forwarded to the web engine and the VR keyboard is dismissed. The problem is that dismiss() hides the widget without notifying the engine, so it never re-calls showSoftInput() and the keyboard stays permanently hidden.

This dismiss() path can be incorrectly triggered by controller or gamepad KeyEvents, which share the SOURCE_CLASS_BUTTON bit with SOURCE_KEYBOARD but are not physical keyboards. That caused the on screen keyboard to disappear after the first character is typed. That's why this was only reproducible when using physical controllers and not with hand tracking.

Fix this by only calling sendKeyEvent() and dismiss() when the KeyEvent source is an actual physical keyboard.

This started to fail after upgrading to the new Meta HorizonOS v2.3.1034.

Fixes #1980