### PR TITLE
build: Remove stale -std=c++14 flag from cppFlags

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ android {
         resValue 'string', 'HOMEPAGE_URL', "https://wolvic.com/start"
         externalNativeBuild {
             cmake {
-                cppFlags "-std=c++14 -fexceptions -frtti -Werror" +
+                cppFlags "-fexceptions -frtti -Werror" +
                          " -I" + file("src/main/cpp").absolutePath +
                          " -I" + file("src/main/cpp/vrb/include").absolutePath +
                          // CMake 3.10+ needs "-DANDROID" flag, since ANDROID


### PR DESCRIPTION
Fixes #2022 
## What

Remove the `-std=c++14` flag from Gradle `cppFlags` in `app/build.gradle`.

## Why

`app/CMakeLists.txt:8` sets `CMAKE_CXX_STANDARD` to 17. Gradle `cppFlags` are injected into `CMAKE_CXX_FLAGS`, so both `-std=c++14` and CMake's generated `-std=c++17` (or `-std=gnu++17`) end up on the same compiler command line. Which one wins depends on flag ordering, which varies across AGP and CMake versions.

C++17 is provably the effective standard - `std::optional` (a C++17 feature that does not exist in C++14) is used in at least 11 places:

| File | Usage |
|---|---|
| `OpenXRInputSource.h:41-44` | `std::optional<OpenXRButtonState>`, `<XrVector2f>`, `<uint8_t>` |
| `OpenXRInputSource.cpp:250,282,388` | Return types of `GetButtonState`, `GetAxis`, `GetImmersiveButton` |
| `OpenXRInputMappings.h:108` | `std::optional<ControllerDelegate::Button>` |
| `DeviceDelegateOpenXR.cpp:110` | `std::optional<XrPosef>` |
| `BrowserWorld.cpp:215,223,224` | `std::optional<vrb::Vector>`, `std::optional<vrb::Quaternion>` ×2 |

The tree would fail to compile if `-std=c++14` ever took effect. Removing it eliminates the ambiguity and lets `CMAKE_CXX_STANDARD 17` be the single source of truth.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`
