### PR TITLE
a11y: Fix wrong content descriptions in settings dialogs

### DIFF
--- a/app/src/main/res/layout/options_exceptions.xml
+++ b/app/src/main/res/layout/options_exceptions.xml
@@ -89,7 +89,7 @@
                     style="@style/customRecyclerViewStyle"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:contentDescription="privacy_options_popups_list_header_v1"
+                    android:contentDescription="@string/privacy_options_popups_list_header_v1"
                     android:paddingEnd="15dp"
                     app:layoutManager="LinearLayoutManager" />
             </LinearLayout>

--- a/app/src/main/res/layout/options_language_content.xml
+++ b/app/src/main/res/layout/options_language_content.xml
@@ -52,7 +52,7 @@
                     android:paddingEnd="15dp"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:contentDescription="@string/app_name"
+                    android:contentDescription="@string/language_options_preferred_languages_content_description"
                     app:layoutManager="LinearLayoutManager" />
             </LinearLayout>
 
@@ -76,7 +76,7 @@
                     android:paddingEnd="15dp"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:contentDescription="@string/app_name"
+                    android:contentDescription="@string/language_options_available_languages_content_description"
                     app:layoutManager="LinearLayoutManager" />
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1724,6 +1724,14 @@
     <!-- This string labels the description in the Content Language header for available languages list. -->
     <string name="language_options_available_languages">Available Languages</string>
 
+    <!-- Accessibility content description for the list of preferred website content languages
+         in the 'Preferred Website Languages' dialog. -->
+    <string name="language_options_preferred_languages_content_description">List of preferred languages</string>
+
+    <!-- Accessibility content description for the list of available website content languages
+         in the 'Preferred Website Languages' dialog. -->
+    <string name="language_options_available_languages_content_description">List of available languages</string>
+
     <!-- This string is for the table column name (in the browser's 'Bookmarks' list) for the 'Name' of the bookmarked website. -->
     <string name="col_name">Name</string>
 


### PR DESCRIPTION
Fixes #2062 

## What

- `options_language_content.xml`: the two language lists in the "Preferred Website Languages" dialog had `contentDescription="@string/app_name"`, so TalkBack announced "Wolvic" (or the flavor's app name) when either list gained accessibility focus. They now use two new translatable strings - "List of preferred languages" / "List of available languages" - added to `values/strings.xml` with translator comments, following the same pattern as #2040.
- `options_exceptions.xml:92`: the popup-exceptions list's `contentDescription` was `"privacy_options_popups_list_header_v1"` - a literal missing its `@string/` prefix, so TalkBack read the raw identifier aloud. The header TextView at `:84` already uses the same string correctly with the prefix, so this just restores the intended reference.

## Why

Both are wrong announcements from bad `contentDescription` values in settings dialogs - the first labels the lists with an unrelated string, the second exposes an internal identifier. Each fix matches its bug: the language lists needed correct strings; the exceptions list only needed the missing prefix.

Nothing in the codebase reads these values (no `getContentDescription` or test usages), so the change is announcement-only with no behavioral surface beyond the screen reader.

If reusing the existing visible header strings (`language_options_preferred_languages` / `language_options_available_languages`) is preferred over adding two new translatable strings, happy to switch - the dedicated-string variant was chosen to match #2040.

## Testing

- [ ] Builds: `./gradlew assembleNoapiArm64GeckoGenericDebug`
- [ ] Existing unit tests pass: `./gradlew testNoapiArm64GeckoGenericDebugUnitTest`