### PR TITLE
Remove QUERY_ALL_PACKAGES in Meta releases

### DIFF
--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" tools:node="remove"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:node="remove" />
 
     <!-- Not needed in Android 10 (API >= 29) -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>


### PR DESCRIPTION
QUERY_ALL_PACKAGES is contributed by
org.mozilla.components:support-utils:153.0 — a mozilla android-components dependency which declares it (with its own tools:ignore). This was caused by the recent bump of Gecko to 153 ESR release.

We can selectively disable it for the Meta release packages.