### PR TITLE
Modify the Lynx package name to allow sideloading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -284,6 +284,7 @@ android {
 
         lynx {
             dimension "platform"
+            applicationIdSuffix ".vanilla"
             externalNativeBuild {
                 cmake {
                     cppFlags " -DLYNX -DOPENXR -I" + file("src/openxr/cpp").absolutePath


### PR DESCRIPTION
Wolvic is a system package in Lynx (as it's the default browser). This prevents users from installing our own distributed packages as the names clash. Use a different one for releases.

From now on packages for Lynx will use "com.igalia.wolvic.vanilla" as package name allowing users to sideload it.

Fixes #2035 #1652.