### PR TITLE
Add a "Close other tabs" button to the tabs panel

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -390,6 +390,14 @@ public class SessionStore implements
         return result;
     }
 
+    public ArrayList<Session> getInactiveSessions(boolean aPrivateMode) {
+        ArrayList<Session> sessions = getSortedSessions(aPrivateMode);
+
+        sessions.removeIf(session -> session.isActive() || session.isWebExtensionSession());
+
+        return sessions;
+    }
+
     public void setPermissionDelegate(PermissionDelegate delegate) {
         mPermissionDelegate = delegate;
     }

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/TabsWidget.java
@@ -40,6 +40,7 @@ public class TabsWidget extends UIDialog {
     protected UITextButton mCloseTabsButton;
     protected UITextButton mBookmarkTabsButton;
     protected UITextButton mCloseTabsAllButton;
+    protected UITextButton mCloseOtherTabsButton;
     protected UITextButton mSelectAllButton;
     protected UITextButton mUnselectTabs;
     protected LinearLayout mTabsSelectModeView;
@@ -131,6 +132,16 @@ public class TabsWidget extends UIDialog {
                 mTabDelegate.onTabsClose(mAdapter.mTabs);
             }
             onDismiss();
+        });
+
+        mCloseOtherTabsButton = findViewById(R.id.tabsCloseOthersButton);
+        mCloseOtherTabsButton.setOnClickListener(v -> {
+            if (mTabDelegate != null) {
+                mTabDelegate.onTabsClose(SessionStore.get().getInactiveSessions(mPrivateMode));
+            }
+
+            refreshTabs();
+            updateSelectionMode();
         });
 
         mSelectAllButton = findViewById(R.id.tabsSelectAllButton);
@@ -356,12 +367,14 @@ public class TabsWidget extends UIDialog {
             mBookmarkTabsButton.setVisibility(View.VISIBLE);
             mUnselectTabs.setVisibility(View.VISIBLE);
             mCloseTabsAllButton.setVisibility(View.GONE);
+            mCloseOtherTabsButton.setVisibility(View.GONE);
             mSelectAllButton.setVisibility(View.GONE);
         } else {
             mCloseTabsButton.setVisibility(View.GONE);
             mBookmarkTabsButton.setVisibility(View.GONE);
             mUnselectTabs.setVisibility(View.GONE);
             mCloseTabsAllButton.setVisibility(View.VISIBLE);
+            mCloseOtherTabsButton.setVisibility(SessionStore.get().getInactiveSessions(mPrivateMode).isEmpty() ? View.GONE : View.VISIBLE);
             mSelectAllButton.setVisibility(View.VISIBLE);
         }
 

--- a/app/src/main/res/layout/tabs.xml
+++ b/app/src/main/res/layout/tabs.xml
@@ -93,6 +93,11 @@
             android:text="@string/tabs_bookmark_selected" />
 
         <com.igalia.wolvic.ui.views.UITextButton
+            android:id="@+id/tabsCloseOthersButton"
+            style="@style/tabsButton"
+            android:text="@string/tabs_close_others" />
+
+        <com.igalia.wolvic.ui.views.UITextButton
             android:id="@+id/tabsCloseAllButton"
             style="@style/tabsButton"
             android:text="@string/tabs_close_all" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2139,6 +2139,10 @@ the Select` button. When clicked it bookmarks all the previously selected tabs -
     <string name="tabs_bookmark_selected">Bookmark tabs</string>
 
     <!-- This string is displayed in a button on the header of the tabs dialog.
+     When clicked it closes the tabs that are not currently displayed in any window -->
+    <string name="tabs_close_others">Close other tabs</string>
+
+    <!-- This string is displayed in a button on the header of the tabs dialog.
      When clicked it closes all the available tabs -->
     <string name="tabs_close_all">Close all</string>
 


### PR DESCRIPTION
The button sits in the selection bar next to "Close all" and closes every tab that is not currently shown in a window. WebExtension sessions are never closed. The button is hidden when there is nothing to close.

https://github.com/Igalia/wolvic/pull/2010#issuecomment-5292454183