### PR TITLE
Fix 360 and 180 stereo VR videos rendering mono

### DIFF
--- a/app/src/main/cpp/VRVideo.cpp
+++ b/app/src/main/cpp/VRVideo.cpp
@@ -267,6 +267,8 @@ struct VRVideo::State {
     rightTransform.ScaleInPlace(vrb::Vector(1.0f, 0.5f, 1.0f));
     equirect->SetUVTransform(device::Eye::Right, rightTransform);
 
+    equirect->SetUseSameLayerForBothEyes(false);
+
     leftEye = vrb::Toggle::Create(create);
     leftEye->AddNode(VRLayerNode::Create(create, equirect));
     rightEye = vrb::Toggle::Create(create);
@@ -345,6 +347,8 @@ struct VRVideo::State {
     equirect->SetUVTransform(device::Eye::Left, uvTransform);
     uvTransform.TranslateInPlace(vrb::Vector(0.0f, 0.5f, 0.0f));
     equirect->SetUVTransform(device::Eye::Right, uvTransform);
+
+    equirect->SetUseSameLayerForBothEyes(false);
 
     leftEye = create180LayerToggle(equirect);
     rightEye = create180LayerToggle(equirect);


### PR DESCRIPTION
Split out of #2038 so the three changes can be reviewed individually, as suggested there.

`VRLayer` defaults `useSameLayerForBothEyes` to true. While it is set,
`OpenXRLayerBase::GetNumXRLayers()` returns 1, so a single equirect layer is
submitted with `XR_EYE_VISIBILITY_BOTH` and only the left eye's UV transform is
applied. Both eyes then receive the same half of the frame and stereo video
plays back mono.

`create180LRProjectionLayer` already cleared the flag.
`create360StereoProjectionLayer` and `create180TBProjectionLayer` did not.

This is not limited to manually selected projections. The bundled `fxr_youtube`
and `fxr_vimeo` extensions tag stereo 360 videos with
`mozVideoProjection=360s_auto`, which resolves to `VIDEO_PROJECTION_360_STEREO`
— the over/under path. On the Gecko backend, every YouTube and Vimeo 360 3D
video therefore takes this path with no user action at all.

### How to test

Generate an over/under clip whose two eyes differ:

ffmpeg -f lavfi -i color=c=red:s=2048x1024:d=10 \
       -f lavfi -i color=c=blue:s=2048x1024:d=10 \
       -filter_complex vstack -pix_fmt yuv420p 360tb.mp4

Open it, enter fullscreen and pick **360 Stereo** from the projection menu.

- before: both eyes show red
- after: left eye red, right eye blue

Tested on a Pico Neo 3.

---