### PR TITLE
Do not prevent the volume keys from working

### DIFF
--- a/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/aosp/java/com/igalia/wolvic/PlatformActivity.java
@@ -18,11 +18,6 @@ public class PlatformActivity extends GameActivity {
         return false;
     }
 
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        // Dummy implementation.
-        return true;
-    }
-
     public static boolean isPositionTrackingSupported() {
         // Dummy implementation.
         return true;

--- a/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
+++ b/app/src/common/shared/com/igalia/wolvic/VRBrowserActivity.java
@@ -1031,7 +1031,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (isNotSpecialKey(event) && mKeyboard.dispatchKeyEvent(event)) {
+        if (mKeyboard.dispatchKeyEvent(event)) {
             return true;
         }
         return super.dispatchKeyEvent(event);

--- a/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/com/igalia/wolvic/ui/widgets/KeyboardWidget.java
@@ -1340,7 +1340,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         final InputConnection connection = mInputConnection;
         if (connection != null) {
             if (isAttachToWindowWidget()) {
-                if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+                if (event.isSystem()) {
                     return false;
                 }
                 // Only forward to Web engine and dismiss the VR keyboard for physical keyboard

--- a/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/hvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -15,7 +15,6 @@ import android.hardware.display.DisplayManager;
 import android.os.Bundle;
 import android.os.Build;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -63,10 +62,6 @@ public abstract class PlatformActivity extends FragmentActivity implements Surfa
 
     public static boolean filterPermission(final String aPermission) {
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        return true;
     }
 
     public static boolean isPositionTrackingSupported() {

--- a/app/src/lynx/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/lynx/java/com/igalia/wolvic/PlatformActivity.java
@@ -7,7 +7,6 @@ package com.igalia.wolvic;
 
 import android.app.NativeActivity;
 import android.content.Intent;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 
@@ -19,11 +18,6 @@ public class PlatformActivity extends NativeActivity {
     public static boolean filterPermission(final String aPermission) {
         // Dummy implementation.
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        // Dummy implementation.
-        return true;
     }
 
     public static boolean isPositionTrackingSupported() {

--- a/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/noapi/java/com/igalia/wolvic/PlatformActivity.java
@@ -11,7 +11,6 @@ import android.opengl.GLSurfaceView;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.WindowInsets;
@@ -35,10 +34,6 @@ public class PlatformActivity extends ComponentActivity {
     @SuppressWarnings("unused")
     public static boolean filterPermission(final String aPermission) {
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        return true;
     }
 
     public static boolean isPositionTrackingSupported() {

--- a/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/oculusvr/java/com/igalia/wolvic/PlatformActivity.java
@@ -12,7 +12,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
@@ -32,10 +31,6 @@ public class PlatformActivity extends NativeActivity {
             return true;
         }
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        return true;
     }
 
     public static boolean isPositionTrackingSupported() {

--- a/app/src/pfdmxr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/pfdmxr/java/com/igalia/wolvic/PlatformActivity.java
@@ -12,7 +12,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
@@ -32,10 +31,6 @@ public class PlatformActivity extends NativeActivity {
             return true;
         }
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        return true;
     }
 
     public static boolean isPositionTrackingSupported() {

--- a/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/picoxr/java/com/igalia/wolvic/PlatformActivity.java
@@ -7,7 +7,6 @@ package com.igalia.wolvic;
 
 import android.app.NativeActivity;
 import android.content.Intent;
-import android.view.KeyEvent;
 
 import com.igalia.wolvic.ui.widgets.WidgetManagerDelegate;
 
@@ -16,11 +15,6 @@ public class PlatformActivity extends NativeActivity {
     public static boolean filterPermission(final String aPermission) {
         // Dummy implementation.
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        // Recognize PICO's screenshot button.
-        return event.getKeyCode() != KeyEvent.KEYCODE_CAMERA;
     }
 
     public static boolean isPositionTrackingSupported() {

--- a/app/src/spaces/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/spaces/java/com/igalia/wolvic/PlatformActivity.java
@@ -7,7 +7,6 @@ package com.igalia.wolvic;
 
 import android.app.NativeActivity;
 import android.content.Intent;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 
@@ -19,11 +18,6 @@ public class PlatformActivity extends NativeActivity {
     public static boolean filterPermission(final String aPermission) {
         // Dummy implementation.
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        // Dummy implementation.
-        return true;
     }
 
     public static boolean isPositionTrackingSupported() {

--- a/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
+++ b/app/src/visionglass/java/com/igalia/wolvic/PlatformActivity.java
@@ -28,7 +28,6 @@ import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.Display;
 import android.view.GestureDetector;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -92,10 +91,6 @@ public class PlatformActivity extends FragmentActivity implements SensorEventLis
     @SuppressWarnings("unused")
     public static boolean filterPermission(final String aPermission) {
         return false;
-    }
-
-    public static boolean isNotSpecialKey(KeyEvent event) {
-        return true;
     }
 
     public static boolean isPositionTrackingSupported() {


### PR DESCRIPTION
The current code "randomly" prevents the hardware volume buttons from working. The transient volume slider is not shown and the volume remains unchanged. It seems to have some connection with the on screen keyboard because clicking on the volume keys can dismiss it.

The problem was that on Android the OS passes KEYCODE_VOLUME_UP/DOWN to the focused app, so any "return true" before super.dispatchKeyEvent() kills the chain that leads to volume changes (that's how events are intercepted in Android). We had such a return in
VRBrowserActivity::dispatchKeyEvent working in tandem with the platform defined isNotSpecialKey() (which BTW is a hardcoded true for all but Pico platforms).

The bug was not there though (it didn't filter out anything in most platforms), it's actually in the keyboard code. The dispatchKeyEvent() implementation swallows all the events classified as SOURCE_KEYBOARD. The volume UP/DOWN events are also SOURCE_KEYBOARD so that branch was taken. The solution is not to enter that code path in the case of receiving a system event.

The isNotSpecialKey() is not really required anymore. It just returned true for all platforms but Pico, and even in that case, it was just filtering out the CAMERA button which is also a system key (and thus superseeded by this change). That's why were removing that code.

Last but not least, the bug was hard to catch because it appeared to be intermittent. The reason for that is because indeed the bug appeared only when the keyboard was shown (the branch eating the events is only executed whenever the focus is on a web text entry). That's why clicking a volume key seemed not to work and close the keyboard, but after that it worked again (because that code path was no longer reachable).

Fixes #2085