### PR TITLE
Fix visionglass startup crash on fresh install

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -559,6 +559,18 @@ android {
                    : "src/oculusvrArmRelease/AndroidManifest.xml"
            }
         }
+
+        // visionglass debug builds need to override src/debug/AndroidManifest.xml, which adds
+        // MAIN/LAUNCHER on VRBrowserActivity. On visionglass the launcher activity is
+        // FirstRunActivity, so the debug-added filter would let users skip the legal gate.
+        // Release builds with useDebugSigningOnRelease=true also pull in src/debug/AndroidManifest.xml
+        // (see the `release` source set above), so the same overlay is needed there.
+        if (name.startsWith('visionglass')) {
+            if (name.toLowerCase().contains('debug')
+                || (name.toLowerCase().contains('release') && getUseDebugSigningOnRelease())) {
+                manifest.srcFile "src/visionglassDebug/AndroidManifest.xml"
+            }
+        }
     }
 
     testOptions {

--- a/app/src/visionglass/AndroidManifest.xml
+++ b/app/src/visionglass/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature
         android:name="android.hardware.vr.headtracking"
@@ -9,16 +10,39 @@
         <activity
             android:name=".VRBrowserActivity"
             android:screenOrientation="portrait"
+            android:exported="false"
+            tools:replace="android:exported">
+            <intent-filter tools:node="removeAll" />
+        </activity>
+        <activity
+            android:name=".FirstRunActivity"
+            android:screenOrientation="portrait"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
-        <activity
-            android:name=".FirstRunActivity"
-            android:screenOrientation="portrait"
-            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="wolvic"
+                    android:host="com.igalia.wolvic" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/app/src/visionglass/java/com/igalia/wolvic/FirstRunActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/FirstRunActivity.java
@@ -1,5 +1,6 @@
 package com.igalia.wolvic;
 
+import android.content.ComponentName;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -22,11 +23,26 @@ public class FirstRunActivity extends FragmentActivity implements SharedPreferen
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setContentView(R.layout.visionglass_first_run);
+        SettingsStore settings = SettingsStore.getInstance(this);
+        if (settings.isTermsServiceAccepted() && settings.isPrivacyPolicyAccepted()) {
+            // Normal launch — skip inflating any UI and jump straight to the browser,
+            // preserving the original intent so VIEW/SEND payloads aren't dropped.
+            startActivity(forwardingIntent());
+            finish();
+            return;
+        }
+
         setTheme(R.style.Theme_MaterialComponents_Light);
+        setContentView(R.layout.visionglass_first_run);
 
         mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         mPrefs.registerOnSharedPreferenceChangeListener(this);
+    }
+
+    private Intent forwardingIntent() {
+        Intent forward = new Intent(getIntent());
+        forward.setComponent(new ComponentName(this, VRBrowserActivity.class));
+        return forward;
     }
 
     @Override
@@ -48,9 +64,8 @@ public class FirstRunActivity extends FragmentActivity implements SharedPreferen
                     .replace(R.id.fragment_placeholder, new PrivacyPolicyFragment())
                     .commit();
         } else {
-            // finish and go to the main activity
-            Intent intent = new Intent(this, VRBrowserActivity.class);
-            startActivity(intent);
+            // finish and go to the main activity, preserving the original intent
+            startActivity(forwardingIntent());
             finish();
         }
     }
@@ -66,6 +81,8 @@ public class FirstRunActivity extends FragmentActivity implements SharedPreferen
     @Override
     public void onDestroy() {
         super.onDestroy();
-        mPrefs.unregisterOnSharedPreferenceChangeListener(this);
+        if (mPrefs != null) {
+            mPrefs.unregisterOnSharedPreferenceChangeListener(this);
+        }
     }
 }

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -191,15 +191,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
         Log.d(LOGTAG, "PlatformActivity onCreate");
         super.onCreate(savedInstanceState);
 
-        // Before we do anything else, we need to ensure that the user has accepted the legal terms.
-        SettingsStore settings = SettingsStore.getInstance(this);
-        if (!settings.isTermsServiceAccepted() && !settings.isPrivacyPolicyAccepted()) {
-            Intent intent = new Intent(this, FirstRunActivity.class);
-            startActivity(intent);
-            finish();
-            return;
-        }
-
         mDisplayManager = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
         mSensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
 

--- a/app/src/visionglassDebug/AndroidManifest.xml
+++ b/app/src/visionglassDebug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity
+            android:name=".VRBrowserActivity">
+            <intent-filter tools:node="removeAll" />
+        </activity>
+    </application>
+</manifest>


### PR DESCRIPTION
VRBrowserActivity is launched and PlatformActivity.onCreate detects that the legal terms have not been accepted yet. It then redirects to FirstRunActivity and finishes the activity early, before mBinding (and the rest of the phone-UI state) has been initialized. Then this exception is thrown:

FATAL EXCEPTION: main
  Process: com.igalia.wolvic.world.visionglass
  java.lang.RuntimeException: Unable to start activity ComponentInfo{
      com.igalia.wolvic.world.visionglass/com.igalia.wolvic.VRBrowserActivity}:
  java.lang.NullPointerException: Attempt to read from field
      'com.google.android.material.button.MaterialButton
       com.igalia.wolvic.databinding.VisionglassLayoutBinding.homeButton'
      on a null object reference
      at com.igalia.wolvic.PlatformActivity$PlatformActivityPluginVisionGlass.<init>
      at com.igalia.wolvic.VRBrowserActivity.onCreate

The early return left VRBrowserActivity.onCreate to continue running: it called initializeWidgets() -> createPlatformPlugin(), whose constructor dereferences the still null mBinding. Even when guarded, further teardown paths fail because PlatformActivity.onCreate registered broadcast receivers, sensors and display listeners only on the happy path while onDestroy/onPause/onResume tear them down unconditionally.

The fix involves several changes:
* Move the MAIN/LAUNCHER intent filter from VRBrowserActivity to FirstRunActivity in the visionglass manifest, so the routing decision happens before VRBrowserActivity is ever instantiated.
* Drop the terms-check + redirect block from PlatformActivity.onCreate. VRBrowserActivity now only ever starts when both flags are already set, so there is no half-initialised state to defend against.
* Short-circuit FirstRunActivity.onCreate when both flags are already accepted: skip setContentView, prefs registration and fragment work, and jump straight to VRBrowserActivity. This keeps the normal launch path lightweight.
* Guard FirstRunActivity.onDestroy so it tolerates the short-circuit path where mPrefs was never assigned.