### PR TITLE
Fix rounded corner on the tray private button

### DIFF
--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -185,9 +185,9 @@
                 app:tooltipLayout="@layout/tooltip_tray"
                 android:src="@{viewmodel.isPrivateSession ? @drawable/ic_icon_tray_private_browsing_on_v2 : @drawable/ic_icon_tray_private_browsing_v2}"
                 app:privateMode="@{viewmodel.isPrivateSession}"
-                app:regularModeBackground="@{traymodel.isMaxWindows &amp;&amp; viewmodel.isTabsBarVisible ? @drawable/tray_background_unchecked_start : @drawable/tray_background_unchecked_middle}"
-                app:privateModeBackground="@{traymodel.isMaxWindows &amp;&amp; viewmodel.isTabsBarVisible ? @drawable/tray_background_start_private : @drawable/tray_background_middle_private}"
-                app:activeModeBackground="@{traymodel.isMaxWindows &amp;&amp; viewmodel.isTabsBarVisible ? @drawable/tray_background_checked_start : @drawable/tray_background_checked_middle}"/>
+                app:regularModeBackground="@{traymodel.isMaxWindows &amp;&amp; !traymodel.tabsButtonInTray ? @drawable/tray_background_unchecked_start : @drawable/tray_background_unchecked_middle}"
+                app:privateModeBackground="@{traymodel.isMaxWindows &amp;&amp; !traymodel.tabsButtonInTray ? @drawable/tray_background_start_private : @drawable/tray_background_middle_private}"
+                app:activeModeBackground="@{traymodel.isMaxWindows &amp;&amp; !traymodel.tabsButtonInTray ? @drawable/tray_background_checked_start : @drawable/tray_background_checked_middle}"/>
 
             <com.igalia.wolvic.ui.views.UIButton
                 android:id="@+id/bookmarksButton"


### PR DESCRIPTION
While testing https://github.com/Igalia/wolvic/pull/2010 I noticed that the tray private browsing button gets a rounded bottom left corner when the maximum number of windows is open, even though the tabs button is still first in the row.

The rounded start background was picked based on `isTabsBarVisible`, which is true during normal browsing regardless of the tabs location. The condition is now `tabsButtonInTray`, so the button only becomes rounded when the tabs button is not in the tray.

Screenshot:
<img width="3840" height="2160" alt="d689f11f08d6fd975cd37c6ccf646985" src="https://github.com/user-attachments/assets/6c2ce885-b50e-4736-b920-7ddc7909b9c7" />

