### PR TITLE
chromium: DisplayImpl: Fail capturePixels explicitly instead of hanging

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/DisplayImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/DisplayImpl.java
@@ -55,7 +55,11 @@ public class DisplayImpl implements WDisplay {
     @NonNull
     @Override
     public WResult<Bitmap> capturePixelsWithAspectPreservingSize(int width) {
-        // TODO: Implement
-        return new ResultImpl<>();
+        // TODO: Implement actual pixel capture against the Chromium compositor.
+        ResultImpl<Bitmap> result = new ResultImpl<>();
+        result.completeExceptionally(
+                new UnsupportedOperationException(
+                        "Chromium capturePixelsWithAspectPreservingSize is not yet implemented"));
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #2024 

## What

`capturePixelsWithAspectPreservingSize()` now returns a `WResult` that immediately completes with `UnsupportedOperationException` instead of returning an empty `ResultImpl` that never completes.

`capturePixels()` delegates to `capturePixelsWithAspectPreservingSize(mWidth)`, so it is also covered.

## Why

The previous stub returned `new ResultImpl<>()`. `ResultImpl`'s constructor only sets the dispatcher — it never calls `complete()` or `completeExceptionally()`, so `mComplete` stays `false` forever.

Callers at `Session.java:648` and `:693` chain `.then(...).exceptionally(...)` on the returned result. Because the result never completes:

- The `.then()` callback (which stores the bitmap in `BitmapCache` and notifies `BitmapChangedListeners`) never fires — thumbnails are silently missing.
- The `.exceptionally()` callback (which logs the error) never fires — the failure is invisible.
- In `captureBackgroundBitmap()` (:684-690), the `cleanResources` runnable that releases the capture `Surface` and `WDisplay` also never executes.

With the explicit exception, callers' existing error-handling paths activate correctly. `captureBackgroundBitmap()` already has a `BuildConfig.FLAVOR_backend == "chromium"` guard at `:672` that prevents the resource leak in practice, but this fix addresses the root cause so that guard can be removed when real capture is implemented.

The `TODO` comment is preserved to signal that real Chromium compositor capture is a follow-up task.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64ChromiumGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64ChromiumGenericDebugUnitTest`
