### PR TITLE
Add a "Close duplicates" button to the tabs panel

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -34,6 +34,7 @@ import com.igalia.wolvic.utils.UrlUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -386,6 +387,32 @@ public class SessionStore implements
             return o2.getLastUse() == o1.getLastUse() ? 0 : 1;
         });
         return result;
+    }
+
+    public ArrayList<Session> getDuplicateSessions(boolean aPrivateMode) {
+        ArrayList<Session> duplicates = new ArrayList<>();
+        HashSet<String> uris = new HashSet<>();
+        ArrayList<Session> sessions = getSortedSessions(aPrivateMode);
+
+        for (Session session : sessions) {
+            if (session.isActive() && !session.getCurrentUri().isEmpty()) {
+                uris.add(session.getCurrentUri());
+            }
+        }
+
+        for (Session session : sessions) {
+            String uri = session.getCurrentUri();
+
+            if (session.isActive() || session.isWebExtensionSession() || uri.isEmpty()) {
+                continue;
+            }
+
+            if (!uris.add(uri)) {
+                duplicates.add(session);
+            }
+        }
+
+        return duplicates;
     }
 
     public void setPermissionDelegate(PermissionDelegate delegate) {

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
@@ -40,6 +40,7 @@ public class TabsWidget extends UIDialog {
     protected UITextButton mCloseTabsButton;
     protected UITextButton mBookmarkTabsButton;
     protected UITextButton mCloseTabsAllButton;
+    protected UITextButton mCloseDuplicateTabsButton;
     protected UITextButton mSelectAllButton;
     protected UITextButton mUnselectTabs;
     protected LinearLayout mTabsSelectModeView;
@@ -131,6 +132,16 @@ public class TabsWidget extends UIDialog {
                 mTabDelegate.onTabsClose(mAdapter.mTabs);
             }
             onDismiss();
+        });
+
+        mCloseDuplicateTabsButton = findViewById(R.id.tabsCloseDuplicatesButton);
+        mCloseDuplicateTabsButton.setOnClickListener(v -> {
+            if (mTabDelegate != null) {
+                mTabDelegate.onTabsClose(SessionStore.get().getDuplicateSessions(mPrivateMode));
+            }
+
+            refreshTabs();
+            updateSelectionMode();
         });
 
         mSelectAllButton = findViewById(R.id.tabsSelectAllButton);
@@ -356,12 +367,15 @@ public class TabsWidget extends UIDialog {
             mBookmarkTabsButton.setVisibility(View.VISIBLE);
             mUnselectTabs.setVisibility(View.VISIBLE);
             mCloseTabsAllButton.setVisibility(View.GONE);
+            mCloseDuplicateTabsButton.setVisibility(View.GONE);
             mSelectAllButton.setVisibility(View.GONE);
         } else {
             mCloseTabsButton.setVisibility(View.GONE);
             mBookmarkTabsButton.setVisibility(View.GONE);
             mUnselectTabs.setVisibility(View.GONE);
             mCloseTabsAllButton.setVisibility(View.VISIBLE);
+            mCloseDuplicateTabsButton.setVisibility(View.VISIBLE);
+            mCloseDuplicateTabsButton.setEnabled(!SessionStore.get().getDuplicateSessions(mPrivateMode).isEmpty());
             mSelectAllButton.setVisibility(View.VISIBLE);
         }
 

--- a/app/src/main/res/layout/tabs.xml
+++ b/app/src/main/res/layout/tabs.xml
@@ -93,6 +93,11 @@
             android:text="@string/tabs_bookmark_selected" />
 
         <com.igalia.wolvic.ui.views.UITextButton
+            android:id="@+id/tabsCloseDuplicatesButton"
+            style="@style/tabsButton"
+            android:text="@string/tabs_close_duplicates" />
+
+        <com.igalia.wolvic.ui.views.UITextButton
             android:id="@+id/tabsCloseAllButton"
             style="@style/tabsButton"
             android:text="@string/tabs_close_all" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2114,6 +2114,11 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <string name="tabs_bookmark_selected">Bookmark tabs</string>
 
     <!-- This string is displayed in a button on the header of the tabs dialog.
+     When clicked it closes the tabs that have the same URL as another tab,
+     keeping the most recently used one -->
+    <string name="tabs_close_duplicates">Close duplicates</string>
+
+    <!-- This string is displayed in a button on the header of the tabs dialog.
      When clicked it closes all the available tabs -->
     <string name="tabs_close_all">Close all</string>
 


### PR DESCRIPTION
Adds "Close duplicates" button under "Select".

* The button sits in the selection bar next to "Close all"
* Two tabs are duplicates when they share the same URL
* The most recently used tab of each URL is kept
* Tabs shown in a window, tabs without a URL and WebExtension sessions are never closed

Closes #2001 

Screenshots:
<img width="3840" height="2160" alt="8c46ad367cd16c1025f38a55930098fc" src="https://github.com/user-attachments/assets/8b9e350f-5ab4-465d-a659-c75818fb9f8d" />
<img width="3840" height="2160" alt="7bdd5513cd9b586183bc7b80257fc1bf" src="https://github.com/user-attachments/assets/4272bc3b-8d38-46ec-acdb-704c4ba00ea2" />

