### PR TITLE
bookmarks: Remove broken position plumbing and dead getItemId

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/Bookmark.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/Bookmark.java
@@ -21,7 +21,6 @@ public class Bookmark {
     private @NonNull String mTitle;
     private @NonNull String mURL;
     private @NonNull String mGuid;
-    private int mPosition;
     private Type mType;
     private boolean mHasChildren;
 
@@ -32,9 +31,6 @@ public class Bookmark {
         mTitle = node.getTitle() != null ? node.getTitle() : "";
         mURL = node.getUrl() != null ? node.getUrl() : "";
         mGuid = node.getGuid() != null ? node.getGuid() : "";
-        // TODO: We shall get the position using `node.getPosition();` instead of 0.
-        // However, position is now kotlin.UInt which is not supported by Java.
-        mPosition = 0;
         mHasChildren = node.getChildren() != null;
 
         switch (node.getType()) {
@@ -76,11 +72,6 @@ public class Bookmark {
 
     public void setLevel(int level) {
         mLevel = level;
-    }
-
-    // TODO: This method is broken because upstream now uses kotlin.UInt for mPosition.
-    public int getPosition() {
-        return mPosition;
     }
 
     public boolean hasChildren() {

--- a/app/src/common/shared/com/igalia/wolvic/ui/adapters/BookmarkAdapter.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/adapters/BookmarkAdapter.java
@@ -321,13 +321,6 @@ public class BookmarkAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         return mDisplayList == null ? 0 : mDisplayList.size();
     }
 
-    @Override
-    // TODO: This method is broken because `bookmark.getPosition()` is broken.
-    public long getItemId(int position) {
-        Bookmark bookmark = mDisplayList.get(position);
-        return  bookmark.getPosition();
-    }
-
     static class BookmarkViewHolder extends RecyclerView.ViewHolder {
 
         final BookmarkItemBinding binding;


### PR DESCRIPTION
Fixes #2043 

## What

Removes `Bookmark.mPosition` (hardcoded to 0), `Bookmark.getPosition()`, and the `BookmarkAdapter.getItemId()` override — 16 deletions, no additions — resolving the three linked TODOs at `Bookmark.java:35-37`, `Bookmark.java:81` and `BookmarkAdapter.java:325`.

## Why

`getPosition()` always returns the hardcoded 0 (the TODO notes upstream moved to `kotlin.UInt`, which Java cannot consume directly), and its only caller is `getItemId()`, which never runs: the adapter sets `setHasStableIds(false)` (`BookmarkAdapter.java:61`), so RecyclerView never consults it.

Restoring the position via a Kotlin interop shim — what the TODOs contemplate — would not actually fix `getItemId()`: the display list flattens several folders into one list, so position-in-parent repeats across folders (duplicate ids) and changes when items move, while stable ids must identify the item itself. The adapter already has the right identity mechanism — its `DiffUtil` callback compares GUIDs in `areItemsTheSame()` (`:107-110`) — which is what drives list updates today.

No behavior change: `hasStableIds` is `false` before and after, so the removed override was unreachable, and the removed field had no other consumer (verified by search over `app/src`).

If stable ids are ever wanted for the bookmarks list, `getItemId()` should be derived from the GUID, matching the DiffUtil callback.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`