### PR TITLE
Improve OpenTelemetry implementation

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -233,6 +233,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     LinkedList<WebXRListener> mWebXRListeners;
     LinkedList<Runnable> mBackHandlers;
     private final MutableLiveData<Boolean> mIsPresentingImmersive = new MutableLiveData<>(false);
+    private long mImmersiveStartMs; // For telemetry, the time when immersive mode was entered.
     private Thread mUiThread;
     private LinkedList<Pair<Object, Float>> mBrightnessQueue;
     private Pair<Object, Float> mCurrentBrightness;
@@ -1289,7 +1290,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 listener.onEnterWebXR();
             }
         });
-        TelemetryService.startImmersive();
+        mImmersiveStartMs = SystemClock.elapsedRealtime();
 
         PauseCompositorRunnable runnable = new PauseCompositorRunnable();
 
@@ -1312,7 +1313,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             return;
         }
         mIsPresentingImmersive.postValue(false);
-        TelemetryService.stopImmersive();
+        if (mImmersiveStartMs > 0) {
+            TelemetryService.immersiveTime(SystemClock.elapsedRealtime() - mImmersiveStartMs);
+            mImmersiveStartMs = 0;
+        }
 
         if (mLaunchImmersive) {
             Log.d(LOGTAG, "Launched in immersive mode: exiting WebXR will finish the app");

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -15,6 +15,7 @@ import androidx.preference.PreferenceManager;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 import android.view.Surface;
 import android.view.inputmethod.CursorAnchorInfo;
@@ -89,6 +90,10 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
     private transient CopyOnWriteArrayList<DrmStateChangedListener> mDrmStateStateListeners;
 
     private SessionState mState;
+    // Monotonic start time of the in-flight page load, or 0 if none. Used to
+    // report page-load duration telemetry; per-Session so concurrent loads in
+    // different windows are measured independently.
+    private transient long mPageLoadStartMs;
     private transient CopyOnWriteArrayList<Runnable> mQueuedCalls = new CopyOnWriteArrayList<>();
     private transient WSession.PermissionDelegate mPermissionDelegate;
     private transient WSession.PromptDelegate mPromptDelegate;
@@ -1256,7 +1261,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         }
         Log.d(LOGTAG, "Session onPageStart");
         mState.mIsLoading = true;
-        TelemetryService.startPageLoadTime(aUri);
+        mPageLoadStartMs = SystemClock.uptimeMillis();
 
         setWebXRState(SessionState.WEBXR_UNUSED);
         for (WSession.ProgressDelegate listener : mProgressListeners) {
@@ -1271,9 +1276,10 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         }
         Log.d(LOGTAG, "Session onPageStop");
         mState.mIsLoading = false;
