### PR TITLE
VRBrowser: Delete jstring local refs in string getters

### DIFF
--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -362,6 +362,7 @@ VRBrowser::GetStorageAbsolutePath(const std::string& aRelativePath) {
   const char *cstr = sEnv->GetStringUTFChars(jStr, nullptr);
   std::string str = std::string(cstr);
   sEnv->ReleaseStringUTFChars(jStr, cstr);
+  sEnv->DeleteLocalRef(jStr);
 
   if (aRelativePath.empty()) {
     return str;
@@ -405,6 +406,7 @@ VRBrowser::GetActiveEnvironment() {
   const char *cstr = sEnv->GetStringUTFChars(jStr, nullptr);
   std::string str = std::string(cstr);
   sEnv->ReleaseStringUTFChars(jStr, cstr);
+  sEnv->DeleteLocalRef(jStr);
 
   return str;
 }


### PR DESCRIPTION
Fixes #2041 

## What

Adds `sEnv->DeleteLocalRef(jStr);` after `ReleaseStringUTFChars()` in `GetStorageAbsolutePath()` and `GetActiveEnvironment()` - the two `jstring` local references in `VRBrowser.cpp` that were never deleted.

## Why

The file has exactly four local-reference sites. `OnAppLink()` (`:445-447`) and `AppendAppNotesToCrashLog()` (`:461-463`) delete their local reference immediately after use; these two getters (`:356`, `:399`) did not.

`sEnv` is the render thread's `JNIEnv` (`InitializeJava()`, `:128-136`) and the render thread stays attached for the app's lifetime, so JNI local references there are reclaimed only by an explicit `DeleteLocalRef` or at thread detach. Each call permanently occupied a slot in the thread's local reference table. Both getters are on the environment/skybox load path (`BrowserWorld.cpp:1366`, `:1369`), so slots leaked on every environment load or change.

## Related observation (out of scope)

`OpenXRSwapChain::InitAndroidSurface()` (`OpenXRSwapChain.cpp:48-51`) overwrites the `surface` reference returned by `xrCreateSwapchainAndroidSurfaceKHR()` with a `NewGlobalRef` of it, without deleting the original - if the runtime returns a local reference there (as the KHR Android-surface extension implies), that local leaks once per swapchain creation. Happy to file separately if it looks worth tracking.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`