### PR TITLE
[Chromium] Remove the WebXR hand input flag

### DIFF
--- a/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
+++ b/app/src/common/chromium/com/igalia/wolvic/browser/api/impl/RuntimeImpl.java
@@ -200,9 +200,6 @@ public class RuntimeImpl implements WRuntime {
             disableFeatures += ",Vulkan";
         CommandLine.getInstance().appendSwitchWithValue("disable-features", disableFeatures);
 
-        // Enable WebXR Hand Input, which is disabled by default in blink (experimental)
-        CommandLine.getInstance().appendSwitchWithValue("enable-features", "WebXRHandInput");
-
         // Enable HTML-in-Canvas, chrome://flags/#canvas-draw-element (experimental).
         CommandLine.getInstance().appendSwitchWithValue("enable-blink-features", "CanvasDrawElement");
 


### PR DESCRIPTION
It's enabled by default in M150. The flag was removed from Chromium so it won't do anything.