### PR TITLE
Give the resource annotations in AddonsManagerAdapter a use-site target

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/addons/adapters/AddonsListViewAdapter.kt
+++ b/app/src/common/shared/com/igalia/wolvic/addons/adapters/AddonsListViewAdapter.kt
@@ -308,25 +308,25 @@ class AddonsManagerAdapter(
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal data class Section(@StringRes val title: Int)
+    internal data class Section(@param:StringRes val title: Int)
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal data class NotYetSupportedSection(@StringRes val title: Int)
+    internal data class NotYetSupportedSection(@param:StringRes val title: Int)
 
     /**
      * Allows to customize how items should look like.
      */
     data class Style(
-        @ColorRes
+        @param:ColorRes
         val sectionsTextColor: Int? = null,
-        @ColorRes
+        @param:ColorRes
         val addonNameTextColor: Int? = null,
-        @ColorRes
+        @param:ColorRes
         val addonSummaryTextColor: Int? = null,
         val sectionsTypeFace: Typeface? = null,
-        @ColorRes
+        @param:ColorRes
         val addonBackgroundIconColor: Int? = null,
-        @DrawableRes
+        @param:DrawableRes
         val addonAllowPrivateBrowsingLabelDrawableRes: Int? = null
     ) {
         internal fun maybeSetSectionsTextColor(textView: TextView) {


### PR DESCRIPTION
Kotlin warns that constructor property annotations without an explicit target will change meaning:

  w: This annotation is currently applied to the value parameter only,
     but in the future it will also be applied to field.

@param: keeps the current behaviour. It is also the target that matters here, as Style is built from Java in AddonsListView.createAddonStyle(), so that is where lint validates the resource IDs.