### PR TITLE
Center 180 degree VR video hemispheres in front of the viewer

### DIFF
--- a/app/src/main/cpp/VRVideo.cpp
+++ b/app/src/main/cpp/VRVideo.cpp
@@ -292,6 +292,7 @@ struct VRVideo::State {
 
     vrb::Matrix uvTransform = vrb::Matrix::Identity();
     uvTransform.ScaleInPlace(vrb::Vector(2.0f, 1.0f, 1.0f));
+    uvTransform.TranslateInPlace(vrb::Vector(-0.5f, 0.0f, 0.0f));
 
     equirect->SetUVTransform(device::Eye::Left, uvTransform);
     equirect->SetUVTransform(device::Eye::Right, uvTransform);
@@ -342,6 +343,7 @@ struct VRVideo::State {
 
     vrb::Matrix uvTransform = vrb::Matrix::Identity();
     uvTransform.ScaleInPlace(vrb::Vector(2.0f, 0.5f, 1.0f));
+    uvTransform.TranslateInPlace(vrb::Vector(-0.5f, 0.0f, 0.0f));
     equirect->SetUVTransform(device::Eye::Left, uvTransform);
     uvTransform.TranslateInPlace(vrb::Vector(0.0f, 0.5f, 0.0f));
     equirect->SetUVTransform(device::Eye::Right, uvTransform);


### PR DESCRIPTION
Split out of #2038 so the three changes can be reviewed individually, as suggested there.

The 180 degree paths use a horizontal UV scale of 2 so the texture maps onto
half the sphere. Without a matching -0.5 horizontal bias, that half sits 90
degrees off to the side: looking straight ahead shows the edge of the image,
with black filling the rest of the view.

`create180LRProjectionLayer` already applied the bias.
`create180ProjectionLayer` and `create180TBProjectionLayer` did not.

### How to test

ffmpeg -f lavfi -i color=c=red:s=1024x1024:d=10 \
       -f lavfi -i color=c=blue:s=1024x1024:d=10 \
       -filter_complex hstack -pix_fmt yuv420p 180lr.mp4

Open it, enter fullscreen and pick **180** or **180 Stereo Top to Bottom**.

- before: the hemisphere starts at the centre of the view, the forward
  direction shows its edge
- after: the hemisphere is centred on the forward direction

Tested on a Pico Neo 3 (OpenXR).