### PR TITLE
chromium: Fail clearData explicitly instead of faking success

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -77,8 +77,9 @@ public class RuntimeImpl implements WRuntime {
     @NonNull
     @Override
     public WResult<Void> clearData(long flags) {
-        // TODO: Implement
-        return WResult.fromValue(null);
+        // TODO: Implement actual data clearing against the Chromium engine.
+        return WResult.fromException(new UnsupportedOperationException(
+                "clearData is not implemented in the Chromium backend"));
     }
 
     @NonNull

--- a/app/src/common/shared/com/igalia/wolvic/browser/api/WResult.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/api/WResult.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.concurrent.CancellationException;
+import java.util.function.BiConsumer;
 
 public interface WResult<T> {
     /**
@@ -118,6 +119,27 @@ public interface WResult<T> {
     @NonNull <U> WResult<U> then(
             @Nullable final WResult.OnValueListener<T, U> valueListener,
             @Nullable final WResult.OnExceptionListener<U> exceptionListener);
+
+
+    /**
+     * Adds a consumer called when the {@link WResult} is completed either with a value or a
+     * {@link Throwable}, mirroring {@link java.util.concurrent.CompletableFuture#whenComplete}.
+     * On success the consumer receives the value and a null {@link Throwable}; on failure it
+     * receives a null value and the {@link Throwable}.
+     *
+     * @param consumer Called with (value, null) on success or (null, throwable) on failure.
+     * @return A new {@link WResult} that completes with the same value or {@link Throwable}
+     *     after the consumer runs.
+     */
+    default @NonNull WResult<T> whenComplete(@NonNull final BiConsumer<T, Throwable> consumer) {
+        return then(value -> {
+            consumer.accept(value, null);
+            return WResult.fromValue(value);
+        }, throwable -> {
+            consumer.accept(null, throwable);
+            return WResult.fromException(throwable);
+        });
+    }
 
 
     /**

--- a/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
+++ b/app/src/common/shared/com/igalia/wolvic/browser/engine/SessionStore.java
@@ -506,11 +506,13 @@ public class SessionStore implements
                 activeSession.add(session);
             }
         }
-        mRuntime.clearData(clearFlags).then(aVoid -> {
-            for (Session session: activeSession) {
+        mRuntime.clearData(clearFlags).whenComplete((aVoid, throwable) -> {
+            if (throwable != null) {
+                Log.e(LOGTAG, "Failed to clear browsing data", throwable);
+            }
+            for (Session session : activeSession) {
                 session.recreateSession();
             }
-            return null;
         });
     }
 


### PR DESCRIPTION
Fixes #2061 

## What

Two coordinated changes:

- The Chromium `RuntimeImpl.clearData()` stub now returns `WResult.fromException(new UnsupportedOperationException(...))` instead of an already-completed success. The `TODO` stays to signal that real clearing against the Chromium engine is a follow-up.
- `SessionStore.clearCache()` now uses the two-listener `then(valueListener, exceptionListener)` overload: on failure it logs the error and still recreates the suspended sessions.

## Why

The stub returned `WResult.fromValue(null)`, so callers took their success path with nothing cleared. The user-facing path is Settings → Privacy → "clear cookies and site data" / "clear web content" (`PrivacyOptionsView.java:74-83`) → `SessionStore.clearCache()`. On Chromium the sessions suspend and reload, so the action looks like it worked - while cookies, site data and caches are untouched. The Gecko backend really clears (`gecko/RuntimeImpl.java:91-92`).

Failing the result alone - the way `capturePixels` was handled in #2025 - would have regressed this path: `clearCache()` suspends every session **before** calling `clearData()`, and `recreateSession()` lived only inside `.then()` with no `.exceptionally()`. An honest failure would have left every session suspended forever. That is why the caller changes in the same PR: with the error branch added, sessions are recreated on both outcomes.

Net behavior:

- **Chromium:** sessions still suspend and recreate exactly as before; the result now reports the truth and the failure is logged instead of silently faked.
- **Gecko:** the success path is unchanged; a real `clearData` failure is now logged and no longer strands suspended sessions (previously an unhandled rejection).

## Follow-up (out of scope)

Implementing `clearData` for real against Chromium's `BrowsingDataRemover`, mapping `WRuntime.ClearFlags` onto its data-type mask.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`