### PR TITLE
Normalize version names

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,8 +103,8 @@ def isWebKitAvailable = {
 }
 
 // Version names for Gecko and Chromium releases.
-def GECKO_RELEASE_VERSION_NAME = '2.0'
-def CHROMIUM_RELEASE_VERSION_NAME = '1.4'
+def GECKO_VERSION_NAME = '2.0'
+def CHROMIUM_VERSION_NAME = '1.4'
 
 android {
     namespace 'com.igalia.wolvic'
@@ -114,7 +114,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 34
         versionCode generatedVersionCode
-        versionName "1.9"
+        versionName GECKO_VERSION_NAME
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
         buildConfigField "Boolean", "DISABLE_CRASH_RESTART", getCrashRestartDisabled()
         buildConfigField "String", "AMO_COLLECTION", "\"fxr\""
@@ -233,12 +233,8 @@ android {
         // Use different version names for release builds for each backend.
         def backend = variant.productFlavors.get(2).name
         variant.outputs.each { output ->
-            if (variant.buildType.name == "release") {
-                if (backend == "gecko") {
-                    output.versionNameOverride = GECKO_RELEASE_VERSION_NAME
-                } else if (backend == "chromium") {
-                    output.versionNameOverride = CHROMIUM_RELEASE_VERSION_NAME
-                }
+            if (backend == "chromium") {
+                output.versionNameOverride = CHROMIUM_VERSION_NAME
             }
             if (shouldUseStaticVersionCode()) {
                 // Overrides any build created with a generated version code from now to 2115


### PR DESCRIPTION
At some point we added variables to the build.gradle file to handle the version numbers for Gecko and Chromium backends. However those were only used for release builds. That is superconfusing for developer builds because that means that the dev build will have a different (and sometimes smaller) version number than the current released package.

That cannot happen because we do a version bump after branching for release. From now on we use the same version for release and debug packages. Main branch will get a version bump after branching for release, that way dev builds will always be ahead of release branches.