### PR TITLE
Use Meta's best practices for app entitlement

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1137,6 +1137,10 @@ BrowserWorld::ProcessOVRPlatformEvents() {
           ovrPlatformInitializeResult result = ovr_PlatformInitialize_GetResult(handle);
           if (result == ovrPlatformInitialize_Success) {
             VRB_DEBUG("OVR Platform initialized");
+            // The platform is now fully initialized, so it is safe to run the entitlement
+            // check (Meta's entitlement best practices recommend issuing it from the init
+            // completion callback rather than eagerly right after requesting async init).
+            ovr_Entitlement_GetIsViewerEntitled();
           } else {
             VRB_ERROR("OVR Platform initialization failed: %s", ovrPlatformInitializeResult_ToString(result));
             VRBrowser::HaltActivity(0);

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -170,7 +170,6 @@ android_main(android_app *aAppState) {
           VRBrowser::HaltActivity(0);
       } else {
           VRB_LOG("ovr_PlatformInitializeAndroidAsynchronous succeeded");
-          ovr_Entitlement_GetIsViewerEntitled();
       }
   } else {
       ovr_Entitlement_GetIsViewerEntitled();


### PR DESCRIPTION
As described in the docs[1], the entitlement check should be deferred until the platform finishes initializing. That happens when the success handler from the ovrMessage_PlatformInitializeAndroidAsynchronous is called (in BrowserWorld::ProcessOVRPlatformEvents()).

The current code should still be fine, but let's better stick to the recommendations to avoid future issues.

[1] https://developers.meta.com/horizon/documentation/unity/ps-entitlement-check/#entitlement-check-best-practices