### PR TITLE
[Chromium] Enable HTML-in-Canvas support

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -197,6 +197,9 @@ public class RuntimeImpl implements WRuntime {
         // Enable WebXR Hand Input, which is disabled by default in blink (experimental)
         CommandLine.getInstance().appendSwitchWithValue("enable-features", "WebXRHandInput");
 
+        // Enable HTML-in-Canvas, chrome://flags/#canvas-draw-element (experimental).
+        CommandLine.getInstance().appendSwitchWithValue("enable-blink-features", "CanvasDrawElement");
+
         setupWebGLMSAA();
         DeviceUtils.addDeviceSpecificUserAgentSwitch();
         LibraryLoader.getInstance().ensureInitialized();


### PR DESCRIPTION
HTML in Canvas is a new experimental spec that allows authors to use fully styled and accessible HTML inside canvas natively. Support has been added to Chromium +147.

Fixes #2012