### PR TITLE
Window movement fixes

### DIFF
--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -207,6 +207,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     // and restart into a fresh process. These guard against a restart storm if a backup is still active.
     private static final String KEY_RESTRICTED_MODE_RESTART = "restricted_mode_restart_uptime";
     private static final long RESTRICTED_RESTART_WINDOW_MS = 10_000L;
+    // How far the window travels for a given amount of hand travel. The distance range
+    // spanned by window_world_z_min..max is wider than a comfortable reach, so the hand
+    // needs amplifying to cover it: at 2.0 half a reach covers the whole range.
+    private static final float WINDOW_MOVE_GAIN = 2.0f;
 
     ConcurrentHashMap<Integer, Widget> mWidgets;
     private int mWidgetHandleIndex = 1;
@@ -2239,10 +2243,17 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Keep
     @SuppressWarnings("unused")
-    private void changeWindowDistance(float aDelta) {
-        float increment = 0.05f;
-        float clamped = Math.max(0.0f, Math.min(mSettings.getWindowDistance() + (aDelta > 0 ? increment : -increment), 1.0f));
-        mSettings.setWindowDistance(clamped);
+    private void moveWindowDistance(float aMeters) {
+        // Accumulated rather than applied from the distance the grab started at, so
+        // that the clamping below cannot wind up: an absolute value keeps growing past
+        // the end of the range and then has to be unwound before the window moves
+        // again. Reversing is still exact, as the increments telescope.
+        float range = Math.abs(WidgetPlacement.floatDimension(this, R.dimen.window_world_z_max)
+                - WidgetPlacement.floatDimension(this, R.dimen.window_world_z_min));
+        if (range <= 0)
+            return;
+        float distance = mSettings.getWindowDistance() + (aMeters * WINDOW_MOVE_GAIN) / range;
+        mSettings.setWindowDistance(Math.max(0.0f, Math.min(distance, 1.0f)));
     }
 
     private boolean supportsCompositionLayers() {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -212,7 +212,7 @@ struct BrowserWorld::State {
   double lastBatteryLevelUpdate = -1.0;
   bool reorientRequested = false;
   LockMode lockMode = LockMode::NO_LOCK;
-  std::optional<vrb::Vector> lockModeLastPosition;
+  std::optional<float> windowMoveLastExtension;
 #if HVR
   bool wasButtonAppPressed = false;
 #elif defined(OCULUSVR) && defined(STORE_BUILD)
@@ -1175,29 +1175,34 @@ BrowserWorld::GetActiveControllerOrientation() const {
 
 void
 BrowserWorld::ThrottledWindowDistanceComputation(const vrb::Matrix& controllerTransform) {
-    const float kThrottleMs = 100;
-    const float kDirectionTolerance = 0.75f;
+    // Applying the distance relayouts every widget, so it is too expensive to do
+    // once per frame. 30Hz is frequent enough to look continuous.
+    const float kThrottleMs = 33;
     auto now = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m.lastTimeWindowDistanceComputation).count();
     if (duration < kThrottleMs)
         return;
+    m.lastTimeWindowDistanceComputation = now;
 
-    auto currentPosition = controllerTransform.GetTranslation();
-    if (!m.lockModeLastPosition) {
-        m.lockModeLastPosition = currentPosition;
+    // Measure how far the controller is held out from the user: from the head, so that
+    // swinging the arm around to rotate the window hardly counts as pushing, and in the
+    // horizontal plane, so that raising or lowering the hand does not count at all. The
+    // controller's own axes are no use for this, as it reports the grip pose, which is
+    // tilted away from the direction the controller points.
+    auto toController = controllerTransform.GetTranslation() - m.device->GetHeadTransform().GetTranslation();
+    auto extension = vrb::Vector(toController.x(), 0.0f, toController.z()).Magnitude();
+
+    if (!m.windowMoveLastExtension) {
+        m.windowMoveLastExtension = extension;
         return;
     }
 
-    auto didMoveSignificantly = (currentPosition - *m.lockModeLastPosition).Magnitude() > 0.01f;
-    if (!didMoveSignificantly)
-        return;
-
-    auto forward = controllerTransform.MultiplyDirection(vrb::Vector(0.0f, 0.0f, -1.0f)).Normalize();
-    auto directionOfMovement = (currentPosition - *m.lockModeLastPosition).Normalize();
-    auto dotProduct = directionOfMovement.Dot(forward);
-    if (abs(dotProduct) > kDirectionTolerance)
-      VRBrowser::ChangeWindowDistance(dotProduct);
-    m.lockModeLastPosition = currentPosition;
+    // Report the change since the previous tick rather than since the grab started. An
+    // absolute measurement winds up past the ends of the range: once the distance
+    // clamps, every bit of further travel has to be unwound before the window moves
+    // again, which leaves the gesture looking dead once the arm has covered any ground.
+    VRBrowser::MoveWindowDistance(extension - *m.windowMoveLastExtension);
+    m.windowMoveLastExtension = extension;
 }
 
 void
@@ -1279,6 +1284,7 @@ BrowserWorld::StartFrame() {
       m.device->Reorient(reorientTransform, m.lockMode == LockMode::HEAD ? DeviceDelegate::ReorientMode::SIX_DOF : DeviceDelegate::ReorientMode::NO_ROLL);
     } else {
         m.previousWindowRelativeRotation.reset();
+        m.windowMoveLastExtension.reset();
     }
     if (m.reorientRequested)
       relayoutWidgets = std::exchange(m.reorientRequested, false);

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -532,7 +532,8 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
     }
 
     if (controller.pointer) {
-      controller.pointer->SetVisible(hitWidget.get() != nullptr && controller.hasAim);
+      const bool isMovingWindow = lockMode == LockMode::CONTROLLER;
+      controller.pointer->SetVisible(!isMovingWindow && hitWidget.get() != nullptr && controller.hasAim);
       controller.pointer->SetHitWidget(hitWidget);
       if (hitWidget && controller.hasAim) {
         vrb::Matrix translation = vrb::Matrix::Translation(hitPoint);

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1174,7 +1174,7 @@ BrowserWorld::GetActiveControllerOrientation() const {
 }
 
 void
-BrowserWorld::ThrottledWindowDistanceComputation(const vrb::Matrix& reorientTransform) {
+BrowserWorld::ThrottledWindowDistanceComputation(const vrb::Matrix& controllerTransform) {
     const float kThrottleMs = 100;
     const float kDirectionTolerance = 0.75f;
     auto now = std::chrono::steady_clock::now();
@@ -1182,7 +1182,7 @@ BrowserWorld::ThrottledWindowDistanceComputation(const vrb::Matrix& reorientTran
     if (duration < kThrottleMs)
         return;
 
-    auto currentPosition = reorientTransform.GetTranslation();
+    auto currentPosition = controllerTransform.GetTranslation();
     if (!m.lockModeLastPosition) {
         m.lockModeLastPosition = currentPosition;
         return;
@@ -1192,7 +1192,7 @@ BrowserWorld::ThrottledWindowDistanceComputation(const vrb::Matrix& reorientTran
     if (!didMoveSignificantly)
         return;
 
-    auto forward = reorientTransform.MultiplyDirection(vrb::Vector(0.0f, 0.0f, -1.0f)).Normalize();
+    auto forward = controllerTransform.MultiplyDirection(vrb::Vector(0.0f, 0.0f, -1.0f)).Normalize();
     auto directionOfMovement = (currentPosition - *m.lockModeLastPosition).Normalize();
     auto dotProduct = directionOfMovement.Dot(forward);
     if (abs(dotProduct) > kDirectionTolerance)
@@ -1260,6 +1260,10 @@ BrowserWorld::StartFrame() {
       OnReorient();
       auto reorientTransform = m.lockMode == LockMode::HEAD ? m.device->GetHeadTransform() : GetActiveControllerOrientation();
       if (m.lockMode == LockMode::CONTROLLER) {
+        // Must run before reorientTransform is replaced below by a rotation-only
+        // matrix, as the distance is derived from the controller's position.
+        ThrottledWindowDistanceComputation(reorientTransform);
+
         if (!m.windowInitialOrientation)
           m.windowInitialOrientation = vrb::Quaternion(reorientTransform);
         Quaternion reorientQuaternion(reorientTransform);
@@ -1271,8 +1275,6 @@ BrowserWorld::StartFrame() {
         reorientTransform = vrb::Matrix::Rotation(relativeRotation);
         m.previousWindowRelativeRotation = std::move(relativeRotation);
         m.reorientRequested = true;
-
-        ThrottledWindowDistanceComputation(reorientTransform);
       }
       m.device->Reorient(reorientTransform, m.lockMode == LockMode::HEAD ? DeviceDelegate::ReorientMode::SIX_DOF : DeviceDelegate::ReorientMode::NO_ROLL);
     } else {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -220,8 +220,9 @@ struct BrowserWorld::State {
 #endif
   TrackedKeyboardRendererPtr trackedKeyboardRenderer;
   float selectThreshold;
-  std::optional<vrb::Quaternion> windowInitialOrientation;
-  std::optional<vrb::Quaternion> previousWindowRelativeRotation;
+  std::optional<vrb::Quaternion> windowMoveStartOrientation;
+  std::optional<vrb::Quaternion> windowMoveAnchorRotation;
+  std::optional<vrb::Quaternion> previousWindowRotation;
   std::chrono::steady_clock::time_point lastTimeWindowDistanceComputation;
 
   State() : paused(true), glInitialized(false), modelsLoaded(false), env(nullptr), cylinderDensity(0.0f), nearClip(0.1f),
@@ -1269,21 +1270,36 @@ BrowserWorld::StartFrame() {
         // matrix, as the distance is derived from the controller's position.
         ThrottledWindowDistanceComputation(reorientTransform);
 
-        if (!m.windowInitialOrientation)
-          m.windowInitialOrientation = vrb::Quaternion(reorientTransform);
-        Quaternion reorientQuaternion(reorientTransform);
-        Quaternion relativeRotation = reorientQuaternion.Inverse() * *m.windowInitialOrientation;
-        // Use SLERP to interpolate the current relative rotation with the previous one to smooth out sudden jumps
-        if (m.previousWindowRelativeRotation)
-          relativeRotation = vrb::Quaternion::Slerp(*m.previousWindowRelativeRotation,relativeRotation, 0.25f);
+        Quaternion controllerOrientation(reorientTransform);
+        if (!m.windowMoveStartOrientation) {
+          m.windowMoveStartOrientation = controllerOrientation;
+          // Anchor the gesture on the rotation the window already has. Reorient() assigns the
+          // reorientation matrix rather than accumulating into it, so without an anchor a zero
+          // rotation would mean the neutral orientation rather than "leave the window alone".
+          // **VERY IMPORTANT**: we invert it on purpose beacuse vrb::Quaternion(Matrix) and
+          // vrb::Matrix::Rotation() disagree on handedness, so Rotation(Quaternion(m)) yields the
+          // transpose of m. The inverse is what survives the round trip back through Reorient().
+          m.windowMoveAnchorRotation = vrb::Quaternion(m.device->GetReorientTransform()).Inverse();
+        }
+        // Turn the window by however much the controller has turned since this grab started (on top
+        // of where the window already was). Measuring from the start of the grab rather than from a
+        // fixed orientation is what keeps re-grabbing with the hand in a different pose (the usual
+        // case) from moving the window.
+        Quaternion rotation = (controllerOrientation.Inverse() * *m.windowMoveStartOrientation)
+                              * *m.windowMoveAnchorRotation;
+        if (m.previousWindowRotation) {
+          rotation = vrb::Quaternion::Slerp(*m.previousWindowRotation, rotation, 0.25f).Normalize();
+        }
 
-        reorientTransform = vrb::Matrix::Rotation(relativeRotation);
-        m.previousWindowRelativeRotation = std::move(relativeRotation);
+        reorientTransform = vrb::Matrix::Rotation(rotation);
+        m.previousWindowRotation = std::move(rotation);
         m.reorientRequested = true;
       }
       m.device->Reorient(reorientTransform, m.lockMode == LockMode::HEAD ? DeviceDelegate::ReorientMode::SIX_DOF : DeviceDelegate::ReorientMode::NO_ROLL);
     } else {
-        m.previousWindowRelativeRotation.reset();
+        m.previousWindowRotation.reset();
+        m.windowMoveStartOrientation.reset();
+        m.windowMoveAnchorRotation.reset();
         m.windowMoveLastExtension.reset();
     }
     if (m.reorientRequested)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -104,7 +104,7 @@ private:
   void ProcessOVRPlatformEvents();
 #endif
   vrb::Matrix GetActiveControllerOrientation() const;
-  void ThrottledWindowDistanceComputation(const vrb::Matrix& reorientTransform);
+  void ThrottledWindowDistanceComputation(const vrb::Matrix& controllerTransform);
   State& m;
   BrowserWorld() = delete;
   VRB_NO_DEFAULTS(BrowserWorld)

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -76,8 +76,8 @@ const char* const kSetHandTrackingSupported = "setHandTrackingSupported";
 const char* const kSetHandTrackingSupportedSignature = "(Z)V";
 const char* const kOnControllersAvailable = "onControllersAvailable";
 const char* const kOnControllersAvailableSignature = "()V";
-const char* const kChangeWindowDistance = "changeWindowDistance";
-const char* const kChangeWindowDistanceSignature = "(F)V";
+const char* const kMoveWindowDistance = "moveWindowDistance";
+const char* const kMoveWindowDistanceSignature = "(F)V";
 const char* const kOnMaxCompositionLayersAvailableName = "onMaxCompositionLayersAvailable";
 const char* const kOnMaxCompositionLayersAvailableSignature = "(I)V";
 
@@ -117,7 +117,7 @@ jmethodID sOnAppFocusChanged = nullptr;
 jmethodID sSetEyeTrackingSupported = nullptr;
 jmethodID sSetHandTrackingSupported = nullptr;
 jmethodID sOnControllersAvailable = nullptr;
-jmethodID sChangeWindowDistance = nullptr;
+jmethodID sMoveWindowDistance = nullptr;
 jmethodID sOnMaxCompositionLayersAvailable = nullptr;
 
 } // namespace
@@ -172,7 +172,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sSetEyeTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetEyeTrackingSupported, kSetEyeTrackingSupportedSignature);
   sSetHandTrackingSupported = FindJNIMethodID(sEnv, sBrowserClass, kSetHandTrackingSupported, kSetHandTrackingSupportedSignature);
   sOnControllersAvailable = FindJNIMethodID(sEnv, sBrowserClass, kOnControllersAvailable, kOnControllersAvailableSignature);
-  sChangeWindowDistance = FindJNIMethodID(sEnv, sBrowserClass, kChangeWindowDistance, kChangeWindowDistanceSignature);
+  sMoveWindowDistance = FindJNIMethodID(sEnv, sBrowserClass, kMoveWindowDistance, kMoveWindowDistanceSignature);
   sOnMaxCompositionLayersAvailable = FindJNIMethodID(sEnv, sBrowserClass, kOnMaxCompositionLayersAvailableName, kOnMaxCompositionLayersAvailableSignature);
 }
 
@@ -222,7 +222,7 @@ VRBrowser::ShutdownJava() {
   sDisableLayers = nullptr;
   sEnv = nullptr;
   sAppendAppNotesToCrashReport = nullptr;
-  sChangeWindowDistance = nullptr;
+  sMoveWindowDistance = nullptr;
   sOnMaxCompositionLayersAvailable = nullptr;
 }
 
@@ -504,9 +504,9 @@ VRBrowser::OnControllersAvailable() {
 }
 
 void
-VRBrowser::ChangeWindowDistance(jfloat aDelta) {
-    if (!ValidateMethodID(sEnv, sActivity, sChangeWindowDistance, __FUNCTION__)) { return; }
-    sEnv->CallVoidMethod(sActivity, sChangeWindowDistance, aDelta);
+VRBrowser::MoveWindowDistance(jfloat aMeters) {
+    if (!ValidateMethodID(sEnv, sActivity, sMoveWindowDistance, __FUNCTION__)) { return; }
+    sEnv->CallVoidMethod(sActivity, sMoveWindowDistance, aMeters);
     CheckJNIException(sEnv, __FUNCTION__);
 }
 

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -53,7 +53,7 @@ void OnAppFocusChanged(const bool aIsFocused);
 void SetEyeTrackingSupported(bool aIsSupported);
 void SetHandTrackingSupported(bool aIsSupported);
 void OnControllersAvailable();
-void ChangeWindowDistance(jfloat aDelta);
+void MoveWindowDistance(jfloat aMeters);
 void OnMaxCompositionLayersAvailable(jint aNumLayers);
 } // namespace VRBrowser;
 


### PR DESCRIPTION
This PR contains several fixes that when together provide a much richer and pleasant experience when rotating/moving windows, in particular
1. fix the regression of pushing/pulling not changing the window distance
2. remove the small jump when grabbing the window
3. do not reset the window position when grabbing it after a previous movement
4. temporarily hide the controller pointer while rotating (window rotation is done with some smoothing applied so the pointer position drifts over time). Meta Horizon UI does the same for example