### PR TITLE
[Chromium] Fix a crash showing the suggestions widget

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -118,6 +118,14 @@
 -keep class com.huawei.hvr.**{*;}
 -keep class com.huawei.hmf.**{*;}
 
+# ---------------------------------------------------------------------
+# UIWidget.createChild() instantiates widgets reflectively via
+# aChildClassName.getConstructor(new Class[]{ Context.class }).
+#----------------------------------------------------------------------
+-keepclassmembers class * extends com.igalia.wolvic.ui.widgets.UIWidget {
+    public <init>(android.content.Context);
+}
+
 -dontwarn **
 -target 1.7
 -dontusemixedcaseclassnames


### PR DESCRIPTION
This is reproducible only in release builds with minification on. The problem is that the code instantiates the SuggestionsWidget reflectively so R8 sees no direct caller and removes the constructors causing a null pointer exception (as null widget returned by create is not handled)

Fixes #2045