### PR TITLE
Fix stale EGL surface handle and honour OpenXR hand flags

### DIFF
--- a/app/src/main/cpp/BrowserEGLContext.cpp
+++ b/app/src/main/cpp/BrowserEGLContext.cpp
@@ -139,6 +139,7 @@ BrowserEGLContext::Initialize(ANativeWindow *aNativeWindow) {
   if (eglMakeCurrent(mDisplay, mSurface, mSurface, mContext) == EGL_FALSE) {
     VRB_ERROR("eglMakeCurrent() failed: %s", ErrorToString(eglGetError()));
     eglDestroySurface(mDisplay, mSurface);
+    mSurface = EGL_NO_SURFACE;
     eglDestroyContext(mDisplay, mContext);
     mContext = EGL_NO_CONTEXT;
     return false;

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -157,7 +157,7 @@ namespace crow {
             { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
         },
         std::vector<OpenXRHaptic> {
-            { kPathHaptic, OpenXRHandFlags::Right },
+            { kPathHaptic, OpenXRHandFlags::Both },
         },
     };
 

--- a/app/src/openxr/cpp/OpenXRInputSource.cpp
+++ b/app/src/openxr/cpp/OpenXRInputSource.cpp
@@ -460,6 +460,10 @@ XrResult OpenXRInputSource::SuggestBindings(SuggestedBindings& bindings) const
 
         // Suggest binding for axis actions.
         for (auto& axis: mapping.axes) {
+            if ((axis.hand & mHandeness) == 0) {
+                continue;
+            }
+
             auto it = mAxisActions.find(axis.type);
             if (it == mAxisActions.end()) {
                 continue;
@@ -470,6 +474,10 @@ XrResult OpenXRInputSource::SuggestBindings(SuggestedBindings& bindings) const
         }
 
         for (auto& haptic: mapping.haptics) {
+            if ((haptic.hand & mHandeness) == 0) {
+                continue;
+            }
+
             RETURN_IF_XR_FAILED(CreateBinding(mapping.path, mHapticAction,
                                               mSubactionPathName + "/" + haptic.path, bindings));
         }


### PR DESCRIPTION
Fixes #2032 
Fixes #2033 

Two small correctness fixes, one commit each.

## Commit 1 - BrowserEGLContext: Reset surface handle on initialization failure

The `eglMakeCurrent()` failure path in `BrowserEGLContext::Initialize()` (`BrowserEGLContext.cpp:139-145`) destroys the surface and the context but only resets `mContext`. The `eglCreateWindowSurface` failure block immediately above (`:132-137`) resets its handle after destroying it, and `Destroy()` (`:150-175`) resets every handle after each destroy - this was the only destroy in the file without a matching reset.

With the stale handle:

- `IsSurfaceReady()` (`:187-190`) reports the destroyed surface as ready, because `mSurface != EGL_NO_SURFACE` still holds and `mNativeWindow` was already assigned at `:99` before the failure point.
- The HVR render loop (`app/src/hvr/cpp/native-lib.cpp:83`) gates `BrowserWorld::Instance().Draw()` on that check, so after a failed init it keeps drawing into a destroyed surface every frame instead of taking the throttled idle branch. Both call sites of `Initialize()` ignore its return value, so the `IsSurfaceReady()` gate is the only defense.
- `Destroy()` (`:163-168`) calls `eglDestroySurface()` a second time on the same handle, producing a spurious `EGL_BAD_SURFACE` at shutdown.

## Commit 2 - openxr: Honour hand flags in axis and haptic bindings

`SuggestBindings()` honours the per-hand flag in the button loop (`OpenXRInputSource.cpp:433-436`) but ignored it in the axis loop (`:462`) and haptic loop (`:472`), while every runtime consumer honours it: axis state reading (`:1012-1015`), haptic counting (`:1082-1085`), and action creation (`:99`, `:114`).

This inconsistency hid a real data error: the OculusTouch (Quest 1) haptic entry (`OpenXRInputMappings.h:160`) was `Right` - the only non-`Both` haptic entry of the 15 in the file. Because haptic counting honours the flag, the Quest 1 left controller reports `numHaptics = 0`, which flows through `ExternalVR` into the WebXR gamepad state as an empty `hapticActuators` array - so web content can never rumble the left controller. Both Quest 1 Touch controllers have haptic motors, and the sibling entries (`oculus-touch-v3`, Quest Touch Pro, Touch Plus) are all `Both`.

The commit corrects that entry to `Both` and adds the button-loop hand check to the axis and haptic loops. After the data fix every axis and haptic entry is `Both`, so the suggested bindings are unchanged - the only behavioural change is that the Quest 1 left controller exposes its haptic actuator again.

Runtime confirmation of the haptic fix needs Quest 1 hardware; the analysis is from source reading.

## Related observations (out of scope)

Kept out of this PR to keep it reviewable; happy to file separately if useful:

- `BrowserEGLContext.cpp:103-105` - `EGLint format;` is passed to `ANativeWindow_setBuffersGeometry()` without checking the `eglGetConfigAttrib()` result, so an indeterminate value can be used if the query fails.
- `BrowserEGLContext.cpp:177-185` - the HVR path of `UpdateNativeWindow()` overwrites `mSurface` with a new `eglCreateWindowSurface()` result without destroying the previous surface.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`