### PR TITLE
Keep all org.mozilla.gecko.** classes in release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -58,6 +58,19 @@
 -keep class org.vosk.** { *; }
 
 # --------------------------------------------------------------------
+# Keep everything under org.mozilla.gecko.**. GeckoView ships a consumer rule
+# that keeps org.mozilla.geckoview.** but only @WrapForJNI-annotated members of
+# org.mozilla.gecko.**. R8 then strips public/protected members of internals
+# like GeckoProcessManager, GeckoAppShell, and XPCOMEventTarget's helpers that
+# Gecko native code reaches via JNI/reflection at startup. The first observable
+# symptom is a MOZ_CRASH on the launcher thread inside
+# mozilla::jni::Accessor::EndAccess after dispatching XPCOMEventTarget.JNIRunnable
+# — see commit 0aa9413e8 (where the MeetKai AAR's implicit global keep rule was
+# removed).
+# --------------------------------------------------------------------
+-keep class org.mozilla.gecko.** { *; }
+
+# --------------------------------------------------------------------
 # Keep classes from FxR
 # --------------------------------------------------------------------
 -keep class com.igalia.wolvic.ui.widgets.WidgetPlacement {*;} # Keep class used in JNI.


### PR DESCRIPTION
GeckoView's bundled consumer ProGuard rule keeps the public org.mozilla.geckoview.** surface in full, but only @WrapForJNI-annotated members of org.mozilla.gecko.**. That leaves public/protected helpers in internals such as GeckoProcessManager, GeckoAppShell and XPCOMEventTarget exposed to R8's shrinker even though Gecko native code reaches them via JNI/reflection at startup.

Until 0aa9413e8 (Replace Meetkai ASR with offline Vosk ASR) this was silently masked: the MeetKai AAR shipped a consumer proguard.txt with "-keep public class * { public protected *; }", a global rule that kept everything across the merged APK. Removing the AAR removed that implicit umbrella, and R8 started stripping members reachable only via JNI. In release builds this manifested as an immediate startup SIGSEGV on the Gecko launcher thread:

  pid: ..., tid: ..., name: launcher  >>> com.igalia.wolvic <<<
  #00 pc ... libxul.so
  ...
  #07 pc ... libnss3.so
  #08 pc ... libmozglue.so

Symbolicating against a local Gecko 140 build showed the top frames were not a null deref but MOZ_CrashSequence triggered from mozilla::jni::Accessor::EndAccess after a JNIRunnable.run() dispatched by XPCOMEventTargetWrapper::DispatchNative threw because the target Java member had been removed by R8.

Add a targeted keep rule that mirrors what GeckoView already does for its public namespace. This is narrower than MeetKai's old global rule and survives Gecko refactors so long as JNI entry points stay under org.mozilla.gecko.**.