### PR TITLE
Prevent a NullPointerException when seeking

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/MediaControlsWidget.java
@@ -259,6 +259,9 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
     }
 
     private void seekForward() {
+        if (mMedia == null) {
+            return;
+        }
         double t = mMedia.getCurrentTime() + 30;
         if (mMedia.getDuration() > 0) {
             t = Math.min(mMedia.getDuration(), t);
@@ -268,12 +271,19 @@ public class MediaControlsWidget extends UIWidget implements WMediaSession.Deleg
     }
 
     private void seekBackward() {
+        if (mMedia == null) {
+            return;
+        }
         mMedia.seek(Math.max(0, mMedia.getCurrentTime() - 10.0f));
         mBinding.mediaSeekBackwardButton.requestFocusFromTouch();
     }
 
     @Override
     public void handleHoverEvent(MotionEvent aEvent) {
+        if (mMedia == null) {
+            return;
+        }
+
         if (aEvent.getAction() == MotionEvent.ACTION_SCROLL) {
             setVisible(true);
 


### PR DESCRIPTION
Some users experienced crashes in the media controls because handleHoverEvent (triggered by a scroll/hover motion event) calls seekForward()/seekBackward(), which dereferenced mMedia without a null check. The widget can have mMedia set to null (the rest of the class already guards against it), so a hover event arriving when no media is bound could easily trigger the crash.

Fixes #2008