### PR TITLE
Compile against Java 11 instead of Java 8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,8 +162,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         coreLibraryDesugaringEnabled = true
     }
 
@@ -186,7 +186,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     buildTypes {


### PR DESCRIPTION
The build runs on a JDK 21 toolchain since bd746c450, and javac warns that it will not keep accepting the old source and target levels:

  Java compiler version 21 has deprecated support for compiling with
  source/target version 8.
  warning: [options] source value 8 is obsolete and will be removed in
  a future release

Move both compileOptions and kotlinOptions.jvmTarget in one go as the Java and Kotlin targets have to agree.