### PR TITLE
Fix TrayWidget listener leaks on detach and release

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TrayWidget.java
@@ -541,6 +541,8 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
         mWidgetManager.removeUpdateListener(this);
         mWidgetManager.getServicesProvider().getDownloadsManager().removeListener(this);
         mWidgetManager.getServicesProvider().getConnectivityReceiver().removeListener(this);
+        PreferenceManager.getDefaultSharedPreferences(getContext()).unregisterOnSharedPreferenceChangeListener(this);
+        SessionStore.get().getBookmarkStore().removeListener(mBookmarksListener);
         mTrayListeners.clear();
 
         if (mTrayViewModel != null) {
@@ -581,7 +583,7 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
             mSession = null;
         }
         if (mAttachedWindow != null) {
-            SessionStore.get().getBookmarkStore().addListener(mBookmarksListener);
+            SessionStore.get().getBookmarkStore().removeListener(mBookmarksListener);
         }
         mWidgetPlacement.parentHandle = -1;
 


### PR DESCRIPTION
Fixes #2018

## What

`TrayWidget` registered three listeners that were never unregistered, retaining `VRBrowserActivity` for the lifetime of the process.

## Why

**1. `detachFromWindow()` called `addListener` where it meant `removeListener`** (`TrayWidget.java:583-585`)

```java
if (mAttachedWindow != null) {
    SessionStore.get().getBookmarkStore().addListener(mBookmarksListener);
}
```

The intent is clear from context: the two statements immediately below correctly call `removeObserver`, and `attachToWindow()` holds the matching `addListener` at `:617`.

**To pre-empt the obvious question - this is not a duplicate-callback bug.**`BookmarksStore.addListener` de-duplicates (`BookmarksStore.kt:94-97`), and `mBookmarksListener` is a single instance field, so duplicates never accumulate. The actual effect is that the listener is *never removed*, which means:

- `BookmarksStore` (long-lived, via `SessionStore.get()`) keeps a strong reference to `mBookmarksListener` → the anonymous inner class at `:786` → `TrayWidget.this` → `VRBrowserActivity`.
- `onBookmarkAdded()` (`:793-795`) keeps firing `showBookmarkAddedNotification()` while the tray is detached from any window.

**2. `releaseWidget()` omitted two listeners** (`TrayWidget.java:539-552`)

It already releases the update (`:541`), downloads (`:542`), connectivity (`:543`) and tray (`:544`) listeners plus the ViewModel observer (`:547`) - but not the `SharedPreferences` listener registered in the constructor at `:149`, and not the bookmark listener (`releaseWidget()` does not call `detachFromWindow()`, so fix 1 alone does not cover this path).

The register/unregister pairing used elsewhere in the codebase confirms this is the intended convention rather than a style preference: `NavigationBarWidget.java:227` → `:523`, `TopBarWidget.java:189` → `:165`, `Windows.java:250` → `:612`.

## Behaviour before and after

| Step | Before | After |
|---|---|---|
| `attachToWindow(W1)` | 1 listener registered | unchanged |
| `attachToWindow(W2)` | detach adds (no-op), attach adds (no-op) → listener still bound to the **old** window | detach **removes**, attach adds → correctly rebound |
| `releaseWidget()` | bookmark + preference listeners both leak | both released |

## Notes for review

- `removeListener` delegates to `listeners.remove()` (`BookmarksStore.kt:100-102`), which is safe when the listener is not present, so the added call in `releaseWidget()` cannot throw.
- **Open question, deliberately left out of this PR:** `mAttachedWindow` is assigned at `:604` and  never set to `null`, so the `:583` guard is permanently true after the first attach. Nulling it in `detachFromWindow()` seems correct, but`mSettingsWidget.attachToWindow(mAttachedWindow)` at `:666` and `:680` would then need null handling. Happy to address it here or in a follow-up - whichever you prefer.

## Testing

- [X] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [X ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`
- [X] Heap dump confirms `VRBrowserActivity` is no longer retained by `BookmarksStore` after
      repeated window attach/detach cycles
- [X] Bookmark-added notification still appears normally while the tray is attached
