### PR TITLE
Do not compare flavor strings with ==

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/SettingsStore.java
@@ -161,7 +161,7 @@ public class SettingsStore {
     public final static int POINTER_COLOR_DEFAULT_DEFAULT = Color.parseColor("#FFFFFF");
     public final static String ENV_DEFAULT = "cyberpunk";
     public final static int MSAA_DEFAULT_LEVEL = 1;
-    public final static boolean AUDIO_ENABLED = BuildConfig.FLAVOR_backend == "chromium";
+    public final static boolean AUDIO_ENABLED = BuildConfig.FLAVOR_backend.equals("chromium");
     public final static boolean LATIN_AUTO_COMPLETE_ENABLED = false;
     public final static boolean WINDOW_MOVEMENT_DEFAULT = false;
     public final static @TabsLocation int TABS_LOCATION_DEFAULT = TABS_LOCATION_TRAY;

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/Session.java
@@ -669,7 +669,7 @@ public class Session implements WContentBlocking.Delegate, WSession.NavigationDe
         // FIXME: calling acquireDisplay() is not well supported in the Chromium backend because
         // that method incorrectly does some extra work handling widgets. Disable the bitmap
         // capture in the meantime (it was not working anyway yet).
-        if (mState.mSession == null || !mFirstContentfulPaint || BuildConfig.FLAVOR_backend == "chromium") {
+        if (mState.mSession == null || !mFirstContentfulPaint || BuildConfig.FLAVOR_backend.equals("chromium")) {
             return CompletableFuture.completedFuture(null);
         }
         Surface captureSurface = BitmapCache.getInstance(mContext).acquireCaptureSurface(displayWidth, displayHeight);


### PR DESCRIPTION
Fixes #2049 

## What

Follow-up to 9100032 ("Do not compare strings with =="), which fixed `BuildConfig.FLAVOR_abi == "x64"` in the Chromium `RuntimeImpl`. This changes the two remaining comparisons of the same shape, both in shared code:

- `SettingsStore.java:164` - `AUDIO_ENABLED`
- `Session.java:672` - the background-capture guard in `captureBackgroundBitmap()`

Style matches the earlier fix (`BuildConfig.FLAVOR_backend.equals("chromium")`). A grep over `app/src/**/*.java` confirms these were the last two.

## Why

Being precise about severity: **both evaluate correctly today.** `BuildConfig.FLAVOR_backend` is generated as a `public static final String` with a literal initializer, so it is a compile-time constant that javac inlines, and the comparison ends up between two interned literals. So this is a robustness and readability change, not a bug fix.

It is still worth making for the same reasons as 9100032: the code reads as a value comparison while it is a reference comparison, and it silently relies on the field staying an inlined constant. If either side ever stopped being one, both checks would quietly become `false` - flipping the audio default (`SettingsStore.java:715`, `ControllerOptionsView.java:99`) and disabling the Chromium background-capture guard - with no compiler warning.

No behavior change in any current build variant.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`