### PR TITLE
Disable DateTimeSuggestions in Chromium

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/PromptDelegateImpl.java
@@ -726,27 +726,9 @@ class PromptDelegateImpl implements UserDialogManagerBridge.Delegate {
             }
             mStepValue = Double.isNaN(step) || step <= 0 ? null : String.valueOf(step);
 
-            // Convert suggestion values to formatted strings. MONTH and WEEK
-            // use a special Chromium encoding (MonthPicker/WeekPicker), the
-            // rest are plain ms-since-epoch.
-            if (suggestions != null && suggestions.length > 0) {
-                List<String> listVals = new ArrayList<>();
-                for (DateTimeSuggestion s : suggestions) {
-                    try {
-                        double sv = s.value();
-                        if (mType == Type.MONTH) {
-                            sv = MonthPicker.createDateFromValue(sv).getTimeInMillis();
-                        } else if (mType == Type.WEEK) {
-                            sv = WeekPicker.createDateFromValue(sv).getTimeInMillis();
-                        }
-                        listVals.add(mFormatter.format(new Date((long) sv)));
-                    } catch (Exception ignored) {
-                    }
-                }
-                mListValues = listVals.isEmpty() ? null : listVals.toArray(new String[0]);
-            } else {
-                mListValues = null;
-            }
+            // Chromium DateTimeSuggestion does not expose a public value getter.
+            // Disable datalist suggestions for datetime inputs in Chromium builds.
+            mListValues = null;
         }
 
         @Override


### PR DESCRIPTION
The DateTimeSuggestion object in Chromium does not have a value() public method so Chromium builds were failing. We can use reflection to call the private value() method but that would be a step in the wrong direction. It looks to me that we are not using that as we should. In the meantime, let's disable it to keep the builds succeeding.