### PR TITLE
Modernize OpenTelemetry usage and how telemetry is exported

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,15 @@ def getHVRApiKey = { ->
     return ""
 }
 
+// OpenTelemetry OTLP export target for release builds. Kept in the gitignored
+// user.properties so only the maintainer's release builds point at the server.
+def getOtelEndpoint = { ->
+    if (gradle.hasProperty("userProperties.otelEndpoint")) {
+        return gradle."userProperties.otelEndpoint"
+    }
+    return ""
+}
+
 def getHVRMLSpeechServices = { ->
     if (getHVRApiKey().isEmpty()) {
         return "{ com.igalia.wolvic.speech.SpeechServices.VOSK }"
@@ -99,7 +108,7 @@ def CHROMIUM_RELEASE_VERSION_NAME = '1.4'
 
 android {
     namespace 'com.igalia.wolvic'
-    compileSdkVersion 35
+    compileSdkVersion 36
     defaultConfig {
         applicationId "com.igalia.wolvic"
         minSdkVersion 24
@@ -121,6 +130,7 @@ android {
         buildConfigField 'String', 'ANNOUNCEMENTS_ENDPOINT', '"https://igalia.github.io/wolvic/announcements.json"'
         buildConfigField 'String', 'EXPERIENCES_ENDPOINT', '"https://igalia.github.io/wolvic/experiences.json"'
         buildConfigField 'String', 'HEYVR_ENDPOINT', '"https://api.heyvr.io/v1/public/global/feed/featured?limit=50"'
+        buildConfigField 'String', 'OTEL_ENDPOINT', '""'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         resValue 'string', 'app_name', 'Wolvic'
@@ -170,6 +180,11 @@ android {
             useLegacyPackaging = true
             pickFirsts += ['**/libxul.so']
         }
+        resources {
+            // OTel 1.62 pulls jspecify, which collides with opentelemetry-exporter-common
+            // on this OSGi metadata file (unused on Android).
+            excludes += ['META-INF/versions/9/OSGI-INF/MANIFEST.MF']
+        }
     }
 
     kotlinOptions {
@@ -182,6 +197,7 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig getUseDebugSigningOnRelease() ? debug.signingConfig : release.signingConfig
+            buildConfigField 'String', 'OTEL_ENDPOINT', "\"${getOtelEndpoint()}\""
         }
         debug {
             applicationIdSuffix getDevApplicationIdSuffix()
@@ -745,12 +761,17 @@ dependencies {
     implementation fileTree(dir: "${project.rootDir}/libs/openwnn/", include: ['*.aar'])
 
     // OpenTelemetry
+    implementation platform(libs.opentelemetry.android.bom)
+    implementation platform(libs.opentelemetry.bom)
+    implementation libs.opentelemetry.android.agent.api
     implementation libs.opentelemetry.android.core
+    implementation libs.opentelemetry.android.instrumentation.api
     implementation libs.opentelemetry.android.instrumentation.activity
     implementation libs.opentelemetry.android.instrumentation.anr
     implementation libs.opentelemetry.android.instrumentation.crash
     implementation libs.opentelemetry.android.instrumentation.sessions
     implementation libs.opentelemetry.exporter.logging
+    implementation libs.opentelemetry.exporter.otlp
     coreLibraryDesugaring libs.desugar.jdk.libs
 }
 

--- a/app/src/common/shared/com/igalia/wolvic/telemetry/ITelemetry.java
+++ b/app/src/common/shared/com/igalia/wolvic/telemetry/ITelemetry.java
@@ -10,4 +10,10 @@ public interface ITelemetry {
     // Records an event that took a known amount of time, so backends that support it (e.g. spans)
     // can represent it with a real duration instead of two disconnected instantaneous events.
     void timedEvent(String name, long durationMillis, Bundle bundle);
+    // Increments a counter metric — for aggregate "how many X" questions.
+    // Attributes should be low-cardinality (no ids). bundle may be null.
+    void count(String name, Bundle bundle);
+    // Emits a discrete event (log record) that retains session context, so
+    // per-session journeys/funnels can be reconstructed. bundle may be null.
+    void event(String name, Bundle bundle);
 }

--- a/app/src/common/shared/com/igalia/wolvic/telemetry/OpenTelemetry.java
+++ b/app/src/common/shared/com/igalia/wolvic/telemetry/OpenTelemetry.java
@@ -6,18 +6,37 @@ import android.os.Bundle;
 import com.igalia.wolvic.BuildConfig;
 import com.igalia.wolvic.VRBrowserApplication;
 
+import java.util.Collection;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.OpenTelemetryRumBuilder;
 import io.opentelemetry.android.config.OtelRumConfig;
-import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfiguration;
+import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig;
 import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation;
 import io.opentelemetry.android.instrumentation.sessions.SessionInstrumentation;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.logging.SystemOutLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public class OpenTelemetry implements ITelemetry {
     private final Application mApplication;
@@ -27,21 +46,26 @@ public class OpenTelemetry implements ITelemetry {
     private final String INSTRUMENTATION_SCOPE_VERSION = BuildConfig.VERSION_NAME;
     private final Executor mDiskIOExecutor;
 
+    private static final String OTLP_TRACES_PATH = "/v1/traces";
+    private static final String OTLP_METRICS_PATH = "/v1/metrics";
+    private static final String OTLP_LOGS_PATH = "/v1/logs";
+
     public OpenTelemetry(Application app) {
         mApplication = app;
         mDiskIOExecutor = ((VRBrowserApplication) mApplication).getExecutors().diskIO();
     }
 
     private void initializeOpenTelemetryAndroid() {
-        DiskBufferingConfiguration diskBufferingConfiguration = DiskBufferingConfiguration.builder()
-                .setEnabled(true)
-                .setMaxCacheSize(10 * 1024 * 1024)
-                .setMaxFileAgeForWriteMillis(1000 * 5)
-                .build();
+        // DiskBufferingConfig replaced the builder with static factories in 1.x.
+        // Args: enabled, maxCacheSize (bytes), maxFileAgeForWriteMillis.
+        DiskBufferingConfig diskBufferingConfig = DiskBufferingConfig.create(
+                true, 10 * 1024 * 1024, 1000L * 5);
         OtelRumConfig config = new OtelRumConfig()
-                .setDiskBufferingConfiguration(diskBufferingConfiguration);
-        mRUMBuilder = OpenTelemetryRum.builder(mApplication, config)
-                .addSpanExporterCustomizer(exporter -> LoggingSpanExporter.create())
+                .setDiskBufferingConfig(diskBufferingConfig);
+        mRUMBuilder = new OpenTelemetryRumBuilder(mApplication, config)
+                .addSpanExporterCustomizer(exporter -> createSpanExporter())
+                .addMetricExporterCustomizer(exporter -> createMetricExporter())
+                .addLogRecordExporterCustomizer(exporter -> createLogRecordExporter())
                 .addInstrumentation(new SessionInstrumentation())
                 .addInstrumentation(new ActivityLifecycleInstrumentation());
         try {
@@ -49,6 +73,78 @@ public class OpenTelemetry implements ITelemetry {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private SpanExporter createSpanExporter() {
+        if (BuildConfig.DEBUG) {
+            return LoggingSpanExporter.create();
+        }
+        String url = otlpUrl(OTLP_TRACES_PATH);
+        if (url == null) {
+            return SpanExporter.composite();
+        }
+        OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder().setEndpoint(url);
+        return builder.build();
+    }
+
+    private MetricExporter createMetricExporter() {
+        if (BuildConfig.DEBUG) {
+            return LoggingMetricExporter.create();
+        }
+        String url = otlpUrl(OTLP_METRICS_PATH);
+        if (url == null) {
+            return noopMetricExporter();
+        }
+        OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder().setEndpoint(url);
+        return builder.build();
+    }
+
+    private LogRecordExporter createLogRecordExporter() {
+        if (BuildConfig.DEBUG) {
+            return SystemOutLogRecordExporter.create();
+        }
+        String url = otlpUrl(OTLP_LOGS_PATH);
+        if (url == null) {
+            return LogRecordExporter.composite();
+        }
+        OtlpHttpLogRecordExporterBuilder builder = OtlpHttpLogRecordExporter.builder().setEndpoint(url);
+        return builder.build();
+    }
+
+    private String otlpUrl(String signalPath) {
+        String base = BuildConfig.OTEL_ENDPOINT;
+        if (base == null || base.isEmpty()) {
+            return null;
+        }
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base + signalPath;
+    }
+
+    // No public no-op MetricExporter exists (unlike Span/LogRecordExporter.composite()).
+    private static MetricExporter noopMetricExporter() {
+        return new MetricExporter() {
+            @Override
+            public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+                return AggregationTemporality.CUMULATIVE;
+            }
+
+            @Override
+            public CompletableResultCode export(Collection<MetricData> metrics) {
+                return CompletableResultCode.ofSuccess();
+            }
+
+            @Override
+            public CompletableResultCode flush() {
+                return CompletableResultCode.ofSuccess();
+            }
+
+            @Override
+            public CompletableResultCode shutdown() {
+                return CompletableResultCode.ofSuccess();
+            }
+        };
     }
 
     private void runOnDiskIO(Runnable runnable) { mDiskIOExecutor.execute(runnable); }
@@ -105,28 +201,58 @@ public class OpenTelemetry implements ITelemetry {
         });
     }
 
+    @Override
+    public void count(String name, Bundle bundle) {
+        final OpenTelemetryRum rum = mRUM;
+        if (rum == null) {
+            return;
+        }
+        runOnDiskIO(() -> rum.getOpenTelemetry()
+                .getMeter(INSTRUMENTATION_SCOPE_NAME)
+                .counterBuilder(name)
+                .build()
+                .add(1, toAttributes(bundle)));
+    }
+
+    @Override
+    public void event(String name, Bundle bundle) {
+        final OpenTelemetryRum rum = mRUM;
+        if (rum == null) {
+            return;
+        }
+        // otel-android attaches session.id, so per-session funnels can be reconstructed downstream.
+        runOnDiskIO(() -> rum.emitEvent(name, "", toAttributes(bundle)));
+    }
+
     private SpanBuilder newSpanBuilder(OpenTelemetryRum rum, String name, Bundle bundle) {
-        SpanBuilder spanBuilder = rum.getOpenTelemetry()
+        return rum.getOpenTelemetry()
                 .getTracer(INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION)
-                .spanBuilder(name);
-        if (bundle != null) {
-            for (String key : bundle.keySet()) {
-                Object value = bundle.get(key);
-                if (value == null) {
-                    continue;
-                }
-                if (value instanceof Boolean) {
-                    spanBuilder.setAttribute(key, (Boolean) value);
-                } else if (value instanceof Integer || value instanceof Long
-                        || value instanceof Short || value instanceof Byte) {
-                    spanBuilder.setAttribute(key, ((Number) value).longValue());
-                } else if (value instanceof Float || value instanceof Double) {
-                    spanBuilder.setAttribute(key, ((Number) value).doubleValue());
-                } else {
-                    spanBuilder.setAttribute(key, value.toString());
-                }
+                .spanBuilder(name)
+                .setAllAttributes(toAttributes(bundle));
+    }
+
+    // Converts a Bundle to typed OpenTelemtry attributes (bool/long/double/string) skipping nulls.
+    private Attributes toAttributes(Bundle bundle) {
+        if (bundle == null) {
+            return Attributes.empty();
+        }
+        AttributesBuilder builder = Attributes.builder();
+        for (String key : bundle.keySet()) {
+            Object value = bundle.get(key);
+            if (value == null) {
+                continue;
+            }
+            if (value instanceof Boolean) {
+                builder.put(AttributeKey.booleanKey(key), (Boolean) value);
+            } else if (value instanceof Integer || value instanceof Long
+                    || value instanceof Short || value instanceof Byte) {
+                builder.put(AttributeKey.longKey(key), ((Number) value).longValue());
+            } else if (value instanceof Float || value instanceof Double) {
+                builder.put(AttributeKey.doubleKey(key), ((Number) value).doubleValue());
+            } else {
+                builder.put(AttributeKey.stringKey(key), value.toString());
             }
         }
-        return spanBuilder;
+        return builder.build();
     }
 }

--- a/app/src/common/shared/com/igalia/wolvic/telemetry/TelemetryService.java
+++ b/app/src/common/shared/com/igalia/wolvic/telemetry/TelemetryService.java
@@ -60,6 +60,9 @@ public class TelemetryService {
         }
     }
 
+    // Signal model: durations -> timed spans; discrete counts -> counter metrics;
+    // funnel/journey-shaped actions -> events (which retain session context).
+
     // Records how long a page took to load. The caller (Session) owns the start timestamp so that
     // concurrent loads across windows are measured independently. URLs are **not** recorded for privacy.
     public static void pageLoadTime(long durationMillis) {
@@ -73,14 +76,14 @@ public class TelemetryService {
         if (service == null) {
             return;
         }
-        service.customEvent("windowsResizeEvent");
+        service.count("windows_resize", null);
     }
 
     public static void windowsMoveEvent() {
         if (service == null) {
             return;
         }
-        service.customEvent("windowsMoveEvent");
+        service.count("windows_move", null);
     }
 
     public static void activePlacementEvent(int from, boolean active) {
@@ -90,7 +93,7 @@ public class TelemetryService {
         Bundle bundle = new Bundle();
         bundle.putInt("from", from);
         bundle.putBoolean("active", active);
-        service.customEvent("activePlacementEvent", bundle);
+        service.count("active_placement", bundle);
     }
 
     public static void openWindowsEvent(int from, int to, boolean isPrivate) {
@@ -101,24 +104,25 @@ public class TelemetryService {
         bundle.putInt("from", from);
         bundle.putInt("to", to);
         bundle.putBoolean("isPrivate", isPrivate);
-        service.customEvent("openWindowsEvent", bundle);
+        service.count("windows_open", bundle);
     }
 
     public static void resetOpenedWindowsCount(int number, boolean isPrivate) {
         if (service == null) {
             return;
         }
+        // A snapshot of the current window count -> event (a counter can't carry a value).
         Bundle bundle = new Bundle();
         bundle.putInt("number", number);
         bundle.putBoolean("isPrivate", isPrivate);
-        service.customEvent("resetOpenedWindowsCount", bundle);
+        service.event("windows_reset", bundle);
     }
 
     public static void sessionStop() {
         if (service == null) {
             return;
         }
-        service.customEvent("sessionStop");
+        service.count("session_stop", null);
     }
 
     @UiThread
@@ -128,7 +132,7 @@ public class TelemetryService {
         }
         Bundle bundle = new Bundle();
         bundle.putBoolean("isUrl", aIsUrl);
-        service.customEvent("urlBarEvent", bundle);
+        service.count("urlbar", bundle);
     }
 
     @UiThread
@@ -136,7 +140,7 @@ public class TelemetryService {
         if (service == null) {
             return;
         }
-        service.customEvent("voiceInputEvent");
+        service.count("voice_input", null);
     }
 
     // Records how long an immersive session lasted. The caller (VRBrowserActivity) owns the start timestamp.
@@ -147,29 +151,26 @@ public class TelemetryService {
         service.timedEvent("immersiveSession", durationMillis, null);
     }
 
+    // windowId is intentionally not recorded: it is high-cardinality and would explode a metric's time-series count. We keep only the aggregate count.
     public static void openWindowEvent(int windowId) {
         if (service == null) {
             return;
         }
-        Bundle bundle = new Bundle();
-        bundle.putInt("windowId", windowId);
-        service.customEvent("openWindowEvent", bundle);
+        service.count("window_open", null);
     }
 
     public static void closeWindowEvent(int windowId) {
         if (service == null) {
             return;
         }
-        Bundle bundle = new Bundle();
-        bundle.putInt("windowId", windowId);
-        service.customEvent("closeWindowEvent", bundle);
+        service.count("window_close", null);
     }
 
     public static void newWindowOpenEvent() {
         if (service == null) {
             return;
         }
-        service.customEvent("newWindowOpenEvent");
+        service.count("new_window_open", null);
     }
 
     public static class FxA implements FxAEntryPoint {
@@ -178,7 +179,7 @@ public class TelemetryService {
             if (service == null) {
                 return;
             }
-            service.customEvent("FxA_signIn");
+            service.event("fxa_sign_in", null);
         }
 
         public static void signInResult(boolean status) {
@@ -187,14 +188,14 @@ public class TelemetryService {
             }
             Bundle bundle = new Bundle();
             bundle.putBoolean("status", status);
-            service.customEvent("FxA_signInResult", bundle);
+            service.event("fxa_sign_in_result", bundle);
         }
 
         public static void signOut() {
             if (service == null) {
                 return;
             }
-            service.customEvent("FxA_signOut");
+            service.event("fxa_sign_out", null);
         }
 
         public static void bookmarksSyncStatus(boolean status) {
@@ -203,7 +204,7 @@ public class TelemetryService {
             }
             Bundle bundle = new Bundle();
             bundle.putBoolean("status", status);
-            service.customEvent("FxA_bookmarksSyncStatus");
+            service.count("fxa_bookmarks_sync", bundle);
         }
 
         public static void historySyncStatus(boolean status) {
@@ -212,14 +213,14 @@ public class TelemetryService {
             }
             Bundle bundle = new Bundle();
             bundle.putBoolean("status", status);
-            service.customEvent("FxA_historySyncStatus", bundle);
+            service.count("fxa_history_sync", bundle);
         }
 
         public static void sentTab() {
             if (service == null) {
                 return;
             }
-            service.customEvent("FxA_sentTab");
+            service.count("fxa_sent_tab", null);
         }
 
         public static void receivedTab(@NonNull mozilla.components.concept.sync.DeviceType source) {
@@ -228,7 +229,7 @@ public class TelemetryService {
             }
             Bundle bundle = new Bundle();
             bundle.putInt("source", source.ordinal());
-            service.customEvent("FxA_receivedTab", bundle);
+            service.count("fxa_received_tab", bundle);
         }
 
         @NonNull
@@ -258,14 +259,14 @@ public class TelemetryService {
             }
             Bundle bundle = new Bundle();
             bundle.putInt("source", source.ordinal());
-            service.customEvent("tab_opened", bundle);
+            service.count("tab_opened", bundle);
         }
 
         public static void activatedEvent() {
             if (service == null) {
                 return;
             }
-            service.customEvent("tab_activated");
+            service.count("tab_activated", null);
         }
     }
 }

--- a/app/src/hvr/java/com/igalia/wolvic/telemetry/HVRTelemetry.java
+++ b/app/src/hvr/java/com/igalia/wolvic/telemetry/HVRTelemetry.java
@@ -66,6 +66,17 @@ public class HVRTelemetry implements ITelemetry {
         customEvent(name, bundle);
     }
 
+    @Override
+    public void count(String name, Bundle bundle) {
+        // HiAnalytics has no separate metric/event channels, so both map to onEvent.
+        customEvent(name, bundle != null ? bundle : new Bundle());
+    }
+
+    @Override
+    public void event(String name, Bundle bundle) {
+        customEvent(name, bundle != null ? bundle : new Bundle());
+    }
+
     private Context mContext;
     private HiAnalyticsInstance mService;
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,11 +35,11 @@ huaweiHmsPush = "6.5.0.300"
 jetbrainsPython = "0.0.31"
 jna = "5.13.0"
 junit = "4.13.2"
-kotlin = "2.1.0"
+kotlin = "2.2.21"
 kotlinCoroutines = "1.7.3"
 okhttp = "4.12.0"
-opentelemetryAndroid = "0.9.1-alpha"
-opentelemetryApi = "1.46.0"
+opentelemetryAndroid = "1.4.0-alpha"
+opentelemetryApi = "1.62.0"
 openxrLoader = "1.1.48"
 openxrLoader10 = "1.0.34"
 robolectric = "4.11.1"
@@ -129,13 +129,18 @@ lifecycle-java8 = { module = "androidx.lifecycle:lifecycle-common-java8", versio
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
 # OKHttp
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-# OpenTelemetry
-opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging", version.ref = "opentelemetryApi" }
-opentelemetry-android-core = { module = "io.opentelemetry.android:core", version.ref = "opentelemetryAndroid" }
-opentelemetry-android-instrumentation-activity = { module = "io.opentelemetry.android:instrumentation-activity", version.ref = "opentelemetryAndroid" }
-opentelemetry-android-instrumentation-anr = { module = "io.opentelemetry.android:instrumentation-anr", version.ref = "opentelemetryAndroid" }
-opentelemetry-android-instrumentation-crash = { module = "io.opentelemetry.android:instrumentation-crash", version.ref = "opentelemetryAndroid" }
-opentelemetry-android-instrumentation-sessions = { module = "io.opentelemetry.android:instrumentation-sessions", version.ref = "opentelemetryAndroid" }
+# OpenTelemetry (artifact versions come from the two BOMs)
+opentelemetry-android-bom = { module = "io.opentelemetry.android:opentelemetry-android-bom", version.ref = "opentelemetryAndroid" }
+opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetryApi" }
+opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp" }
+opentelemetry-android-agent-api = { module = "io.opentelemetry.android:agent-api" }
+opentelemetry-android-core = { module = "io.opentelemetry.android:core" }
+opentelemetry-android-instrumentation-api = { module = "io.opentelemetry.android.instrumentation:android-instrumentation" }
+opentelemetry-android-instrumentation-activity = { module = "io.opentelemetry.android.instrumentation:activity" }
+opentelemetry-android-instrumentation-anr = { module = "io.opentelemetry.android.instrumentation:anr" }
+opentelemetry-android-instrumentation-crash = { module = "io.opentelemetry.android.instrumentation:crash" }
+opentelemetry-android-instrumentation-sessions = { module = "io.opentelemetry.android.instrumentation:sessions" }
 # OpenXR
 openxrloader = { module = "org.khronos.openxr:openxr_loader_for_android", version.ref = "openxrLoader" }
 openxrloader10 = { module = "org.khronos.openxr:openxr_loader_for_android", version.ref = "openxrLoader10" }


### PR DESCRIPTION
Upgrade OpenTelemetry to the current v1.4 release. This pulls in newer transitive requirements, so it also bumps the compile SDK and Kotlin versions and adjusts a couple of dependency and packaging details to match.

We're also routing telemetry differently depending on the build, debug builds log to logcat as before, while release builds send data to an OTLP collector. The collector address is supplied at build time and kept out of the repository, so only purpose-built release packages report anywhere and everything else stays local or silent. We would need to provide some UI so users could have the chance to opt-out, but that can be done in a follow up before this is released.

Model each kind of telemetry as what it actually is instead of forcing everything into one shape: timings are recorded as durations, simple "how many" occurrences as counters, and the sign-in flow and window-count snapshots as events that keep enough context to follow a session. Before this upgrade everything was modeled as a span. It's worth noticing that high-cardinality identifiers (like window ids) are left out of the aggregate counts.