-        if (!SessionUtils.isLocalizedContent(mState.mUri)) {
-            TelemetryService.stopPageLoadTimeWithURI(mState.mUri);
+        if (mPageLoadStartMs > 0 && !SessionUtils.isLocalizedContent(mState.mUri)) {
+            TelemetryService.pageLoadTime(SystemClock.uptimeMillis() - mPageLoadStartMs);
         }
+        mPageLoadStartMs = 0;
 
         for (WSession.ProgressDelegate listener : mProgressListeners) {
             listener.onPageStop(aSession, b);

--- a/app/src/common/shared/com/igalia/wolvic/telemetry/ITelemetry.java
+++ b/app/src/common/shared/com/igalia/wolvic/telemetry/ITelemetry.java
@@ -7,4 +7,7 @@ public interface ITelemetry {
     void stop();
     void customEvent(String name);
     void customEvent(String name, Bundle bundle);
+    // Records an event that took a known amount of time, so backends that support it (e.g. spans)
+    // can represent it with a real duration instead of two disconnected instantaneous events.
+    void timedEvent(String name, long durationMillis, Bundle bundle);
 }

--- a/app/src/common/shared/com/igalia/wolvic/telemetry/OpenTelemetry.java
+++ b/app/src/common/shared/com/igalia/wolvic/telemetry/OpenTelemetry.java
@@ -1,7 +1,5 @@
 package com.igalia.wolvic.telemetry;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-
 import android.app.Application;
 import android.os.Bundle;
 
@@ -9,6 +7,7 @@ import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.VRBrowserApplication;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.OpenTelemetryRumBuilder;
@@ -16,6 +15,7 @@ import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfiguration;
 import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation;
 import io.opentelemetry.android.instrumentation.sessions.SessionInstrumentation;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 
@@ -24,7 +24,7 @@ public class OpenTelemetry implements ITelemetry {
     private OpenTelemetryRum mRUM;
     private OpenTelemetryRumBuilder mRUMBuilder;
     private final String INSTRUMENTATION_SCOPE_NAME = BuildConfig.APPLICATION_ID;
-    private final String INSTRUMENTATION_SCOPE_VERSION = "1.0.0";
+    private final String INSTRUMENTATION_SCOPE_VERSION = BuildConfig.VERSION_NAME;
     private final Executor mDiskIOExecutor;
 
     public OpenTelemetry(Application app) {
@@ -67,9 +67,13 @@ public class OpenTelemetry implements ITelemetry {
 
     @Override
     public void customEvent(String name) {
-        assert mRUM != null;
+        // Capture mRUM as stop() may null it on the main thread before the disk-IO runnable runs.
+        final OpenTelemetryRum rum = mRUM;
+        if (rum == null) {
+            return;
+        }
         runOnDiskIO(() -> {
-            mRUM.getOpenTelemetry().getTracer(INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION)
+            rum.getOpenTelemetry().getTracer(INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION)
                     .spanBuilder(name)
                     .startSpan()
                     .end();
@@ -78,14 +82,51 @@ public class OpenTelemetry implements ITelemetry {
 
     @Override
     public void customEvent(String name, Bundle bundle) {
-        assert mRUM != null;
+        final OpenTelemetryRum rum = mRUM;
+        if (rum == null) {
+            return;
+        }
+        runOnDiskIO(() -> newSpanBuilder(rum, name, bundle).startSpan().end());
+    }
+
+    @Override
+    public void timedEvent(String name, long durationMillis, Bundle bundle) {
+        final OpenTelemetryRum rum = mRUM;
+        if (rum == null) {
+            return;
+        }
         runOnDiskIO(() -> {
-            SpanBuilder spanBuilder = mRUM.getOpenTelemetry().getTracer(INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION)
-                    .spanBuilder(name);
-            for (String key : bundle.keySet()) {
-                spanBuilder.setAttribute(key, bundle.get(key).toString());
-            }
-            spanBuilder.startSpan().end();
+            long endMillis = System.currentTimeMillis();
+            long startMillis = endMillis - Math.max(0, durationMillis);
+            Span span = newSpanBuilder(rum, name, bundle)
+                    .setStartTimestamp(startMillis, TimeUnit.MILLISECONDS)
+                    .startSpan();
+            span.end(endMillis, TimeUnit.MILLISECONDS);
         });
+    }
+
+    private SpanBuilder newSpanBuilder(OpenTelemetryRum rum, String name, Bundle bundle) {
+        SpanBuilder spanBuilder = rum.getOpenTelemetry()
+                .getTracer(INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION)
+                .spanBuilder(name);
+        if (bundle != null) {
+            for (String key : bundle.keySet()) {
+                Object value = bundle.get(key);
+                if (value == null) {
+                    continue;
+                }
+                if (value instanceof Boolean) {
+                    spanBuilder.setAttribute(key, (Boolean) value);
+                } else if (value instanceof Integer || value instanceof Long
+                        || value instanceof Short || value instanceof Byte) {
+                    spanBuilder.setAttribute(key, ((Number) value).longValue());
+                } else if (value instanceof Float || value instanceof Double) {
+                    spanBuilder.setAttribute(key, ((Number) value).doubleValue());
+                } else {
+                    spanBuilder.setAttribute(key, value.toString());
+                }
+            }
+        }
+        return spanBuilder;
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/telemetry/TelemetryService.java
+++ b/app/src/common/shared/com/igalia/wolvic/telemetry/TelemetryService.java
@@ -8,7 +8,6 @@ import androidx.annotation.UiThread;
 
 import com.igalia.wolvic.R;
 import com.igalia.wolvic.browser.SettingsStore;
-import com.igalia.wolvic.search.SearchEngineWrapper;
 import com.igalia.wolvic.utils.SystemUtils;
 
 import mozilla.components.concept.sync.FxAEntryPoint;
@@ -61,18 +60,13 @@ public class TelemetryService {
         }
     }
 
-    public static void startPageLoadTime(String aUrl) {
+    // Records how long a page took to load. The caller (Session) owns the start timestamp so that
+    // concurrent loads across windows are measured independently. URLs are **not** recorded for privacy.
+    public static void pageLoadTime(long durationMillis) {
         if (service == null) {
             return;
         }
-        service.customEvent("startPageLoadTime");
-    }
-
-    public static void stopPageLoadTimeWithURI(String uri) {
-        if (service == null) {
-            return;
-        }
-        service.customEvent("stopPageLoadTime");
+        service.timedEvent("pageLoad", durationMillis, null);
     }
 
     public static void windowsResizeEvent() {
@@ -145,18 +139,12 @@ public class TelemetryService {
         service.customEvent("voiceInputEvent");
     }
 
-    public static void startImmersive() {
+    // Records how long an immersive session lasted. The caller (VRBrowserActivity) owns the start timestamp.
+    public static void immersiveTime(long durationMillis) {
         if (service == null) {
             return;
         }
-        service.customEvent("startImmersive");
-    }
-
-    public static void stopImmersive() {
-        if (service == null) {
-            return;
-        }
-        service.customEvent("stopImmersive");
+        service.timedEvent("immersiveSession", durationMillis, null);
     }
 
     public static void openWindowEvent(int windowId) {
@@ -175,10 +163,6 @@ public class TelemetryService {
         Bundle bundle = new Bundle();
         bundle.putInt("windowId", windowId);
         service.customEvent("closeWindowEvent", bundle);
-    }
-
-    private static String getDefaultSearchEngineIdentifierForTelemetry() {
-        return SearchEngineWrapper.get(context).resolveCurrentSearchEngine().getId();
     }
 
     public static void newWindowOpenEvent() {

--- a/app/src/hvr/java/com/igalia/wolvic/telemetry/HVRTelemetry.java
+++ b/app/src/hvr/java/com/igalia/wolvic/telemetry/HVRTelemetry.java
@@ -56,6 +56,16 @@ public class HVRTelemetry implements ITelemetry {
         }
     }
 
+    @Override
+    public void timedEvent(String name, long durationMillis, Bundle bundle) {
+        // HiAnalytics has no notion of a timed span, so report the duration as an attribute on a regular event.
+        if (bundle == null) {
+            bundle = new Bundle();
+        }
+        bundle.putLong("durationMillis", durationMillis);
+        customEvent(name, bundle);
+    }
+
     private Context mContext;
     private HiAnalyticsInstance mService;
 }


### PR DESCRIPTION
Our preliminary OpenTelemetry implementation had several bugs that were not detected previously because the current code runs exclusively on the local machine, i.e, it does not send any kind of information anywhere.

In particular this PR fixes the following issues:
1. Fixes a crash when an event fires after telemetry is toggled off.
2. Properly type the span attributes (they were all strings). Also add null protection.
3. Collect page load duration (no URL just durations).
4. Collect immersive sessions duration.
5. Versioned instrumentation scope based BuildConfig.VERSION_NAME.
6. Removed unused imports.

Note that times won't appear in the local logs (page load, or immersive session length) because the logger does not print them, not because they are not collected. We've verified that they're indeed collected by temporarily switching to the JSON logger (which prints all the info).