### PR TITLE
Do not resolve the jnaForTest configuration at configuration time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -697,7 +697,7 @@ dependencies {
     testImplementation libs.androidcomponents.support.test
     testImplementation libs.androidcomponents.support.test.appservices
     jnaForTest libs.jna
-    testImplementation files(configurations.jnaForTest.copyRecursive().files)
+    testImplementation files { configurations.jnaForTest.copyRecursive().files }
     testImplementation libs.work.testing
 
     // Vosk


### PR DESCRIPTION
Passing the resolved file set to files() forced the resolution while the project was still being configured, which Gradle reports as:

  Configuration 'jnaForTest' was resolved during configuration time.
  This is a build performance and scalability issue.

Wrapping it in a closure makes files() evaluate it lazily instead. The result is unchanged: the unit test runtime classpath still gets the pinned jna-5.13.0.jar ahead of the newer transitive one.